### PR TITLE
fix(core): should `multi_line_indent_all` maintain alignment with the leaf start indentation instead of the leaf start column?

### DIFF
--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -578,6 +578,8 @@ impl AtomCollection {
                 content: String::from(node.utf8_text(source)?),
                 id,
                 original_position: node.start_position().into(),
+                original_indentation:
+                    count_indenting_characters(str::from_utf8(&source[..node.start_byte() as usize])?) as u32,
                 single_line_no_indent: false,
                 multi_line_indent_all: false,
                 keep_whitespace: false,
@@ -1119,6 +1121,11 @@ pub struct QueryPredicates {
     pub multi_line_scope_only: Option<String>,
     /// A query name, for debugging/logging purposes
     pub query_name: Option<String>,
+}
+
+pub fn count_indenting_characters(s: &str) -> usize {
+    let last_line = &s[s.rfind('\n').map(|i| i + 1).unwrap_or(0)..];
+    last_line[..last_line.find(|c: char| !c.is_whitespace()).unwrap_or(last_line.len())].chars().count()
 }
 
 /// Collapses spaces before antispace atoms in a vector of atoms.

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -73,6 +73,7 @@ pub enum Atom {
         content: String,
         id: usize,
         original_position: Position,
+        original_indentation: u32,
         // marks the leaf to be printed on a single line, with no indentation
         single_line_no_indent: bool,
         // if the leaf is multi-line, each line will be indented, not just the first

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -48,7 +48,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
 
             Atom::Leaf {
                 content,
-                original_position,
+                original_indentation,
                 single_line_no_indent,
                 multi_line_indent_all,
                 keep_whitespace,
@@ -67,12 +67,9 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                 };
 
                 let mut content = if *multi_line_indent_all {
-                    let cursor = current_column(&buffer) as i32;
+                    let cursor = crate::atom_collection::count_indenting_characters(&buffer) as i32;
 
-                    // original_position is 1-based
-                    let original_column = original_position.column as i32 - 1;
-
-                    let indenting = cursor - original_column;
+                    let indenting = cursor - *original_indentation as i32;
 
                     // The following assumes spaces are used for indenting
                     match indenting {
@@ -110,10 +107,6 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
     }
 
     Ok(buffer)
-}
-
-fn current_column(s: &str) -> usize {
-    s.chars().rev().take_while(|c| *c != '\n').count()
 }
 
 fn add_spaces_after_newlines(s: &str, n: i32) -> String {


### PR DESCRIPTION
# should `multi_line_indent_all` maintain alignment of subsequent lines with the *indentation* of the leaf start instead of the *column* of the leaf start?

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #1225

## Description

[PR Description]

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] tests
- [ ] get rid of all those numeric casts
- [ ] document `original_indentation`
- [ ] document `count_indenting_characters`
- [ ] `CHANGELOG.md` updated
- [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] Updated regression tests
