### PR TITLE
feat(@append_empty_input_softline): to complete the set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ This name should be decided amongst the team before the release.
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.
 - [#1217](https://github.com/topiary/topiary/pull/1217) Add `--check` flag to `topiary fmt` for CI formatting verification.
+- [#1227](https://github.com/topiary/topiary/pull/1227) Add `@append_empty_input_softline` and `@prepend_empty_input_softline` captures, thanks to @BirdeeHub
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/docs/book/src/reference/capture-names/vertical-spacing.md
+++ b/docs/book/src/reference/capture-names/vertical-spacing.md
@@ -25,6 +25,7 @@ See:
 - [`@append_empty_softline` / `@prepend_empty_softline`](#append_empty_softline--prepend_empty_softline)
 - [`@append_spaced_softline` / `@prepend_spaced_softline`](#append_spaced_softline--prepend_spaced_softline)
 - [`@append_input_softline` / `@prepend_input_softline`](#append_input_softline--prepend_input_softline)
+- [`@append_empty_input_softline` / `@prepend_empty_input_softline`](#append_empty_input_softline--prepend_empty_input_softline)
 
 <div class="warning">
 
@@ -40,16 +41,17 @@ Windows).
 
 ### Understanding the different line break captures
 
-| Type            | Single-Line Context | Multi-Line Context |
-| :-------------- | :------------------ | :----------------- |
-| Hardline        | Line break          | Line break         |
-| Empty Softline  | Nothing             | Line break         |
-| Spaced Softline | Space               | Line break         |
-| Input Softline  | Space               | Input-Dependent    |
+| Type                 | Single-Line Context | Multi-Line Context |
+| :------------------- | :------------------ | :----------------- |
+| Hardline             | Line break          | Line break         |
+| Empty Softline       | Nothing             | Line break         |
+| Spaced Softline      | Space               | Line break         |
+| Input Softline       | Space               | Input-Dependent    |
+| Empty Input Softline | Nothing             | Input-Dependent    |
 
 "Input softlines" are rendered as line breaks whenever the targeted node
 follows/precedes (for append/prepend, respectively) a line break in the
-input. Otherwise, they are rendered as spaces.
+input. Otherwise, they are rendered as nothing or spaces, depending on the capture name.
 
 #### Example
 
@@ -229,6 +231,34 @@ In the single-line context, a space is added before each delimiter; in
 the multi-line context, a line break is added before the delimiters that
 had a line break before them in the original input.
 
+##### `@append_empty_input_softline`
+
+```json
+{
+  "single-line":
+  [1,2,3,4],
+  "multi-line":
+  [1,2,
+  3,4]
+}
+```
+
+The same as `@append_input_softline` except it does not insert a space.
+
+##### `@prepend_empty_input_softline`
+
+```json
+{
+  "single-line":
+  [1,2,3,4],
+  "multi-line":
+  [1,2,3
+  ,4]
+}
+```
+
+The same as `@prepend_input_softline` except it does not insert a space.
+
 ### Testing context with predicates
 
 Sometimes, similarly to what happens with softlines, we want a query to
@@ -383,6 +413,14 @@ input document, otherwise it is a space.
   [ "," ";" ]* @do_nothing
 )
 ```
+
+## `@append_empty_input_softline` / `@prepend_empty_input_softline`
+
+This option is the empty counterpart to [`@append_input_softline` / `@prepend_input_softline`](#append_input_softline--prepend_input_softline)
+
+This option has the same relation to [`@append_input_softline` / `@prepend_input_softline`](#append_input_softline--prepend_input_softline)
+as [`@append_empty_softline` / `@prepend_empty_softline`](#append_empty_softline--prepend_empty_softline)
+has to [`@append_spaced_softline` / `@prepend_spaced_softline`](#append_spaced_softline--prepend_spaced_softline)
 
 ## `@keep_whitespace`
 

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -242,6 +242,15 @@ impl AtomCollection {
 
                 self.append(space, node, predicates);
             }
+            "append_empty_input_softline" => {
+                let space = if self.line_break_after.contains(&node.id()) {
+                    Atom::Hardline
+                } else {
+                    Atom::Empty
+                };
+
+                self.append(space, node, predicates);
+            }
             "append_space" => self.append(Atom::Space, node, predicates),
             "append_antispace" => self.append(Atom::Antispace, node, predicates),
             "append_spaced_softline" => {
@@ -263,6 +272,15 @@ impl AtomCollection {
                     Atom::Hardline
                 } else {
                     Atom::Space
+                };
+
+                self.prepend(space, node, predicates);
+            }
+            "prepend_empty_input_softline" => {
+                let space = if self.line_break_before.contains(&node.id()) {
+                    Atom::Hardline
+                } else {
+                    Atom::Empty
                 };
 
                 self.prepend(space, node, predicates);


### PR DESCRIPTION
# @append_empty_input_softline: to complete the set

## Description

It just should be there. Before I even used the program, I wanted to know why it wasn't there.

more relevant context which isn't necessary to read for this PR because it obviously should be there:

https://github.com/topiary/topiary/discussions/1221#discussioncomment-16708029

I am using this in my config and it works exactly as expected.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date