### PR TITLE
add `--check` flag to `topiary fmt` for CI formatting verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ This name should be decided amongst the team before the release.
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.
+- [#1217](https://github.com/topiary/topiary/pull/1217) Add `--check` flag to `topiary fmt` for CI formatting verification.
+
+### Removed
+- [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.
 
 <!--
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2340,7 +2340,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3505,7 +3505,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3562,7 +3562,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3832,6 +3832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "simple-counter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4002,7 +4011,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4311,6 +4320,7 @@ dependencies = [
  "nickel-lang-core",
  "pastey",
  "predicates",
+ "similar",
  "tabled",
  "tempfile",
  "tokio",
@@ -4910,7 +4920,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/book/src/cli/dialogue.md
+++ b/docs/book/src/cli/dialogue.md
@@ -69,9 +69,10 @@ formatting. Otherwise, the following exit codes are defined:
 | Multiple errors              |    9 |
 | Unspecified error            |   10 |
 
-Negative results with error code `1` only happen when Topiary is called
-with the `coverage` sub-command, if the input does not cover 100% of the
-query.
+Negative results with error code `1` happen when Topiary is called
+with the `coverage` sub-command (if the input does not cover 100% of the
+query), or with `format --check` (if the input is not already
+formatted).
 
 When given multiple inputs, Topiary will do its best to process them
 all, even in the presence of errors. Should _any_ errors occur, Topiary

--- a/docs/book/src/cli/usage/format.md
+++ b/docs/book/src/cli/usage/format.md
@@ -15,6 +15,9 @@ Arguments:
           defined in the Topiary configuration.
 
 Options:
+  -c, --check
+          Verify inputs are already formatted (exit non-zero with diff if not)
+
   -t, --tolerate-parsing-errors
           Consume as much as possible in the presence of parsing errors
 
@@ -73,6 +76,24 @@ some_command | topiary format --language LANGUAGE
 ```
 
 </div>
+
+## Checking formatting
+
+The `--check` flag (or `-c`) verifies that inputs are already formatted
+without modifying them. If any input differs from its formatted form,
+Topiary prints a diff to stderr and exits with code 1. This is useful
+for CI pipelines:
+
+```bash
+# Check a single file
+topiary format --check src/main.rs
+
+# Check all files in a directory
+topiary format --check src/
+
+# Check via stdin
+echo '{"foo":"bar"}' | topiary format --check --language json
+```
 
 <div class="warning">
 

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -39,6 +39,7 @@ topiary-config.workspace = true
 topiary-queries.workspace = true
 miette.workspace = true
 tabled = { workspace = true }
+similar = "3.1"
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/topiary-cli/src/check.rs
+++ b/topiary-cli/src/check.rs
@@ -1,0 +1,49 @@
+use std::io::BufReader;
+
+use topiary_core::{Language, Operation, formatter};
+
+use crate::{
+    error::{CLIError, CLIResult, TopiaryError},
+    io::{InputFile, read_input},
+};
+
+/// Run the formatter on an input and compare the result to the original.
+/// Returns `Ok(())` if the input is already formatted, or a `CheckFailed` error
+/// containing the original and formatted strings if it is not.
+pub fn check_input(
+    input: InputFile,
+    language: &Language,
+    skip_idempotence: bool,
+    tolerate_parsing_errors: bool,
+) -> CLIResult<()> {
+    let source_name = input.source().to_string();
+
+    let mut buf_input = BufReader::new(input);
+    let original = read_input(&mut buf_input)?;
+
+    let mut formatted_bytes: Vec<u8> = Vec::new();
+    formatter(
+        &mut original.as_bytes(),
+        &mut formatted_bytes,
+        language,
+        Operation::Format {
+            skip_idempotence,
+            tolerate_parsing_errors,
+        },
+    )?;
+
+    let formatted = String::from_utf8_lossy(&formatted_bytes).into_owned();
+
+    if original != formatted {
+        return Err(TopiaryError::Bin(
+            format!("{source_name} is not formatted"),
+            Some(CLIError::CheckFailed {
+                source_name,
+                original,
+                formatted,
+            }),
+        ));
+    }
+
+    Ok(())
+}

--- a/topiary-cli/src/cli.rs
+++ b/topiary-cli/src/cli.rs
@@ -122,6 +122,10 @@ pub enum Commands {
     /// Format inputs
     #[command(alias = "fmt", display_order = 1)]
     Format {
+        /// Verify inputs are already formatted (exit non-zero with diff if not)
+        #[arg(short = 'c', long)]
+        check: bool,
+
         /// Consume as much as possible in the presence of parsing errors
         #[arg(short, long)]
         tolerate_parsing_errors: bool,
@@ -182,7 +186,7 @@ pub enum Commands {
     },
 
     /// Check if an input parses to the respective Tree-sitter grammar
-    #[command(alias = "check", display_order = 6)]
+    #[command(display_order = 6)]
     CheckGrammar {
         #[command(flatten)]
         inputs: AtLeastOneInput,

--- a/topiary-cli/src/error.rs
+++ b/topiary-cli/src/error.rs
@@ -1,4 +1,6 @@
 use std::{error, fmt, io, path::PathBuf, process::ExitCode, result};
+
+use similar::TextDiff;
 use topiary_config::error::{TopiaryConfigError, TopiaryConfigFetchingError};
 use topiary_core::FormatterError;
 
@@ -24,6 +26,13 @@ pub enum CLIError {
     Multiple,
     UnsupportedLanguage(String),
 
+    /// Formatting check failed: input is not already formatted
+    CheckFailed {
+        source_name: String,
+        original: String,
+        formatted: String,
+    },
+
     /// Could not detect the input language from the `(filename, Option<extension>)`
     LanguageDetection(PathBuf, Option<String>),
 }
@@ -45,6 +54,23 @@ impl fmt::Display for TopiaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TopiaryError::Lib(error) => write!(f, "{error}"),
+            TopiaryError::Bin(
+                _,
+                Some(CLIError::CheckFailed {
+                    source_name,
+                    original,
+                    formatted,
+                }),
+            ) => {
+                let diff = TextDiff::from_lines(original, formatted);
+                write!(
+                    f,
+                    "Diff in {source_name}:\n{}",
+                    diff.unified_diff()
+                        .context_radius(3)
+                        .header("original", "formatted")
+                )
+            }
             TopiaryError::Bin(message, _) => write!(f, "{message}"),
             TopiaryError::Config(e) => write!(f, "{e}"),
         }
@@ -59,6 +85,7 @@ impl error::Error for TopiaryError {
             TopiaryError::Bin(_, Some(CLIError::Generic(error))) => error.source(),
             TopiaryError::Bin(_, Some(CLIError::Multiple)) => None,
             TopiaryError::Bin(_, Some(CLIError::UnsupportedLanguage(_))) => None,
+            TopiaryError::Bin(_, Some(CLIError::CheckFailed { .. })) => None,
             TopiaryError::Bin(_, Some(CLIError::LanguageDetection(_, _))) => None,
             TopiaryError::Bin(_, None) => None,
             TopiaryError::Config(error) => error.source(),
@@ -71,6 +98,10 @@ impl From<TopiaryError> for ExitCode {
         let exit_code = match e {
             // Things went well but Topiary needs to answer 'false' in a clean way: Exit 1
             _ if e.benign() => 1,
+
+            // Check mode detected unformatted files: Exit 1
+            // This error is not benign, but we still need to answer `false` without resulting in a typical an error
+            TopiaryError::Bin(_, Some(CLIError::CheckFailed { .. })) => 1,
 
             // Multiple errors: Exit 9
             TopiaryError::Bin(_, Some(CLIError::Multiple)) => 9,

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod check;
 mod cli;
 mod error;
 mod fs;
@@ -45,49 +46,64 @@ async fn run() -> CLIResult<()> {
     // Delegate by subcommand
     match args.command {
         Commands::Format {
+            check,
             tolerate_parsing_errors,
             skip_idempotence,
             inputs,
         } => {
             let inputs = Inputs::new(&config, &inputs);
 
-            process_inputs(inputs, move |input, language| {
-                let output = OutputFile::try_from(&input)?;
+            if check {
+                process_inputs(inputs, move |input, language| {
+                    log::info!(
+                        "Checking {}, as {} using {}",
+                        input.source(),
+                        input.language().name,
+                        input.query(),
+                    );
 
-                log::info!(
-                    "Formatting {}, as {} using {}, to {}",
-                    input.source(),
-                    input.language().name,
-                    input.query(),
-                    output
-                );
+                    check::check_input(input, &language, skip_idempotence, tolerate_parsing_errors)
+                })
+                .await?;
+            } else {
+                process_inputs(inputs, move |input, language| {
+                    let output = OutputFile::try_from(&input)?;
 
-                let mut buf_output = BufWriter::new(output);
+                    log::info!(
+                        "Formatting {}, as {} using {}, to {}",
+                        input.source(),
+                        input.language().name,
+                        input.query(),
+                        output
+                    );
 
-                {
-                    // NOTE This newly opened scope is important! `buf_input` takes
-                    // ownership of `input`, which -- upon reading -- contains an
-                    // open file handle. We need to close this file, by dropping
-                    // `buf_input`, before we attempt to persist our output.
-                    // Otherwise, we get an exclusive lock problem on Windows.
-                    let mut buf_input = BufReader::new(input);
+                    let mut buf_output = BufWriter::new(output);
 
-                    formatter(
-                        &mut buf_input,
-                        &mut buf_output,
-                        &language,
-                        Operation::Format {
-                            skip_idempotence,
-                            tolerate_parsing_errors,
-                        },
-                    )?;
-                }
+                    {
+                        // NOTE This newly opened scope is important! `buf_input` takes
+                        // ownership of `input`, which -- upon reading -- contains an
+                        // open file handle. We need to close this file, by dropping
+                        // `buf_input`, before we attempt to persist our output.
+                        // Otherwise, we get an exclusive lock problem on Windows.
+                        let mut buf_input = BufReader::new(input);
 
-                buf_output.into_inner()?.persist()?;
+                        formatter(
+                            &mut buf_input,
+                            &mut buf_output,
+                            &language,
+                            Operation::Format {
+                                skip_idempotence,
+                                tolerate_parsing_errors,
+                            },
+                        )?;
+                    }
 
-                CLIResult::Ok(())
-            })
-            .await?;
+                    buf_output.into_inner()?.persist()?;
+
+                    CLIResult::Ok(())
+                })
+                .await?;
+            }
         }
 
         Commands::CheckGrammar { inputs } => {

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -46,64 +46,69 @@ async fn run() -> CLIResult<()> {
     // Delegate by subcommand
     match args.command {
         Commands::Format {
-            check,
+            check: true,
             tolerate_parsing_errors,
             skip_idempotence,
             inputs,
         } => {
             let inputs = Inputs::new(&config, &inputs);
+            process_inputs(inputs, move |input, language| {
+                log::info!(
+                    "Checking {}, as {} using {}",
+                    input.source(),
+                    input.language().name,
+                    input.query(),
+                );
 
-            if check {
-                process_inputs(inputs, move |input, language| {
-                    log::info!(
-                        "Checking {}, as {} using {}",
-                        input.source(),
-                        input.language().name,
-                        input.query(),
-                    );
+                check::check_input(input, &language, skip_idempotence, tolerate_parsing_errors)
+            })
+            .await?;
+        }
+        Commands::Format {
+            tolerate_parsing_errors,
+            skip_idempotence,
+            inputs,
+            ..
+        } => {
+            let inputs = Inputs::new(&config, &inputs);
 
-                    check::check_input(input, &language, skip_idempotence, tolerate_parsing_errors)
-                })
-                .await?;
-            } else {
-                process_inputs(inputs, move |input, language| {
-                    let output = OutputFile::try_from(&input)?;
+            process_inputs(inputs, move |input, language| {
+                let output = OutputFile::try_from(&input)?;
 
-                    log::info!(
-                        "Formatting {}, as {} using {}, to {}",
-                        input.source(),
-                        input.language().name,
-                        input.query(),
-                        output
-                    );
+                log::info!(
+                    "Formatting {}, as {} using {}, to {}",
+                    input.source(),
+                    input.language().name,
+                    input.query(),
+                    output
+                );
 
-                    let mut buf_output = BufWriter::new(output);
+                let mut buf_output = BufWriter::new(output);
 
-                    {
-                        // NOTE This newly opened scope is important! `buf_input` takes
-                        // ownership of `input`, which -- upon reading -- contains an
-                        // open file handle. We need to close this file, by dropping
-                        // `buf_input`, before we attempt to persist our output.
-                        // Otherwise, we get an exclusive lock problem on Windows.
-                        let mut buf_input = BufReader::new(input);
+                {
+                    // NOTE This newly opened scope is important! `buf_input` takes
+                    // ownership of `input`, which -- upon reading -- contains an
+                    // open file handle. We need to close this file, by dropping
+                    // `buf_input`, before we attempt to persist our output.
+                    // Otherwise, we get an exclusive lock problem on Windows.
+                    let mut buf_input = BufReader::new(input);
 
-                        formatter(
-                            &mut buf_input,
-                            &mut buf_output,
-                            &language,
-                            Operation::Format {
-                                skip_idempotence,
-                                tolerate_parsing_errors,
-                            },
-                        )?;
-                    }
+                    formatter(
+                        &mut buf_input,
+                        &mut buf_output,
+                        &language,
+                        Operation::Format {
+                            skip_idempotence,
+                            tolerate_parsing_errors,
+                        },
+                    )?;
+                }
 
-                    buf_output.into_inner()?.persist()?;
+                buf_output.into_inner()?.persist()?;
 
-                    CLIResult::Ok(())
-                })
-                .await?;
-            }
+                CLIResult::Ok(())
+            })
+            .await?;
         }
 
         Commands::CheckGrammar { inputs } => {

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -196,6 +196,78 @@ fn test_fmt_dir() {
 
 #[test]
 #[cfg(feature = "json")]
+fn test_check_stdin_clean() {
+    initialize();
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
+        .arg("fmt")
+        .arg("--check")
+        .arg("--language")
+        .arg("json")
+        .write_stdin(JSON_EXPECTED)
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "json")]
+fn test_check_stdin_dirty() {
+    initialize();
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
+        .arg("fmt")
+        .arg("--check")
+        .arg("--language")
+        .arg("json")
+        .write_stdin(JSON_INPUT)
+        .assert()
+        .failure();
+}
+
+#[test]
+#[cfg(feature = "json")]
+fn test_check_file_dirty_no_modify() {
+    initialize();
+    let json = State::new(JSON_INPUT, "json");
+    let original_content = json.read();
+
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
+        .arg("fmt")
+        .arg("--check")
+        .arg(json.path())
+        .assert()
+        .failure();
+
+    // The file must NOT be modified by --check
+    assert_eq!(json.read(), original_content);
+}
+
+#[test]
+#[cfg(feature = "json")]
+fn test_check_file_clean() {
+    initialize();
+    let json = State::new(JSON_EXPECTED, "json");
+
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
+        .arg("fmt")
+        .arg("--check")
+        .arg(json.path())
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "json")]
 fn test_fmt_invalid() {
     initialize();
     let mut topiary = cargo_bin_cmd!("topiary");

--- a/topiary-cli/tests/sample-tester.rs
+++ b/topiary-cli/tests/sample-tester.rs
@@ -133,6 +133,58 @@ mod test_fmt {
 }
 
 #[cfg(test)]
+mod test_check {
+    use super::*;
+
+    #[allow(unused)]
+    fn check_input(lang: &str) {
+        let file = format!("{lang}.{}", get_file_extension(lang));
+        let input = PathBuf::from(format!("tests/samples/input/{file}"));
+        let expected = PathBuf::from(format!("tests/samples/expected/{file}"));
+
+        // Make sure our test makes sense
+        assert!(input.exists() && expected.exists());
+
+        // The input file is unformatted, so --check should fail
+        let mut topiary = cargo_bin_cmd!("topiary");
+        topiary
+            .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
+            .arg("fmt")
+            .arg("--check")
+            .arg(&input)
+            .assert()
+            .failure();
+
+        // The expected file is already formatted, so --check should succeed
+        let mut topiary = cargo_bin_cmd!("topiary");
+        topiary
+            .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
+            .arg("fmt")
+            .arg("--check")
+            .arg(&expected)
+            .assert()
+            .success();
+    }
+
+    lang_test!(
+        "bash",
+        "css",
+        "json",
+        "nickel",
+        "ocaml",
+        "ocaml_interface",
+        "ocamllex",
+        "openscad",
+        "rust",
+        "sdml",
+        "toml",
+        "tree_sitter_query",
+        "wit",
+        check_input
+    );
+}
+
+#[cfg(test)]
 mod test_coverage {
     use super::*;
 


### PR DESCRIPTION
Allow `topiary fmt --check` to verify files are already formatted without modifying them. Exits 0 if formatted, exits 1 with a diff if not. 
BREAKING CHANGE: The `check` alias was removed to avoid confusion with `fmt --check`.

# add `--check` flag

Resolves #977 

## Description
Allow `topiary fmt --check` to verify files are already formatted
without modifying them. Exits 0 if formatted, exits 1 with a diff
if not.

BREAKING CHANGE: The `check` alias was removed to avoid confusion with
`fmt --check`.


## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [ ] Updated regression tests
