### PR TITLE
Process comments (and extra nodes) separately from the rest of the code

### DIFF
--- a/examples/client-app/src/main.rs
+++ b/examples/client-app/src/main.rs
@@ -26,6 +26,7 @@ async fn main() {
     let language: Language = Language {
         name: "json".to_owned(),
         query: TopiaryQuery::new(&grammar, query).unwrap(),
+        comment_query: None,
         grammar,
         indent: None,
     };

--- a/topiary-cli/tests/samples/expected/nickel.ncl
+++ b/topiary-cli/tests/samples/expected/nickel.ncl
@@ -182,6 +182,7 @@
     x,
 
     # let blocks
+
     let x = 1, y = 2 in x + y,
     let
       x = 1,

--- a/topiary-cli/tests/samples/expected/ocaml-interface.mli
+++ b/topiary-cli/tests/samples/expected/ocaml-interface.mli
@@ -437,8 +437,7 @@ module Gas : sig
 
   val pp_cost_as_gas : Format.formatter -> cost -> unit
 
-  type error += Operation_quota_exceeded
-  (* `Temporary *)
+  type error += Operation_quota_exceeded (* `Temporary *)
 
   (** [consume ctxt cost] subtracts [cost] to the current operation
      gas level in [ctxt]. This operation may fail with
@@ -453,11 +452,9 @@ module Gas : sig
       would fall below [0]. *)
   val consume_from : Arith.fp -> cost -> Arith.fp tzresult
 
-  type error += Block_quota_exceeded
-  (* `Temporary *)
+  type error += Block_quota_exceeded (* `Temporary *)
 
-  type error += Gas_limit_too_high
-  (* `Permanent *)
+  type error += Gas_limit_too_high (* `Permanent *)
 
   (** See {!Raw_context.consume_gas_limit_in_block}. *)
   val consume_limit_in_block : context -> 'a Arith.t -> context tzresult
@@ -1398,11 +1395,9 @@ module Sapling : sig
 
     val rpc_arg : t RPC_arg.arg
 
-    val parse_z : Z.t -> t
-    (* To be used in parse_data only *)
+    val parse_z : Z.t -> t (* To be used in parse_data only *)
 
-    val unparse_to_z : t -> Z.t
-    (* To be used in unparse_data only *)
+    val unparse_to_z : t -> Z.t (* To be used in unparse_data only *)
   end
 
   (** Create a fresh sapling state in the context. *)
@@ -4925,11 +4920,9 @@ module Operation : sig
 
   val compare_by_passes : packed_operation -> packed_operation -> int
 
-  type error += Missing_signature
-  (* `Permanent *)
+  type error += Missing_signature (* `Permanent *)
 
-  type error += Invalid_signature
-  (* `Permanent *)
+  type error += Invalid_signature (* `Permanent *)
 
   val check_signature : public_key -> Chain_id.t -> _ operation -> unit tzresult
 
@@ -5458,14 +5451,11 @@ module Fees : sig
     Z.t ->
     (context * Z.t * Receipt.balance_updates) tzresult Lwt.t
 
-  type error += Cannot_pay_storage_fee
-  (* `Temporary *)
+  type error += Cannot_pay_storage_fee (* `Temporary *)
 
-  type error += Operation_quota_exceeded
-  (* `Temporary *)
+  type error += Operation_quota_exceeded (* `Temporary *)
 
-  type error += Storage_limit_too_high
-  (* `Permanent *)
+  type error += Storage_limit_too_high (* `Permanent *)
 
   val check_storage_limit : context -> storage_limit: Z.t -> unit tzresult
 end

--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -51,11 +51,10 @@ let id6 = function x -> x
 
 (* Extensible buffers *)
 
-type t = (* Multi-
-          * line comment with
-          * too much padding.
-          *)
-{
+type t = { (* Multi-
+            * line comment with
+            * too much padding.
+            *)
   mutable buffer: bytes;
   mutable position: int; (* End-of-line comment *)
   mutable length: int;
@@ -838,12 +837,12 @@ let _ =
 [@@@deprecated "writing code is deprecated, use ai-generated code instead"]
 
 type t = {
-  verbose: int;
   (** Verbosity level. *)
-  loggers: string;
+  verbose: int;
   (** Loggers enabled. *)
+  loggers: string;
   bflags: bool StrMap.t
-  (** Boolean flags. *)
+(** Boolean flags. *)
 }
 
 let _ = {

--- a/topiary-cli/tests/samples/expected/rust.rs
+++ b/topiary-cli/tests/samples/expected/rust.rs
@@ -14,10 +14,10 @@ pub fn node_kind_for_id(&self, id: u16) -> &'static str {
 
 // More comments.
 
-enum OneLine { Leaf { content: String, /* comment */ id: usize /* another comment */, size: usize, }, Hardline { content: String, id: usize, }, Space, } // End of line comment
+enum OneLine { Leaf { content: String, id: usize, size: usize, }, Hardline { content: String, id: usize, }, Space, } /* comment */ /* another comment */ // End of line comment
 
 enum ExpandEnum {
-    Leaf { content: String, /* Comment between fields. */ id: usize, size: usize, },
+    Leaf { content: String, id: usize, size: usize, }, /* Comment between fields. */
     Hardline { content: String, id: usize, },
     Space,
 }
@@ -91,21 +91,25 @@ enum Mode6 {
 fn inline_let() { let hi = 1; }
 
 // While loop spacing
-while i == true {
-    let i = 42;
+fn my_while() {
+    while i == true {
+        let i = 42;
+    }
 }
 
 // Scoped blocks
-{
-    let i = 42;
-}
-{
-    let i = 43;
+fn foo() {
+    {
+        let i = 42;
+    }
+    {
+        let i = 43;
+    }
 }
 
 // Empty block inside of impl function
 impl MyTrait for MyStruct {
     fn foo() {
-        // ... logic ...
+    // ... logic ...
     }
 }

--- a/topiary-cli/tests/samples/expected/tree_sitter_query.scm
+++ b/topiary-cli/tests/samples/expected/tree_sitter_query.scm
@@ -1023,8 +1023,8 @@
   ":" @append_indent_start
   (_) @append_indent_end
   .
-  ; just doing _ above doesn't work, because it matches the final named node as
-  ; well as the final non-named node, causing double indentation.
+; just doing _ above doesn't work, because it matches the final named node as
+; well as the final non-named node, causing double indentation.
 )
 
 (value_specification

--- a/topiary-cli/tests/samples/input/rust.rs
+++ b/topiary-cli/tests/samples/input/rust.rs
@@ -91,17 +91,21 @@ enum Mode6 {
 fn inline_let() { let hi = 1; }
 
 // While loop spacing
-while i == true {
-    let i = 42;
+fn my_while() {
+    while i == true {
+        let i = 42;
+    }
 }
 
 
 // Scoped blocks
-{
-    let i = 42;
-}
-{
-    let i = 43;
+fn foo() {
+    {
+        let i = 42;
+    }
+    {
+        let i = 43;
+    }
 }
 
 // Empty block inside of impl function

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -7,6 +7,8 @@ use topiary_core::{formatter, Language, Operation, TopiaryQuery};
 async fn format() {
     let input = fs::read_to_string("../topiary-cli/tests/samples/input/ocaml.ml").unwrap();
     let query_content = fs::read_to_string("../topiary-queries/queries/ocaml.scm").unwrap();
+    let comment_query_content =
+        fs::read_to_string("../topiary-queries/queries/ocaml.comment.scm").unwrap();
     let ocaml = tree_sitter_ocaml::LANGUAGE_OCAML;
 
     let mut input = input.as_bytes();
@@ -15,6 +17,9 @@ async fn format() {
     let language: Language = Language {
         name: "ocaml".to_owned(),
         query: TopiaryQuery::new(&ocaml.clone().into(), &query_content).unwrap(),
+        comment_query: Some(
+            TopiaryQuery::new(&ocaml.clone().into(), &comment_query_content).unwrap(),
+        ),
         grammar: ocaml.into(),
         indent: None,
     };

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -1062,7 +1062,7 @@ impl AtomCollection {
         // antispaces may have produced more empty atoms.
         self.post_process_inner();
 
-        log::debug!("List of atoms after post-processing: {:?}", self.atoms);
+        log::debug!("List of atoms after post-processing: {:#?}", self.atoms);
     }
 
     /// This function post-processes the atoms in the collection.

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -1112,12 +1112,13 @@ impl AtomCollection {
                 ) => {
                     if head.dominates(moved_prev) {
                         *moved_prev = Atom::Empty;
+                        prev = head;
+                        remaining = tail;
                     } else {
                         *head = Atom::Empty;
+                        prev = moved_prev;
+                        remaining = tail;
                     }
-
-                    prev = moved_prev;
-                    remaining = tail;
                 }
                 // If a whitespace atom is followed by an indent atom, swap their positions.
                 (

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -535,7 +535,7 @@ impl AtomCollection {
             self.atoms.push(Atom::Leaf {
                 content: String::from(node.utf8_text(source)?),
                 id,
-                original_position: node.start_position().into(),
+                original_column: node.start_position().column() as i32,
                 single_line_no_indent: false,
                 multi_line_indent_all: false,
             });

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -8,7 +8,8 @@ use std::{
 use topiary_tree_sitter_facade::Node;
 
 use crate::{
-    tree_sitter::NodeExt, Atom, FormatterError, FormatterResult, ScopeCondition, ScopeInformation,
+    tree_sitter::NodeExt,
+    Atom, FormatterError, FormatterResult, ScopeCondition, ScopeInformation,
 };
 
 /// A struct that holds sets of node IDs that have line breaks before or after them.

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -959,17 +959,22 @@ impl AtomCollection {
                         single_line_no_indent: false,
                         multi_line_indent_all: true,
                     };
-                    comments_queue_with_context.push_front(CommentWithContext{
+                    comments_queue_with_context.push_front(CommentWithContext {
                         comment: comment_atom,
                         blank_line_after,
-                        blank_line_before
+                        blank_line_before,
                     });
                 }
                 atoms_with_comments_before.push_front(atom);
             } else if Atom::Hardline == atom || Atom::Blankline == atom {
                 let mut blank_line_before_first_comment = false;
                 // Prepend the comments, each one followed by a newline
-                while let Some(CommentWithContext{comment, blank_line_after, blank_line_before}) = comments_queue_with_context.pop_back() {
+                while let Some(CommentWithContext {
+                    comment,
+                    blank_line_after,
+                    blank_line_before,
+                }) = comments_queue_with_context.pop_back()
+                {
                     if blank_line_after {
                         atoms_with_comments_before.push_front(Atom::Blankline)
                     } else {
@@ -989,7 +994,12 @@ impl AtomCollection {
         }
         let mut blank_line_before_first_comment = false;
         // If we still have comments left, add them at the beginning of the file
-        while let Some(CommentWithContext{comment, blank_line_after, blank_line_before}) = comments_queue_with_context.pop_back() {
+        while let Some(CommentWithContext {
+            comment,
+            blank_line_after,
+            blank_line_before,
+        }) = comments_queue_with_context.pop_back()
+        {
             if blank_line_after {
                 atoms_with_comments_before.push_front(Atom::Blankline)
             } else {

--- a/topiary-core/src/comments.rs
+++ b/topiary-core/src/comments.rs
@@ -378,8 +378,8 @@ fn find_anchor<'tree>(node: &'tree Node<'tree>, input: &str) -> FormatterResult<
         })?;
     if prefix.trim_start() == "" {
         if let Some(anchor) = next_non_comment_leaf(node.clone()) {
-            let prev = previous_disjoint_node(&node);
-            let next = next_disjoint_node(&node);
+            let prev = previous_disjoint_node(node);
+            let next = next_disjoint_node(node);
             Ok(Commented::CommentedAfter {
                 section: (&anchor).into(),
                 blank_line_after: next
@@ -400,8 +400,8 @@ fn find_anchor<'tree>(node: &'tree Node<'tree>, input: &str) -> FormatterResult<
         if let Some(anchor) = previous_non_comment_leaf(node.clone()) {
             Ok(Commented::CommentedBefore((&anchor).into()))
         } else if let Some(anchor) = next_non_comment_leaf(node.clone()) {
-            let prev = previous_disjoint_node(&node);
-            let next = next_disjoint_node(&node);
+            let prev = previous_disjoint_node(node);
+            let next = next_disjoint_node(node);
             Ok(Commented::CommentedAfter {
                 section: (&anchor).into(),
                 blank_line_after: next

--- a/topiary-core/src/comments.rs
+++ b/topiary-core/src/comments.rs
@@ -135,13 +135,13 @@ fn find_comments(
 
 /// The section of code to which a comment refers. We also remember whether the comment
 /// is positioned before or after the section.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Commented {
     /// The code section is before the comment, as in:
     /// ```
     /// struct Foo {
-    ///     baz: Baz, // this is baz
-    ///     quz: Qux, // this is qux
+    ///     baz: usize, // this is baz
+    ///     quz: usize, // this is qux
     /// }
     /// ```
     CommentedBefore(InputSection),
@@ -149,9 +149,9 @@ pub enum Commented {
     /// ```
     /// struct Foo {
     ///     // let's have a baz
-    ///     baz: Baz,
+    ///     baz: usize,
     ///     // and a qux
-    ///     qux: Qux,
+    ///     qux: usize,
     /// }
     /// ```
     CommentedAfter(InputSection),
@@ -335,7 +335,7 @@ fn find_anchor<'tree>(node: &'tree Node<'tree>, input: &str) -> FormatterResult<
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AnchoredComment {
     pub comment_text: String,
     // We need to keep track of the column for indentation purposes

--- a/topiary-core/src/comments.rs
+++ b/topiary-core/src/comments.rs
@@ -1,0 +1,416 @@
+use topiary_tree_sitter_facade::{InputEdit, Language, Node, Tree};
+
+use crate::{
+    common::{parse, Diff, InputSection, Position},
+    error::FormatterError,
+    FormatterResult,
+};
+
+/// When you remove a block of text from the input, it changes the positions of every subsequent character.
+/// This is what this Diff instance does.
+impl Diff<InputSection> for Position {
+    type ErrorType = FormatterError;
+
+    fn subtract(&mut self, other: InputSection) -> FormatterResult<()> {
+        if *self <= other.start {
+            // The point is before the removed block: nothing happens.
+            Ok(())
+        } else if other.end <= *self {
+            // The point is after the removed block: its new coordinates depend on whether it was
+            // on the same row as the last point of the removed block.
+            //
+            // See in the following example how the positions of characters `a` and `b`
+            // change when the bracketed block is removed:
+            //
+            // Before:
+            // ..........
+            // ...[---------
+            // ---------
+            // -------]...a..
+            // ...b......
+            // .............
+            //
+            // After:
+            // ..........
+            // ......a..
+            // ...b......
+            // .............
+            let mut row = self.row;
+            let mut column = self.column;
+            if row == other.end.row {
+                column = column + other.start.column - other.end.column
+            }
+            row = row + other.start.row - other.end.row;
+            *self = Position { row, column };
+            Ok(())
+        } else {
+            // The point is within the removed block:
+            // fail, because the point can't be accessed after the subtraction
+            Err(FormatterError::Internal(
+                "Tried to remove a section from a point it contains".into(),
+                None,
+            ))
+        }
+    }
+}
+
+impl Diff<InputSection> for InputSection {
+    type ErrorType = FormatterError;
+
+    fn subtract(&mut self, other: Self) -> FormatterResult<()> {
+        self.start.subtract(other)?;
+        self.end.subtract(other)
+    }
+}
+
+// TODO: allow the users to manually identify comments. Maybe with a separate query file?
+fn is_comment(node: &Node) -> bool {
+    node.is_extra() && node.kind().to_string().contains("comment")
+}
+
+fn into_edit(node: &Node<'_>) -> InputEdit {
+    InputEdit::new(
+        node.start_byte(),
+        node.end_byte(),
+        node.start_byte(),
+        &node.start_position(),
+        &node.end_position(),
+        &node.start_position(),
+    )
+}
+
+fn find_comments(
+    node: Node,
+    input: &str,
+    comments: &mut Vec<(InputEdit, AnchoredComment)>,
+) -> FormatterResult<()> {
+    if is_comment(&node) {
+        let commented = find_anchor(&node, input)?;
+        // Build the corresponding InputEdit:
+        // - If the comment is not alone on its line, return its bounds
+        // - If the comment is alone on its line, return the bounds of all its line
+        //   (we don't want to create undue blank lines)
+        let prev = previous_disjoint_node(&node);
+        let next = next_disjoint_node(&node);
+        // Nested ifs are necessary, because `if let ...` don't play well with other clauses
+        let edit: InputEdit = if let Some(prev) = prev {
+            if let Some(next) = next {
+                if prev.end_position().row() < node.start_position().row()
+                    && node.end_position().row() < next.start_position().row()
+                {
+                    InputEdit::new(
+                        prev.end_byte(),
+                        node.end_byte(),
+                        prev.end_byte(),
+                        &prev.end_position(),
+                        &node.end_position(),
+                        &prev.end_position(),
+                    )
+                } else {
+                    into_edit(&node)
+                }
+            } else {
+                into_edit(&node)
+            }
+        } else {
+            into_edit(&node)
+        };
+        comments.push((
+            edit,
+            AnchoredComment {
+                comment_text: node.utf8_text(input.as_bytes())?.to_string(),
+                original_column: node.start_position().column() as i32,
+                commented,
+            },
+        ));
+        Ok(())
+    } else {
+        let mut walker = node.walk();
+        for child in node.children(&mut walker) {
+            find_comments(child, input, comments)?;
+        }
+        Ok(())
+    }
+}
+
+/// The section of code to which a comment refers. We also remember whether the comment
+/// is positioned before or after the section.
+#[derive(Copy, Clone, Debug)]
+pub enum Commented {
+    /// The code section is before the comment, as in:
+    /// ```
+    /// struct Foo {
+    ///     baz: Baz, // this is baz
+    ///     quz: Qux, // this is qux
+    /// }
+    /// ```
+    CommentedBefore(InputSection),
+    /// The code section is after the comment, as in:
+    /// ```
+    /// struct Foo {
+    ///     // let's have a baz
+    ///     baz: Baz,
+    ///     // and a qux
+    ///     qux: Qux,
+    /// }
+    /// ```
+    CommentedAfter(InputSection),
+}
+
+impl Diff<InputSection> for Commented {
+    type ErrorType = FormatterError;
+
+    fn subtract(&mut self, other: InputSection) -> FormatterResult<()> {
+        match self {
+            Commented::CommentedBefore(section) => section.subtract(other),
+            Commented::CommentedAfter(section) => section.subtract(other),
+        }
+    }
+}
+
+fn next_disjoint_node<'tree>(starting_node: &'tree Node<'tree>) -> Option<Node<'tree>> {
+    let mut node: Node<'tree> = starting_node.clone();
+    // move up until we find a next sibling
+    while node.next_sibling().is_none() {
+        match node.parent() {
+            None => return None,
+            Some(parent) => node = parent,
+        }
+    }
+    node.next_sibling()
+}
+
+fn previous_disjoint_node<'tree>(starting_node: &'tree Node<'tree>) -> Option<Node<'tree>> {
+    let mut node: Node<'tree> = starting_node.clone();
+    // move up until we find a previous sibling
+    while node.prev_sibling().is_none() {
+        match node.parent() {
+            None => return None,
+            Some(parent) => node = parent,
+        }
+    }
+    node.prev_sibling()
+}
+
+// TODO: if performance is an issue, use TreeCursor to navigate the tree
+fn next_non_comment_leaf<'tree>(starting_node: Node<'tree>) -> Option<Node<'tree>> {
+    let mut node: Node<'tree> = starting_node;
+    loop {
+        // get the next leaf:
+        // 1) move up until we find a next sibling
+        loop {
+            match node.next_sibling() {
+                None => {
+                    if let Some(parent) = node.parent() {
+                        node = parent
+                    } else {
+                        return None;
+                    } // we've reached the root and found nothing
+                }
+                Some(sibling) => {
+                    node = sibling;
+                    if is_comment(&node) {
+                        // get the following sibling
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        // 2) get the leftmost leaf of the sibling.
+        // If we encounter a comment, we stop. We'll get back to 1) after the loop
+        while let Some(child) = node.child(0) {
+            if is_comment(&child) {
+                break;
+            } else {
+                node = child
+            }
+        }
+        // check if the leaf is a comment. If it is not, start over again.
+        if is_comment(&node) {
+            continue;
+        } else {
+            return Some(node);
+        }
+    }
+}
+
+// TODO: if performance is an issue, use TreeCursor to navigate the tree
+fn previous_non_comment_leaf<'tree>(starting_node: Node<'tree>) -> Option<Node<'tree>> {
+    let mut node: Node<'tree> = starting_node;
+    loop {
+        // get the previous leaf:
+        // 1) move up until we find a previous sibling
+        loop {
+            match node.prev_sibling() {
+                None => {
+                    if let Some(parent) = node.parent() {
+                        node = parent
+                    } else {
+                        // we've reached the root and found nothing
+                        return None;
+                    }
+                }
+                Some(sibling) => {
+                    node = sibling;
+                    if is_comment(&node) {
+                        // get the previous sibling
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        // 2) get the rightmost leaf of the sibling.
+        // If we encounter a comment, we stop. We'll get back to 1) after the loop
+        while let Some(child) = {
+            if node.child_count() == 0 {
+                None
+            } else {
+                node.child(node.child_count() - 1)
+            }
+        } {
+            if is_comment(&child) {
+                break;
+            } else {
+                node = child
+            }
+        }
+        // check if the leaf is a comment. If it is not, start over again.
+        if is_comment(&node) {
+            continue;
+        } else {
+            return Some(node);
+        }
+    }
+}
+
+// Use the following heuristics to find a comment's anchor:
+// If the comment is only prefixed by blank symbols on its line, then the anchor is the
+// next non-comment sibling node.
+// Otherwise, the anchor is the previous non-comment sibling node.
+// If there is no such node, we anchor to the first non-comment sibling node
+// in the other direction.
+#[allow(clippy::collapsible_else_if)]
+fn find_anchor<'tree>(node: &'tree Node<'tree>, input: &str) -> FormatterResult<Commented> {
+    let point = node.start_position();
+    let mut lines = input.lines();
+    let prefix = lines
+        .nth(point.row() as usize)
+        .map(|line| &line[..point.column() as usize])
+        .ok_or_else(|| {
+            FormatterError::Internal(
+                format!(
+                    "Trying to access nonexistent line {} in text:\n{}",
+                    point.row(),
+                    input,
+                ),
+                None,
+            )
+        })?;
+    if prefix.trim_start() == "" {
+        if let Some(anchor) = next_non_comment_leaf(node.clone()) {
+            return Ok(Commented::CommentedAfter(anchor.into()));
+        } else if let Some(anchor) = previous_non_comment_leaf(node.clone()) {
+            return Ok(Commented::CommentedBefore(anchor.into()));
+        } else {
+            return Err(FormatterError::Internal(
+                format!("Could find no anchor for comment {node:?}",),
+                None,
+            ));
+        }
+    } else {
+        if let Some(anchor) = previous_non_comment_leaf(node.clone()) {
+            return Ok(Commented::CommentedBefore(anchor.into()));
+        } else if let Some(anchor) = next_non_comment_leaf(node.clone()) {
+            return Ok(Commented::CommentedAfter(anchor.into()));
+        } else {
+            return Err(FormatterError::Internal(
+                format!("Could find no anchor for comment {node:?}",),
+                None,
+            ));
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AnchoredComment {
+    pub comment_text: String,
+    // We need to keep track of the column for indentation purposes
+    pub original_column: i32,
+    pub commented: Commented,
+}
+
+pub struct SeparatedInput {
+    pub input_tree: Tree,
+    pub input_string: String,
+    pub comments: Vec<AnchoredComment>,
+}
+
+pub fn extract_comments<'a>(
+    tree: &'a Tree,
+    input: &'a str,
+    grammar: &Language,
+    tolerate_parsing_errors: bool,
+) -> FormatterResult<SeparatedInput> {
+    let mut anchors: Vec<(InputEdit, AnchoredComment)> = Vec::new();
+    let mut anchored_comments: Vec<AnchoredComment> = Vec::new();
+    let mut new_input: String = input.to_string();
+    let mut new_tree: Tree = tree.clone();
+    find_comments(tree.root_node(), input, &mut anchors)?;
+    anchors.sort_by_key(|(node, _)| node.start_byte());
+    let mut edits: Vec<InputEdit> = Vec::new();
+    // for each (comment, anchor) pair in reverse order, we:
+    // 1) remove the comment from the input,
+    // 2) register an InputEdit to modify the tree,
+    // 3) edit the following anchors to account for the removed comment.
+    //
+    // The order is reversed so that all InputEdits can be applied in succession:
+    // one will not affect the others.
+    while let Some((edit, anchored_comment)) = anchors.pop() {
+        // 1)
+        new_input.replace_range(
+            (edit.start_byte() as usize)..(edit.old_end_byte() as usize),
+            "",
+        );
+        // 2)
+        let section: InputSection = (&edit).into();
+        edits.push(edit);
+        // 3)
+        anchored_comments.push(anchored_comment);
+        anchored_comments = anchored_comments
+            .iter()
+            .map(
+                |AnchoredComment {
+                     mut commented,
+                     original_column,
+                     comment_text,
+                 }|
+                 -> FormatterResult<AnchoredComment> {
+                    commented.subtract(section)?;
+                    Ok(AnchoredComment {
+                        commented,
+                        original_column: *original_column,
+                        comment_text: comment_text.to_string(),
+                    })
+                },
+            )
+            .collect::<FormatterResult<Vec<_>>>()?;
+    }
+    for edit in edits {
+        new_tree.edit(&edit);
+    }
+    new_tree = parse(
+        new_input.as_str(),
+        grammar,
+        tolerate_parsing_errors,
+        Some(&new_tree),
+    )?;
+    Ok(SeparatedInput {
+        input_tree: new_tree,
+        input_string: new_input,
+        comments: anchored_comments,
+    })
+}

--- a/topiary-core/src/common.rs
+++ b/topiary-core/src/common.rs
@@ -1,0 +1,113 @@
+use std::{cmp::Ord, fmt::Display};
+
+use serde::Serialize;
+use topiary_tree_sitter_facade::{InputEdit, Node, Parser, Point, Tree};
+
+use crate::{error::FormatterError, FormatterResult};
+
+/// A module for common, low-level types and functions in the topiary-core crate
+
+/// Refers to a position within the code. Used for error reporting, and for
+/// comparing input with formatted output. The numbers are 1-based, because that
+/// is how editors usually refer to a position. Derived from tree_sitter::Point.
+/// Note that the order is the standard western reading order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct Position {
+    pub row: u32,
+    pub column: u32,
+}
+
+impl Display for Position {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "({},{})", self.row, self.column)
+    }
+}
+
+impl From<Point> for Position {
+    fn from(point: Point) -> Self {
+        Self {
+            row: point.row() + 1,
+            column: point.column() + 1,
+        }
+    }
+}
+
+/// Some section of contiguous characters in the input.
+/// It is assumed that `start <= end`, according to the order on `Position`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InputSection {
+    pub start: Position,
+    pub end: Position,
+}
+
+impl From<Node<'_>> for InputSection {
+    fn from(value: Node) -> Self {
+        InputSection {
+            start: value.start_position().into(),
+            end: value.end_position().into(),
+        }
+    }
+}
+
+impl From<&InputEdit> for InputSection {
+    fn from(value: &InputEdit) -> Self {
+        InputSection {
+            start: value.start_position().into(),
+            end: value.old_end_position().into(),
+        }
+    }
+}
+
+/// A generic trait to subtract stuff from other stuff. The function can be partial.
+/// In practice, it will be used to update text positions within the input,
+/// when removing parts of it.
+pub trait Diff<T> {
+    type ErrorType;
+
+    fn subtract(&mut self, other: T) -> Result<(), Self::ErrorType>;
+}
+
+/// Parses some string into a syntax tree, given a tree-sitter grammar.
+pub fn parse(
+    content: &str,
+    grammar: &topiary_tree_sitter_facade::Language,
+    tolerate_parsing_errors: bool,
+    old_tree: Option<&Tree>,
+) -> FormatterResult<Tree> {
+    let mut parser = Parser::new()?;
+    parser.set_language(grammar).map_err(|_| {
+        FormatterError::Internal("Could not apply Tree-sitter grammar".into(), None)
+    })?;
+
+    let tree = parser
+        .parse(content, old_tree)?
+        .ok_or_else(|| FormatterError::Internal("Could not parse input".into(), None))?;
+
+    // Fail parsing if we don't get a complete syntax tree.
+    if !tolerate_parsing_errors {
+        check_for_error_nodes(&tree.root_node())?;
+    }
+
+    Ok(tree)
+}
+
+fn check_for_error_nodes(node: &Node) -> FormatterResult<()> {
+    if node.kind() == "ERROR" {
+        let start = node.start_position();
+        let end = node.end_position();
+
+        // Report 1-based lines and columns.
+        return Err(FormatterError::Parsing {
+            start_line: start.row() + 1,
+            start_column: start.column() + 1,
+            end_line: end.row() + 1,
+            end_column: end.column() + 1,
+        });
+    }
+
+    for child in node.children(&mut node.walk()) {
+        check_for_error_nodes(&child)?;
+    }
+
+    Ok(())
+}

--- a/topiary-core/src/common.rs
+++ b/topiary-core/src/common.rs
@@ -40,8 +40,14 @@ pub struct InputSection {
     pub end: Position,
 }
 
-impl From<Node<'_>> for InputSection {
-    fn from(value: Node) -> Self {
+impl InputSection {
+    pub fn contains(self, other: &Self) -> bool {
+        self.start <= other.start && other.end <= self.end
+    }
+}
+
+impl From<&Node<'_>> for InputSection {
+    fn from(value: &Node) -> Self {
         InputSection {
             start: value.start_position().into(),
             end: value.end_position().into(),

--- a/topiary-core/src/language.rs
+++ b/topiary-core/src/language.rs
@@ -13,6 +13,9 @@ pub struct Language {
     /// The Query Topiary will use to get the formating captures, must be
     /// present. The topiary engine does not include any formatting queries.
     pub query: TopiaryQuery,
+    /// The Query Topiary will use to determine which nodes are comments.
+    /// When missing, ther ewill be no separate comment processing.
+    pub comment_query: Option<TopiaryQuery>,
     /// The tree-sitter Language. Topiary will use this Language for parsing.
     pub grammar: topiary_tree_sitter_facade::Language,
     /// The indentation string used for that particular language. Defaults to "  "

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -63,7 +63,7 @@ pub enum Atom {
     Leaf {
         content: String,
         id: usize,
-        original_position: Position,
+        original_column: i32,
         // marks the leaf to be printed on a single line, with no indentation
         single_line_no_indent: bool,
         // if the leaf is multi-line, each line will be indented, not just the first

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -199,6 +199,7 @@ pub enum Operation {
 /// let language: Language = Language {
 ///     name: "json".to_owned(),
 ///     query: TopiaryQuery::new(&json.clone().into(), &query_content).unwrap(),
+///     comment_query: None,
 ///     grammar: json.into(),
 ///     indent: None,
 /// };
@@ -240,6 +241,7 @@ pub fn formatter(
             let mut atoms = tree_sitter::apply_query(
                 &content,
                 &language.query,
+                &language.comment_query,
                 &language.grammar,
                 tolerate_parsing_errors,
             )?;
@@ -395,6 +397,7 @@ mod tests {
         let language = Language {
             name: "json".to_owned(),
             query: TopiaryQuery::new(&grammar, query_content).unwrap(),
+            comment_query: None,
             grammar,
             indent: None,
         };
@@ -431,6 +434,7 @@ mod tests {
         let language = Language {
             name: "json".to_owned(),
             query: TopiaryQuery::new(&grammar, &query_content).unwrap(),
+            comment_query: None,
             grammar,
             indent: None,
         };

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -23,13 +23,13 @@ pub use crate::{
 };
 
 mod atom_collection;
-mod comments;
-mod common;
+pub mod comments;
+pub mod common;
 mod error;
 mod graphviz;
 mod language;
 mod pretty;
-mod tree_sitter;
+pub mod tree_sitter;
 
 #[doc(hidden)]
 pub mod test_utils;

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -14,15 +14,17 @@ use std::io;
 
 use itertools::Itertools;
 use pretty_assertions::StrComparison;
-use tree_sitter::Position;
 
 pub use crate::{
+    common::{parse, Position},
     error::{FormatterError, IoError},
     language::Language,
     tree_sitter::{apply_query, CoverageData, SyntaxNode, TopiaryQuery, Visualisation},
 };
 
 mod atom_collection;
+mod comments;
+mod common;
 mod error;
 mod graphviz;
 mod language;
@@ -262,7 +264,7 @@ pub fn formatter(
         }
 
         Operation::Visualise { output_format } => {
-            let tree = tree_sitter::parse(&content, &language.grammar, false)?;
+            let tree = parse(&content, &language.grammar, false, None)?;
             let root: SyntaxNode = tree.root_node().into();
 
             match output_format {

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -41,7 +41,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
 
             Atom::Leaf {
                 content,
-                original_position,
+                original_column,
                 single_line_no_indent,
                 multi_line_indent_all,
                 ..
@@ -56,9 +56,6 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
 
                 let content = if *multi_line_indent_all {
                     let cursor = current_column(&buffer) as i32;
-
-                    // original_position is 1-based
-                    let original_column = original_position.column as i32 - 1;
 
                     let indenting = cursor - original_column;
 

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -225,7 +225,8 @@ pub fn apply_query(
     for AnchoredComment {
         comment_text,
         commented,
-    } in comments
+        ..
+    } in comments.iter()
     {
         log::debug!("Found comment \"{comment_text}\" with anchor {commented:?}");
     }
@@ -251,7 +252,7 @@ pub fn apply_query(
     let specified_leaf_nodes: HashSet<usize> = collect_leaf_ids(&matches, capture_names.clone());
 
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
-    let mut atoms = AtomCollection::collect_leafs(&root, source, specified_leaf_nodes)?;
+    let mut atoms = AtomCollection::collect_leafs(&root, source, specified_leaf_nodes, comments)?;
 
     log::debug!("List of atoms before formatting: {atoms:?}");
 

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -254,7 +254,7 @@ pub fn apply_query(
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
     let mut atoms = AtomCollection::collect_leafs(&root, source, specified_leaf_nodes, comments)?;
 
-    log::debug!("List of atoms before formatting: {atoms:?}");
+    log::debug!("List of atoms before formatting: {atoms:#?}");
 
     // Memoization of the pattern positions
     let mut pattern_positions: Vec<Option<Position>> = Vec::new();

--- a/topiary-core/tests/comment_tests.rs
+++ b/topiary-core/tests/comment_tests.rs
@@ -55,7 +55,11 @@ fn test_extract_comments() {
     let mut expected_comments: Vec<AnchoredComment> = vec![
         AnchoredComment {
             comment_text: "(* starting comment *)".into(),
-            commented: CommentedAfter(FUN_SECTION),
+            commented: CommentedAfter{
+                section: FUN_SECTION,
+                blank_line_after: false,
+                blank_line_before: false
+            },
             original_column: 0,
         },
         AnchoredComment {
@@ -70,7 +74,11 @@ fn test_extract_comments() {
         },
         AnchoredComment {
             comment_text: "(** multi-lined\n    * body comment\n    *)".into(),
-            commented: CommentedAfter(BODY_SECTION),
+            commented: CommentedAfter{
+                section: BODY_SECTION,
+                blank_line_after: false,
+                blank_line_before: false,
+            },
             original_column: 2,
         },
         AnchoredComment {

--- a/topiary-core/tests/comment_tests.rs
+++ b/topiary-core/tests/comment_tests.rs
@@ -55,10 +55,10 @@ fn test_extract_comments() {
     let mut expected_comments: Vec<AnchoredComment> = vec![
         AnchoredComment {
             comment_text: "(* starting comment *)".into(),
-            commented: CommentedAfter{
+            commented: CommentedAfter {
                 section: FUN_SECTION,
                 blank_line_after: false,
-                blank_line_before: false
+                blank_line_before: false,
             },
             original_column: 0,
         },
@@ -74,7 +74,7 @@ fn test_extract_comments() {
         },
         AnchoredComment {
             comment_text: "(** multi-lined\n    * body comment\n    *)".into(),
-            commented: CommentedAfter{
+            commented: CommentedAfter {
                 section: BODY_SECTION,
                 blank_line_after: false,
                 blank_line_before: false,

--- a/topiary-core/tests/comment_tests.rs
+++ b/topiary-core/tests/comment_tests.rs
@@ -1,0 +1,93 @@
+use topiary_core::{
+    comments::{
+        extract_comments, AnchoredComment,
+        Commented::{CommentedAfter, CommentedBefore},
+        SeparatedInput,
+    },
+    common::{parse, InputSection},
+    Position,
+};
+
+const OCAML_WITH_COMMENTS: &str = r#"(* starting comment *)
+fun (* fun comment *) x (* var comment *) ->
+  (** multi-lined
+    * body comment
+    *)
+  body
+(* final comment *)
+"#;
+
+const OCAML_WITHOUT_COMMENTS: &str = r#"fun  x  ->
+  body
+"#;
+
+// The section corresponding to `fun` in the curated code
+const FUN_SECTION: InputSection = InputSection {
+    start: Position { row: 1, column: 1 },
+    end: Position { row: 1, column: 4 },
+};
+
+// The section corresponding to `x` in the curated code
+const VAR_SECTION: InputSection = InputSection {
+    start: Position { row: 1, column: 6 },
+    end: Position { row: 1, column: 7 },
+};
+
+// The section corresponding to `body` in the curated code
+const BODY_SECTION: InputSection = InputSection {
+    start: Position { row: 2, column: 3 },
+    end: Position { row: 2, column: 7 },
+};
+
+#[test]
+fn test_extract_comments() {
+    let input = OCAML_WITH_COMMENTS;
+    let ocaml = tree_sitter_ocaml::LANGUAGE_OCAML;
+
+    let tree = parse(input, &ocaml.into(), false, None).unwrap();
+
+    let SeparatedInput {
+        input_tree: _,
+        input_string: new_input_string,
+        mut comments,
+    } = extract_comments(&tree, input, &ocaml.into(), false).unwrap();
+
+    let mut expected_comments: Vec<AnchoredComment> = vec![
+        AnchoredComment {
+            comment_text: "(* starting comment *)".into(),
+            commented: CommentedAfter(FUN_SECTION),
+            original_column: 0,
+        },
+        AnchoredComment {
+            comment_text: "(* fun comment *)".into(),
+            commented: CommentedBefore(FUN_SECTION),
+            original_column: 4,
+        },
+        AnchoredComment {
+            comment_text: "(* var comment *)".into(),
+            commented: CommentedBefore(VAR_SECTION),
+            original_column: 24,
+        },
+        AnchoredComment {
+            comment_text: "(** multi-lined\n    * body comment\n    *)".into(),
+            commented: CommentedAfter(BODY_SECTION),
+            original_column: 2,
+        },
+        AnchoredComment {
+            comment_text: "(* final comment *)".into(),
+            commented: CommentedBefore(BODY_SECTION),
+            original_column: 0,
+        },
+    ];
+
+    // sort the comments so that we're order-independent
+    comments.sort_by_key(|comment| comment.comment_text.clone());
+    expected_comments.sort_by_key(|comment| comment.comment_text.clone());
+
+    assert_eq!(new_input_string, OCAML_WITHOUT_COMMENTS);
+
+    assert_eq!(comments.len(), 5);
+    for (comment, expected_comment) in comments.iter().zip(expected_comments.iter()) {
+        assert_eq!(comment, expected_comment)
+    }
+}

--- a/topiary-playground/src/lib.rs
+++ b/topiary-playground/src/lib.rs
@@ -44,6 +44,7 @@ mod wasm_mod {
         let language = Language {
             name: language.name,
             query,
+            comment_query: None,
             grammar,
             indent: language.config.indent,
         };

--- a/topiary-queries/queries/bash.comment.scm
+++ b/topiary-queries/queries/bash.comment.scm
@@ -1,0 +1,2 @@
+; Identify nodes for comment processing
+(comment) @comment

--- a/topiary-queries/queries/bash.scm
+++ b/topiary-queries/queries/bash.scm
@@ -6,7 +6,6 @@
 ; variable expansions (simple or otherwise)
 ; FIXME The first line of heredocs are affected by the indent level
 [
-  (comment)
   (expansion)
   (heredoc_redirect)
   (string)
@@ -39,7 +38,6 @@
   (case_item)
   (case_statement)
   (command)
-  (comment)
   (compound_statement)
   (declaration_command)
   (for_statement)
@@ -144,53 +142,6 @@
 [
   "in"
 ] @prepend_space
-
-;; Comments
-
-; Comments come in two flavours: standalone (i.e., it's the only thing
-; on a line, starting at the current indent level); and trailing (i.e.,
-; following some other statement on the same line, with a space
-; interposed). Bash does not have multi-line comments; they are all
-; single-line.
-;
-; The grammar parses all comments as the (comment) node, which are
-; siblings under a common parent.
-;
-; Formatting Rules:
-;
-; 1. A comment's contents must not be touched; some (namely the shebang)
-;    have a syntactic purpose.
-; 2. All comments must end with a new line.
-; 3. Comments can be interposed by blank lines, if they exist in the
-;    input (i.e., blank lines shouldn't be engineered elsewhere).
-; 4. A comment can never change flavour (i.e., standalone to trailing,
-;    or vice versa).
-; 5. Trailing comments should be interposed by a space.
-
-; Rule 1: See @leaf rule, above
-
-; Rule 2
-(comment) @append_hardline
-
-; Rule 3: See @allow_blank_line_before rule, above.
-; FIXME This doesn't quite get us what we want. It's close, but blank
-; lines between comments can get consumed.
-
-; Rule 4: We only have to protect against the case of a standalone
-; comment, after a statement, being slurped on to that statement's line
-; and becoming a trailing comment. That case is satisfied by Rule 5.
-
-; Rule 5
-(
-  (comment) @prepend_begin_scope @append_begin_measuring_scope
-  .
-  _ @prepend_end_measuring_scope @prepend_end_scope
-  (#scope_id! "line_break_after_comment")
-)
-(
-  (comment) @prepend_space
-  (#multi_line_scope_only! "line_break_after_comment")
-)
 
 ;; Compound Statements and Subshells
 

--- a/topiary-queries/queries/css.comment.scm
+++ b/topiary-queries/queries/css.comment.scm
@@ -1,0 +1,2 @@
+; Identify nodes for comment processing
+(comment) @comment

--- a/topiary-queries/queries/css.scm
+++ b/topiary-queries/queries/css.scm
@@ -50,9 +50,6 @@
 ; Spacing before and after a rule_set
 (rule_set) @allow_blank_line_before @prepend_hardline
 
-; Allow comments to have a blank line before them
-(comment) @allow_blank_line_before
-
 ; Allow blank lines before any declaration in a block except the first one
 (block . (declaration) (declaration) @allow_blank_line_before)
 

--- a/topiary-queries/queries/nickel.comment.scm
+++ b/topiary-queries/queries/nickel.comment.scm
@@ -1,0 +1,2 @@
+; Identify nodes for comment processing
+(comment) @comment

--- a/topiary-queries/queries/nickel.scm
+++ b/topiary-queries/queries/nickel.scm
@@ -11,7 +11,6 @@
 
 ; Allow a blank line before the following nodes
 [
-  (comment)
   (record_field)
   (record_last_field)
 ] @allow_blank_line_before
@@ -208,10 +207,6 @@
   (pattern_fun)
 )
 
-;; Comments
-
-(comment) @prepend_input_softline @append_hardline
-
 ;; Bound Expressions
 ; i.e., Let expressions and record fields
 
@@ -279,16 +274,6 @@
       ]? @do_nothing
     )
   ) @append_indent_end
-)
-
-; If the RHS starts with a comment, which itself is followed by a hard
-; line, then we apply the normal indent block formatting in a multi-line
-; context (i.e., no exceptions)
-(_
-  "=" @append_indent_start
-  .
-  (comment)
-  (term) @append_indent_end
 )
 
 ; A let expression looks like:
@@ -654,8 +639,6 @@
   ]
   .
   ["," ";"] @append_spaced_scoped_softline
-  .
-  (comment)? @do_nothing
 )
 
 ; Enums and records can have a `;` at the very beginning; allow spaces after
@@ -664,6 +647,4 @@
   (#scope_id! "container")
   .
   ";" @append_spaced_scoped_softline
-  .
-  (comment)? @do_nothing
 )

--- a/topiary-queries/queries/ocaml.comment.scm
+++ b/topiary-queries/queries/ocaml.comment.scm
@@ -1,0 +1,2 @@
+; Identify nodes for comment processing
+(comment) @comment

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -31,8 +31,6 @@
   ]
 ) @leaf
 
-(comment) @multi_line_indent_all
-
 ; line number directives must be alone on their line, and can't be indented
 (line_number_directive) @single_line_no_indent
 
@@ -41,7 +39,6 @@
   (class_definition)
   (class_initializer)
   (class_type_definition)
-  (comment)
   (exception_definition)
   (external)
   (floating_attribute)
@@ -84,9 +81,7 @@
   "and" @allow_blank_line_before
 )
 
-; Append line breaks. If there is a comment following, we don't add anything,
-; because the input softlines and spaces above will already have sorted out the
-; formatting.
+; Append line breaks.
 (
   [
     (exception_definition)
@@ -97,8 +92,6 @@
   ] @append_spaced_softline
   .
   "in"? @do_nothing
-  .
-  (comment)* @do_nothing
 )
 ; Also append line breaks after open_module, except when it's
 ; preceded by "let", because in this case it's in a let_open_expression.
@@ -106,8 +99,6 @@
   "let"? @do_nothing
   .
   (open_module) @append_hardline
-  .
-  (comment)* @do_nothing
 )
 
 ; Append line break after module include, except if it's alone in a single-lined struct
@@ -430,7 +421,7 @@
 )
 
 ; Softlines. These become either a space or a newline, depending on whether we
-; format their node as single-line or multi-line. If there is a comment
+; format their node as single-line or multi-line. If there is an attribute
 ; following, we don't add anything, because they will have their own line break
 ; processing applied to them.
 ;
@@ -450,7 +441,6 @@
   .
   [
     (attribute)
-    (comment)
     "%"
   ]* @do_nothing
 )
@@ -470,18 +460,13 @@
   "%"
   .
   (attribute_id) @append_spaced_softline
-  .
-  (comment)* @do_nothing
 )
 
 ; only add softlines after "else" if it's not part of an "else if" construction
 (
   "else" @append_spaced_softline
   .
-  [
-    (comment)
-    (if_expression)
-  ]? @do_nothing
+  (if_expression)? @do_nothing
 )
 
 ; ":" must not always be followed by a softline, we explicitly enumerate
@@ -791,10 +776,7 @@
 (record_declaration
   (field_declaration) @append_delimiter
   .
-  [
-    (comment)
-    (attribute)
-  ]*
+  (attribute)*
   .
   ";" @delete
   (#delimiter! ";")
@@ -818,7 +800,6 @@
   [
     (field_declaration)
     (attribute)
-    (comment)
   ]? @append_end_scope
   .
   (field_declaration) @prepend_begin_scope
@@ -828,7 +809,6 @@
   [
     (field_declaration)
     (attribute)
-    (comment)
   ] @append_end_scope
   .
   "}"
@@ -842,10 +822,7 @@
 (record_expression
   (field_expression) @append_delimiter
   .
-  [
-    (comment)
-    (attribute)
-  ]*
+  (attribute)*
   .
   ";" @delete
   (#delimiter! ";")
@@ -860,7 +837,6 @@
   [
     (field_expression)
     (attribute)
-    (comment)
   ]? @append_end_scope
   .
   (field_expression) @prepend_begin_scope
@@ -870,7 +846,6 @@
   [
     (field_expression)
     (attribute)
-    (comment)
   ] @append_end_scope
   .
   "}"
@@ -1803,16 +1778,4 @@
   ":" @append_spaced_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
   .
-)
-
-; Input softlines before and after all comments. This means that the input
-; decides if a comment should have line breaks before or after. But don't put a
-; softline directly in front of commas or semicolons.
-
-(comment) @prepend_input_softline
-
-(
-  (comment) @append_input_softline
-  .
-  ["," ";"]* @do_nothing
 )

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -113,10 +113,9 @@
 ; Append line break after module include, except if it's alone in a single-lined struct
 (
   [
-    ; start equivalence class
+    ; both elements are in an equivalence class
     (include_module)
     (include_module_type)
-    ; end equivalence class
   ] @append_hardline
   .
   "end"? @do_nothing
@@ -125,10 +124,9 @@
   "struct"
   .
   [
-    ; start equivalence class
+    ; both elements are in an equivalence class
     (include_module)
     (include_module_type)
-    ; end equivalence class
   ] @append_spaced_softline
   .
   "end"
@@ -740,10 +738,9 @@
     (module_definition)
     (value_specification)
     (type_definition)
-    ; start equivalence class
+    ; the following two elements are in an equivalence class
     (include_module)
     (include_module_type)
-    ; end equivalence class
   ] @append_spaced_softline
 )
 
@@ -937,8 +934,8 @@
   ":" @append_indent_start
   (_) @append_indent_end
   .
-  ; just doing _ above doesn't work, because it matches the final named node as
-  ; well as the final non-named node, causing double indentation.
+; just doing _ above doesn't work, because it matches the final named node as
+; well as the final non-named node, causing double indentation.
 )
 
 (value_specification

--- a/topiary-queries/queries/ocaml_interface.comment.scm
+++ b/topiary-queries/queries/ocaml_interface.comment.scm
@@ -1,0 +1,1 @@
+ocaml.comment.scm

--- a/topiary-queries/queries/ocamllex.comment.scm
+++ b/topiary-queries/queries/ocamllex.comment.scm
@@ -1,0 +1,2 @@
+; Identify nodes for comment processing
+(comment) @comment

--- a/topiary-queries/queries/ocamllex.scm
+++ b/topiary-queries/queries/ocamllex.scm
@@ -14,17 +14,17 @@
   "{" @append_spaced_scoped_softline @append_indent_start
   (ocaml) @multi_line_indent_all
   "}" @prepend_spaced_scoped_softline @prepend_indent_end
-  ; This last capture name is a bit unfortunate, but it resolves an issue where
-  ; the @append_input_softline of the comment is not resolved because the \n is
-  ; after it.
+; This last capture name is a bit unfortunate, but it resolves an issue where
+; the @append_input_softline of the comment is not resolved because the \n is
+; after it.
 ) @prepend_input_softline
 
 ; Regular expression related rules
 (named_regexp
   "let" @append_space
   "=" @prepend_space @append_space
-  ; If the regexp spand multiple lines, we may want it to be indented
-  ; regexp: (_) @prepend_indent_start @append_indent_end
+; If the regexp spand multiple lines, we may want it to be indented
+; regexp: (_) @prepend_indent_start @append_indent_end
 ) @allow_blank_line_before @append_hardline
 
 ; Actual regex rules
@@ -91,7 +91,7 @@
   (#scope_id! "lexer_entry")
   ; TODO: Is this allowed to be a space? Use hardline if not
   "|" @prepend_hardline @allow_blank_line_before
-  ; @prepend_space is for NOTE[regexp]
+; @prepend_space is for NOTE[regexp]
 )
 
 (lexer_entry

--- a/topiary-queries/queries/ocamllex.scm
+++ b/topiary-queries/queries/ocamllex.scm
@@ -1,8 +1,6 @@
 ; NOTE[regexp] regexp is a unnamed node without a field name, so we typically
 ; account for places it can be instead of formatting it directly.
 
-(comment) @multi_line_indent_all @allow_blank_line_before @prepend_input_softline @append_input_softline @multi_line_indent_all
-
 (
   (#scope_id! "action")
   (action) @prepend_begin_scope @append_end_scope

--- a/topiary-queries/queries/rust.comment.scm
+++ b/topiary-queries/queries/rust.comment.scm
@@ -1,0 +1,5 @@
+; Identify nodes for comment processing
+[
+  (block_comment)
+  (line_comment)
+] @comment

--- a/topiary-queries/queries/rust.scm
+++ b/topiary-queries/queries/rust.scm
@@ -2,15 +2,12 @@
 ; not be formatted, but taken as is. We use the leaf capture name to inform the
 ; tool of this.
 [
-  (block_comment)
-  (line_comment)
   (string_literal)
 ] @leaf
 
 ; Allow blank line before
 [
   (attribute_item)
-  (block_comment)
   (call_expression)
   (enum_item)
   (enum_variant)
@@ -18,7 +15,6 @@
   (function_item)
   (impl_item)
   (let_declaration)
-  (line_comment)
   (mod_item)
   (struct_item)
   (type_item)
@@ -54,25 +50,7 @@
   ":"
 ] @append_space
 
-; Input softlines before and after all comments. This means that the input
-; decides if a comment should have line breaks before or after. A line comment
-; always ends with a line break.
-[
-  (block_comment)
-  (line_comment)
-] @prepend_input_softline
-
-; Input softline after block comments unless followed by comma or semicolon, as
-; they are always put directly after.
-(
-  (block_comment) @append_input_softline
-  .
-  ["," ";"]* @do_nothing
-)
-
-; Append line breaks. If there is a comment following, we don't add anything,
-; because the input softlines and spaces above will already have sorted out the
-; formatting.
+; Append line breaks.
 (
   [
     (attribute_item)
@@ -87,32 +65,14 @@
     (type_item)
     (use_declaration)
   ] @append_spaced_softline
-  .
-  [
-    (block_comment)
-    (line_comment)
-  ]* @do_nothing
 )
 
-(line_comment) @append_hardline
-
-(block_comment) @multi_line_indent_all
-
-; Allow line break after block comments
-(
-  (block_comment)
-  .
-  _ @prepend_input_softline
-)
-
-; Append softlines, unless followed by comments.
+; Append softlines
 (
   [
     ","
     ";"
   ] @append_spaced_softline
-  .
-  [(block_comment) (line_comment)]* @do_nothing
 )
 
 ; Prepend softlines before dots

--- a/topiary-queries/queries/toml.comment.scm
+++ b/topiary-queries/queries/toml.comment.scm
@@ -1,0 +1,2 @@
+; Identify nodes for comment processing
+(comment) @comment

--- a/topiary-queries/queries/toml.scm
+++ b/topiary-queries/queries/toml.scm
@@ -8,16 +8,12 @@
 
 ; Allow blank line before
 [
-  (comment)
   (table)
   (table_array_element)
   (pair)
 ] @allow_blank_line_before
 
 ; Append line breaks
-[
-  (comment)
-] @append_hardline
 
 (document
   (pair) @append_hardline
@@ -50,19 +46,12 @@
   "}"
 ] @prepend_space @append_space
 
-; Input softlines before all comments. This means that the input decides if a
-; comment should have line breaks in front of it.
-(comment) @prepend_input_softline
-
 ; Softlines. These become either a space or a newline, depending on whether we
 ; format their node as single-line or multi-line.
 (
   "," @append_spaced_softline
   .
-  [
-    (comment)
-    "]"
-  ]? @do_nothing
+  "]"? @do_nothing
 )
 
 ; remove trailing comma from last element of single line array
@@ -72,7 +61,7 @@
 
 ; add trailing comma if absent to last string of multiline array
 (array
-  (((string) @append_delimiter) . ","* @do_nothing . (comment)? . "]")(#delimiter! ",")
+  (((string) @append_delimiter) . ","* @do_nothing . "]")(#delimiter! ",")
   (#multi_line_only!)
 )
 

--- a/topiary-queries/queries/tree_sitter_query.comment.scm
+++ b/topiary-queries/queries/tree_sitter_query.comment.scm
@@ -1,0 +1,2 @@
+; Identify nodes for comment processing
+(comment) @comment

--- a/topiary-queries/queries/tree_sitter_query.scm
+++ b/topiary-queries/queries/tree_sitter_query.scm
@@ -7,8 +7,6 @@
   (string)
 ] @leaf
 
-(comment) @prepend_input_softline @append_hardline @allow_blank_line_before
-
 ; Elements at top-level must be alone on their line. Blank lines are allowed
 (program
   _ @allow_blank_line_before @prepend_hardline

--- a/topiary-queries/src/lib.rs
+++ b/topiary-queries/src/lib.rs
@@ -58,3 +58,58 @@ pub fn toml() -> &'static str {
 pub fn tree_sitter_query() -> &'static str {
     include_str!("../queries/tree_sitter_query.scm")
 }
+
+/// Returns the Topiary-compatible comment query file for Bash.
+#[cfg(feature = "bash")]
+pub fn bash_comment() -> &'static str {
+    include_str!("../queries/bash.comment.scm")
+}
+
+/// Returns the Topiary-compatible comment query file for CSS.
+#[cfg(feature = "css")]
+pub fn css_comment() -> &'static str {
+    include_str!("../queries/css.comment.scm")
+}
+
+/// Returns the Topiary-compatible comment query file for Nickel.
+#[cfg(feature = "nickel")]
+pub fn nickel_comment() -> &'static str {
+    include_str!("../queries/nickel.comment.scm")
+}
+
+/// Returns the Topiary-compatible comment query file for Ocaml.
+#[cfg(feature = "ocaml")]
+pub fn ocaml_comment() -> &'static str {
+    include_str!("../queries/ocaml.comment.scm")
+}
+
+/// Returns the Topiary-compatible comment query file for Ocaml Interface.
+#[cfg(feature = "ocaml_interface")]
+pub fn ocaml_interface_comment() -> &'static str {
+    include_str!("../queries/ocaml_interface.comment.scm")
+}
+
+/// Returns the Topiary-compatible comment query file for Ocamllex.
+#[cfg(feature = "ocamllex")]
+pub fn ocamllex_comment() -> &'static str {
+    include_str!("../queries/ocamllex.comment.scm")
+}
+
+/// Returns the Topiary-compatible query file for Rust.
+#[cfg(feature = "rust")]
+pub fn rust_comment() -> &'static str {
+    include_str!("../queries/rust.comment.scm")
+}
+
+/// Returns the Topiary-compatible query file for Toml.
+#[cfg(feature = "toml")]
+pub fn toml_comment() -> &'static str {
+    include_str!("../queries/toml.comment.scm")
+}
+
+/// Returns the Topiary-compatible query file for the
+/// Tree-sitter query language.
+#[cfg(feature = "tree_sitter_query")]
+pub fn tree_sitter_query_comment() -> &'static str {
+    include_str!("../queries/tree_sitter_query.comment.scm")
+}


### PR DESCRIPTION
This PR is an attempt at processing the comments separately from the rest of the code, so that formatting queries can be both resilient to the presence of random comments, and simple to write.

### Identifying comments
This is a challenge in itself:
- We can't use the same mechanism we use for leaf identification, _i.e._ a formatting directive in the query file that would look like `(block_comment) @comment`. Indeed, it would mean either running the query twice, or accounting for the presence of comments in the rest of the query file, both situations we want to avoid.
- The current implementation selects comment nodes from the CST with the following heuristics:
```node.is_extra() && node.kind().to_string().contains("comment")```. I think it should capture all types of comments for all supported languages, but I haven't checked that yet.
- Another option would be to have a separate query file for comments, one for each language, which would contain selecting and formatting directives for comments. It could also contain instructions on how to re-insert comments back in the code, once it's formatted.

### Anchoring comments
Each comment should be anchored to a non-comment node of the code. Ideally, it should be the node it's supposed to comment, but such semantics can't be deduced from the CST alone. This PR uses the following heuristics instead:
- If the comment node is alone on its line, anchor it to its next sibling in the CST. If it's the last of its siblings, anchor it to its previous sibling instead.
- If the comment node isn't alone on its line, anchor it to its previous sibling in the CST. If it's the first of its siblings, anchor it to its next sibling instead.
- I haven't thought at what it would mean for a comment node to be an only child in the CST, nor if that case can actually happen. In that case, it would probably be a safe bet to anchor it to its parent node.

### Extracting comments
`tree-sitter` grammars and queries don't offer lots of tools to edit an existing CST. The only reasonable way I've found is to use `input.replace_range()` to remove the comment's bytes from the input, then `tree.edit()` to mark a node as edited in the CST, then finally `reparse(old_tree, new_input, grammar)` to get the new CST, without comments. The query file would then be applied to this new CST.

### Re-inserting comments
This is a part I haven't had time to experiment with, but I think re-insertion should be done after processing all append/prepend directives, but before post-processing. I imagine something like this should work:
- If the anchor was before the comment, re-insert with `(anchor).(space).(comment)` (line breaks should already have been taken care of).
- If the anchor was after the comment, re-insert with `(comment).(line break).(anchor)`.

### State of the PR
- [x] Identifying comments
- [x] Anchoring comments
- [x] Extracting comments
- [x] Re-inserting comments
- [ ] Add more documentation where needed
- [ ] Update README