### PR TITLE
OCamllex/OCaml language injections!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This name should be decided amongst the team before the release.
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.
 - [#1217](https://github.com/topiary/topiary/pull/1217) Add `--check` flag to `topiary fmt` for CI formatting verification.
 - [#1227](https://github.com/topiary/topiary/pull/1227) Add `@append_empty_input_softline` and `@prepend_empty_input_softline` captures, thanks to @BirdeeHub
+- [#1244](https://github.com/topiary/topiary/pull/1244) Add language injection support for injection languages known at query writing.
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "topiary-config",
  "topiary-queries",
  "topiary-tree-sitter-facade",
  "topiary-web-tree-sitter-sys",

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -41,6 +41,7 @@
 
 - [Language support](reference/language-support.md)
 - [Formatting pipeline](reference/formatting-pipeline.md)
+- [Language injections](reference/language-injections.md)
 - [Capture names](reference/capture-names/index.md)
   - [General advice](reference/capture-names/general.md)
   - [Horizontal spacing](reference/capture-names/horizontal-spacing.md)

--- a/docs/book/src/guides/adding-a-new-language.md
+++ b/docs/book/src/guides/adding-a-new-language.md
@@ -212,7 +212,7 @@ inner language:
 )
 ```
 
-The host language's `formatting.scm` still controls layout around the
+The host language's `formatting.scm` retains control of the layout around the
 captured node. The captured content is formatted independently by the
 inner language and then rendered as a host leaf. See
 [Language injections](../reference/language-injections.md) for the

--- a/docs/book/src/guides/adding-a-new-language.md
+++ b/docs/book/src/guides/adding-a-new-language.md
@@ -193,6 +193,31 @@ fn to_query<T>(name: T) -> CLIResult<QuerySource>
 This will allow your query file to by considered as the default fallback
 query, when no other file can be found at runtime for your language.
 
+## Optional: add language injections
+
+If the new language embeds source code from another Topiary language,
+add an `injections.scm` file next to `formatting.scm`:
+
+```sh
+touch topiary-queries/queries/clang/injections.scm
+```
+
+An injection query captures host syntax that should be formatted by the
+inner language:
+
+```scheme
+(
+  (embedded_code) @injection.content
+  (#injection_language! "inner_language")
+)
+```
+
+The host language's `formatting.scm` still controls layout around the
+captured node. The captured content is formatted independently by the
+inner language and then rendered as a host leaf. See
+[Language injections](../reference/language-injections.md) for the
+full behaviour and limitations.
+
 ## Iterate
 
 Once the above steps have been completed, Topiary will be able to use

--- a/docs/book/src/reference/formatting-pipeline.md
+++ b/docs/book/src/reference/formatting-pipeline.md
@@ -11,6 +11,12 @@ list of atomic units -- formatting directives, defined by the matching
 capture names, and leaf node content (see also [`@leaf`](capture-names/general.md#leaf))
 -- along with the necessary metadata to drive the process.
 
+If the host language defines [language injections](language-injections.md),
+Topiary first discovers the injected spans and treats those host nodes as
+forced leaves during query matching. The captured leaf content is
+rewritten with the inner language's formatted output before atom
+post-processing and pretty printing continue.
+
 ## Atom processing
 
 The list of atoms from the first step are then processed into a
@@ -36,6 +42,10 @@ renders each atom into a stream of text output. For example, an
 atoms immediately following a hardline will now be prefixed with the
 appropriate indent string, until the respective "indentation end" atom
 is reached.
+
+Injected leaves are rendered like any other leaf. This means the host
+formatter controls indentation around the injected span, while the inner
+formatter controls the text inside the span.
 
 ## Vertical whitespace trimming
 

--- a/docs/book/src/reference/language-injections.md
+++ b/docs/book/src/reference/language-injections.md
@@ -65,9 +65,11 @@ There is no host reparse after injected text is rewritten.
 
 ## Failure behaviour
 
-Injected formatting is best-effort. If an injected span cannot be
-formatted, Topiary logs a warning and preserves the original injected
-source text. The host formatter continues.
+Injected formatting is all-or-nothing. If an injection query matches,
+Topiary must resolve the injected language and format the captured span
+successfully. If the injected language cannot be resolved, its grammar
+or query files cannot be loaded, or the captured span cannot be
+formatted, formatting fails.
 
 Idempotence is still checked at the outer formatting level by default.
 Injected spans are formatted again during that second pass, so unstable
@@ -81,9 +83,9 @@ are cached by the existing language definition cache, so formatting many
 spans of the same injected language does not recompile the grammar or
 reload the same queries for every span.
 
-If the CLI cannot resolve the injected language at runtime, the span is
-preserved with a warning. This can happen when a language is missing
-from the runtime configuration or its query files cannot be found.
+If the CLI cannot resolve the injected language at runtime, formatting
+fails. This can happen when a language is missing from the runtime
+configuration or its query files cannot be found.
 
 ## Limitations
 

--- a/docs/book/src/reference/language-injections.md
+++ b/docs/book/src/reference/language-injections.md
@@ -1,0 +1,106 @@
+# Language injections
+
+Language injections let a host language delegate part of its input to
+another Topiary language. This is useful for languages that embed code
+from another language in a syntactically distinct region. For example,
+OCamllex embeds OCaml code in `(ocaml)` nodes, and Topiary can format
+that inner OCaml with the OCaml formatter while the OCamllex formatter
+continues to control the surrounding lexer syntax.
+
+Injection declarations live in an `injections.scm` file next to a
+language's `formatting.scm` file:
+
+```text
+topiary-queries/queries/<language>/formatting.scm
+topiary-queries/queries/<language>/injections.scm
+```
+
+The formatting query still describes host-language layout. The
+injection query only describes which host syntax nodes should be
+formatted by another language.
+
+## Query schema
+
+The initial injection schema supports a captured content node and a
+static injected language name:
+
+```scheme
+(
+  (ocaml) @injection.content
+  (#injection_language! "ocaml")
+)
+```
+
+The `@injection.content` capture marks the host node whose source text
+will be formatted by the injected language. The
+`#injection_language!` predicate declares the Topiary language
+identifier to use for that captured content.
+
+Patterns without `#injection_language!` are skipped with a warning.
+Patterns without `@injection.content` do not inject anything.
+
+Dynamic language selection, such as taking the language name from a
+Markdown code fence, is not supported yet. It is future work for
+broader multi-language document support.
+
+## Formatting model
+
+Topiary parses the host input once. If the host language has an
+`injections.scm` file, Topiary runs that query against the host tree and
+collects the captured spans. Those captured nodes are then treated as
+host leaves while the normal host formatting query is applied.
+
+After host atomisation, each injected span is formatted independently
+with its resolved inner language. The resulting text replaces the
+corresponding host leaf before normal atom post-processing and pretty
+printing continue.
+
+Inner formatters produce text from column zero. The host renderer is
+still responsible for applying indentation at the point where the
+injected leaf is rendered. This works well when the host grammar has a
+natural boundary around the injected code, such as OCamllex action
+blocks.
+
+There is no host reparse after injected text is rewritten.
+
+## Failure behaviour
+
+Injected formatting is best-effort. If an injected span cannot be
+formatted, Topiary logs a warning and preserves the original injected
+source text. The host formatter continues.
+
+Idempotence is still checked at the outer formatting level by default.
+Injected spans are formatted again during that second pass, so unstable
+injected formatting can still make the top-level idempotence check fail.
+
+## CLI behaviour
+
+The CLI resolves injected language names through the normal language
+configuration and query discovery paths. Compiled language definitions
+are cached by the existing language definition cache, so formatting many
+spans of the same injected language does not recompile the grammar or
+reload the same queries for every span.
+
+If the CLI cannot resolve the injected language at runtime, the span is
+preserved with a warning. This can happen when a language is missing
+from the runtime configuration or its query files cannot be found.
+
+## Limitations
+
+Injected spans are formatted independently. Current injection formatting
+cannot express layout decisions that need to measure or choose between
+softline layouts across the host/injected boundary.
+
+The model is also stateless. The injected language is determined by the
+injection query match itself, not by earlier host-language context. For
+example, a host syntax where one declaration changes the language of a
+later heredoc is outside the current model.
+
+The injection query should not produce overlapping or nested
+`@injection.content` captures. If multiple patterns match the same
+region of code, Topiary will attempt to format each one. However,
+because an injected span is treated as a forced leaf in the host
+language, any nested captures will fail to find their corresponding leaf
+node during the rewrite phase, resulting in a formatting error. Query
+authors should ensure that injection patterns are mutually exclusive for
+any given span of text.

--- a/examples/client-app/src/main.rs
+++ b/examples/client-app/src/main.rs
@@ -28,6 +28,7 @@ async fn main() {
         query: TopiaryQuery::new(&grammar, query).unwrap(),
         grammar,
         indent: None,
+        injection_query: None,
     };
 
     // Format the input JSON using the language configuration
@@ -39,6 +40,7 @@ async fn main() {
             skip_idempotence: false,
             tolerate_parsing_errors: false,
         },
+        None,
     )
     .unwrap();
 

--- a/examples/client-app/src/main.rs
+++ b/examples/client-app/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     // Create Language struct
     let language: Language = Language {
         name: "json".to_owned(),
-        query: TopiaryQuery::new(&grammar, query).unwrap(),
+        formatting_query: TopiaryQuery::new(&grammar, query).unwrap(),
         grammar,
         indent: None,
         injection_query: None,

--- a/nix/packages/topiary.nix
+++ b/nix/packages/topiary.nix
@@ -50,6 +50,10 @@ let
     ];
   };
 
+  prepareTopiaryDefaultConfiguration = ''
+    cp ${prefetchLanguagesNickelFile ../../topiary-config/languages.ncl} topiary-config/languages.ncl
+  '';
+
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
   clippy = craneLib.cargoClippy (
@@ -74,6 +78,8 @@ let
     // {
       inherit cargoArtifacts;
       cargoTestCommand = "cargo bench --profile release";
+      preConfigurePhases = [ "prepareTopiaryDefaultConfiguration" ];
+      inherit prepareTopiaryDefaultConfiguration;
     }
   );
 
@@ -92,6 +98,8 @@ let
       inherit cargoArtifacts;
       pname = "topiary-core";
       cargoExtraArgs = "-p topiary-core";
+      preConfigurePhases = [ "prepareTopiaryDefaultConfiguration" ];
+      inherit prepareTopiaryDefaultConfiguration;
     }
   );
 
@@ -108,10 +116,7 @@ let
         cargoTestExtraArgs = "--no-default-features";
 
         preConfigurePhases = optional prefetchGrammars "prepareTopiaryDefaultConfiguration";
-
-        prepareTopiaryDefaultConfiguration = optional prefetchGrammars (
-          "cp ${prefetchLanguagesNickelFile ../../topiary-config/languages.ncl} topiary-config/languages.ncl"
-        );
+        inherit prepareTopiaryDefaultConfiguration;
 
         postInstall = ''
           mkdir -p $out/share/queries

--- a/topiary-cli/src/check.rs
+++ b/topiary-cli/src/check.rs
@@ -1,6 +1,6 @@
-use std::{io::BufReader, sync::Arc};
+use std::io::BufReader;
 
-use topiary_core::{Language, Operation, formatter};
+use topiary_core::{Language, LanguageResolver, Operation, formatter};
 
 use crate::{
     error::{CLIError, CLIResult, TopiaryError},
@@ -15,7 +15,7 @@ pub fn check_input(
     language: &Language,
     skip_idempotence: bool,
     tolerate_parsing_errors: bool,
-    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
+    resolve: Option<&LanguageResolver<'_>>,
 ) -> CLIResult<()> {
     let source_name = input.source().to_string();
 

--- a/topiary-cli/src/check.rs
+++ b/topiary-cli/src/check.rs
@@ -1,4 +1,4 @@
-use std::io::BufReader;
+use std::{io::BufReader, sync::Arc};
 
 use topiary_core::{Language, Operation, formatter};
 
@@ -15,7 +15,7 @@ pub fn check_input(
     language: &Language,
     skip_idempotence: bool,
     tolerate_parsing_errors: bool,
-    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
 ) -> CLIResult<()> {
     let source_name = input.source().to_string();
 

--- a/topiary-cli/src/check.rs
+++ b/topiary-cli/src/check.rs
@@ -15,6 +15,7 @@ pub fn check_input(
     language: &Language,
     skip_idempotence: bool,
     tolerate_parsing_errors: bool,
+    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
 ) -> CLIResult<()> {
     let source_name = input.source().to_string();
 
@@ -30,6 +31,7 @@ pub fn check_input(
             skip_idempotence,
             tolerate_parsing_errors,
         },
+        resolve,
     )?;
 
     let formatted = String::from_utf8_lossy(&formatted_bytes).into_owned();

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -188,6 +188,7 @@ impl InputFile<'_> {
             query,
             grammar,
             indent: self.language().indent(),
+            injection_query: None,
         })
     }
 
@@ -228,6 +229,7 @@ pub(crate) async fn to_language_from_config<T: AsRef<str>>(
         query,
         grammar,
         indent: config_language.indent(),
+        injection_query: None,
     })
 }
 
@@ -486,6 +488,7 @@ pub(crate) async fn format_config(
             skip_idempotence: true,
             tolerate_parsing_errors: false,
         },
+        None,
     )?;
 
     Ok(())

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -268,16 +268,23 @@ pub(crate) async fn to_language_from_config<T: AsRef<str>>(
     let grammar = config_language.grammar()?;
     let query_source = to_query_from_language(config_language)?;
     let query_content = query_source.get_content().await?;
-    let query = TopiaryQuery::new(&grammar, &query_content)
+    let formatting_query = TopiaryQuery::new(&grammar, &query_content)
         .attach_filepath(query_source.filepath())
         .context(FormatterError::Parsing)?;
+    let injection_query = match to_injection_query_from_language(config_language) {
+        Some(source) => {
+            let contents = source.get_content().await?;
+            Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
+        }
+        None => None,
+    };
 
     Ok(Language {
         name: name.as_ref().to_string(),
-        formatting_query: query,
+        formatting_query,
+        injection_query,
         grammar,
         indent: config_language.indent(),
-        injection_query: None,
     })
 }
 

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -1,11 +1,10 @@
 use std::{
-    collections::HashMap,
     ffi::OsString,
     fmt::{self, Display},
     fs::File,
     io::{self, BufWriter, Read, Result, Seek, Write},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use nickel_lang_core::eval::value::NickelValue;
@@ -79,32 +78,6 @@ impl QuerySource {
             Self::BuiltIn(contents) => contents.to_owned(),
         };
         Ok(contents)
-    }
-}
-
-pub(crate) struct LanguageResolver {
-    config: Configuration,
-    cache: Mutex<HashMap<String, &'static Language>>,
-}
-
-impl LanguageResolver {
-    pub(crate) fn new(config: Configuration) -> Self {
-        Self {
-            config,
-            cache: Mutex::new(HashMap::new()),
-        }
-    }
-
-    pub(crate) fn resolve(&self, name: &str) -> Option<&'static Language> {
-        if let Some(language) = self.cache.lock().ok()?.get(name).copied() {
-            return Some(language);
-        }
-
-        let language = to_language_from_config_sync(&self.config, name).ok()?;
-        let language: &'static Language = Box::leak(Box::new(language));
-        self.cache.lock().ok()?.insert(name.to_owned(), language);
-
-        Some(language)
     }
 }
 
@@ -212,14 +185,14 @@ pub struct InputFile<'cfg> {
 }
 
 impl InputFile<'_> {
-    /// Convert our `InputFile` into language definition values that Topiary can consume
+    /// Convert our `InputFile` into a language definition values with blocking I/O.
     #[allow(clippy::result_large_err)]
-    pub async fn to_language(&self) -> CLIResult<Language> {
+    pub fn to_language_sync(&self) -> CLIResult<Language> {
         let grammar = self.language().grammar()?;
-        let query_contents = self.formatting_query.get_content().await?;
+        let query_contents = self.formatting_query.get_content_sync()?;
         let injection_query = match &self.injection_query {
             Some(source) => {
-                let contents = source.get_content().await?;
+                let contents = source.get_content_sync()?;
                 Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
             }
             None => None,
@@ -255,6 +228,11 @@ impl InputFile<'_> {
     pub fn formatting_query(&self) -> &QuerySource {
         &self.formatting_query
     }
+
+    /// Expose optional injection query path for input
+    pub fn injection_query(&self) -> Option<&QuerySource> {
+        self.injection_query.as_ref()
+    }
 }
 
 pub(crate) async fn to_language_from_config<T: AsRef<str>>(
@@ -285,7 +263,7 @@ pub(crate) async fn to_language_from_config<T: AsRef<str>>(
     })
 }
 
-fn to_language_from_config_sync<T: AsRef<str> + fmt::Display>(
+pub(crate) fn to_language_from_config_sync<T: AsRef<str> + fmt::Display>(
     config: &Configuration,
     name: T,
 ) -> CLIResult<Language> {
@@ -388,7 +366,9 @@ impl<'cfg, 'i> Inputs<'cfg> {
 }
 
 #[allow(clippy::result_large_err)]
-fn to_query_from_language(language: &topiary_config::language::Language) -> CLIResult<QuerySource> {
+pub(crate) fn to_query_from_language(
+    language: &topiary_config::language::Language,
+) -> CLIResult<QuerySource> {
     let query: QuerySource = match language.find_query_file() {
         Ok(p) => p.into(),
         // For some reason, Topiary could not find any
@@ -405,7 +385,7 @@ fn to_query_from_language(language: &topiary_config::language::Language) -> CLIR
     Ok(query)
 }
 
-fn to_injection_query_from_language(
+pub(crate) fn to_injection_query_from_language(
     language: &topiary_config::language::Language,
 ) -> Option<QuerySource> {
     language
@@ -599,24 +579,34 @@ pub(crate) async fn format_config(
 }
 
 // meant to be used in scenarios where multiple inputs are possible
-pub(crate) async fn process_inputs<F>(inputs: Inputs<'_>, process_fn: F) -> CLIResult<()>
+pub(crate) async fn process_inputs<F>(
+    inputs: Inputs<'_>,
+    process_fn: F,
+    cache: Arc<LanguageDefinitionCache>,
+) -> CLIResult<()>
 where
-    F: Fn(InputFile, Arc<Language>) -> CLIResult<()> + Send + Sync + 'static,
+    F: Fn(InputFile, Arc<Language>, Arc<LanguageDefinitionCache>) -> CLIResult<()>
+        + Send
+        + Sync
+        + 'static,
 {
-    let cache = LanguageDefinitionCache::new();
     let (_, mut results) = async_scoped::TokioScope::scope_and_block(|scope| {
         for input in inputs {
-            scope.spawn(async {
+            let cache = cache.clone();
+            let process_fn = &process_fn;
+            scope.spawn(async move {
                 // This happens when the input resolver cannot establish an input
                 // source, language or query file.
                 let input = input?;
                 let location = input.source().location();
-                let language = cache.fetch(&input).await?;
-                process_fn(input, language).map_err(|e| {
-                    if let TopiaryError::Lib(report) = e {
-                        return report.attach_filepath(location.to_path()).into();
-                    }
-                    e
+                tokio::task::block_in_place(|| {
+                    let language = cache.fetch_input(&input)?;
+                    process_fn(input, language, cache).map_err(|e| {
+                        if let TopiaryError::Lib(report) = e {
+                            return report.attach_filepath(location.to_path()).into();
+                        }
+                        e
+                    })
                 })
             });
         }

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -1,10 +1,11 @@
 use std::{
+    collections::HashMap,
     ffi::OsString,
     fmt::{self, Display},
     fs::File,
     io::{self, BufWriter, Read, Result, Seek, Write},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use nickel_lang_core::eval::value::NickelValue;
@@ -70,6 +71,43 @@ impl QuerySource {
             Self::BuiltIn(contents) => contents.to_owned(),
         };
         Ok(contents)
+    }
+
+    fn get_content_sync(&self) -> CLIResult<String> {
+        let contents = match self {
+            Self::Path(query) => std::fs::read_to_string(query)?,
+            Self::BuiltIn(contents) => contents.to_owned(),
+        };
+        Ok(contents)
+    }
+}
+
+pub(crate) struct LanguageResolver {
+    config: Configuration,
+    cache: Mutex<HashMap<String, &'static Language>>,
+}
+
+impl LanguageResolver {
+    pub(crate) fn new(config: Configuration) -> Self {
+        Self {
+            config,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn resolve(&self, name: &str) -> Option<&'static Language> {
+        if let Some(language) = self.cache.lock().ok()?.get(name).copied() {
+            return Some(language);
+        }
+
+        let language = to_language_from_config_sync(&self.config, name).ok()?;
+        let language: &'static Language = Box::leak(Box::new(language));
+        self.cache
+            .lock()
+            .ok()?
+            .insert(name.to_owned(), language);
+
+        Some(language)
     }
 }
 
@@ -240,6 +278,34 @@ pub(crate) async fn to_language_from_config<T: AsRef<str>>(
         grammar,
         indent: config_language.indent(),
         injection_query: None,
+    })
+}
+
+fn to_language_from_config_sync<T: AsRef<str> + fmt::Display>(
+    config: &Configuration,
+    name: T,
+) -> CLIResult<Language> {
+    let config_language = config.get_language(name.as_ref())?;
+    let grammar = config_language.grammar()?;
+    let query_source = to_query_from_language(config_language)?;
+    let query_content = query_source.get_content_sync()?;
+    let formatting_query = TopiaryQuery::new(&grammar, &query_content)
+        .attach_filepath(query_source.filepath())
+        .context(FormatterError::Parsing)?;
+    let injection_query = match to_injection_query_from_language(config_language) {
+        Some(source) => {
+            let contents = source.get_content_sync()?;
+            Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
+        }
+        None => None,
+    };
+
+    Ok(Language {
+        name: name.as_ref().to_string(),
+        formatting_query,
+        injection_query,
+        grammar,
+        indent: config_language.indent(),
     })
 }
 

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -11,7 +11,9 @@ use nickel_lang_core::eval::value::NickelValue;
 use rootcause::prelude::ResultExt;
 use tempfile::tempfile;
 use topiary_config::Configuration;
-use topiary_core::{FormatterError, Language, Operation, SpanAttachment, TopiaryQuery, formatter};
+use topiary_core::{
+    FormatterError, InjectionQuery, Language, Operation, SpanAttachment, TopiaryQuery, formatter,
+};
 
 use crate::{
     cli::{AtLeastOneInput, ExactlyOneInput, FromStdin},
@@ -170,7 +172,8 @@ impl fmt::Display for InputLocation {
 pub struct InputFile<'cfg> {
     source: InputSource,
     language: &'cfg topiary_config::language::Language,
-    pub(crate) query: QuerySource,
+    pub(crate) formatting_query: QuerySource,
+    pub(crate) injection_query: Option<QuerySource>,
 }
 
 impl InputFile<'_> {
@@ -178,17 +181,24 @@ impl InputFile<'_> {
     #[allow(clippy::result_large_err)]
     pub async fn to_language(&self) -> CLIResult<Language> {
         let grammar = self.language().grammar()?;
-        let query_contents = self.query.get_content().await?;
-        let query = TopiaryQuery::new(&grammar, &query_contents)
-            .attach_filepath(self.query.filepath())
+        let query_contents = self.formatting_query.get_content().await?;
+        let injection_query = match &self.injection_query {
+            Some(source) => {
+                let contents = source.get_content().await?;
+                Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
+            }
+            None => None,
+        };
+        let formatting_query = TopiaryQuery::new(&grammar, &query_contents)
+            .attach_filepath(self.formatting_query.filepath())
             .context(FormatterError::Parsing)?;
 
         Ok(Language {
             name: self.language.name.clone(),
-            query,
+            formatting_query,
+            injection_query,
             grammar,
             indent: self.language().indent(),
-            injection_query: None,
         })
     }
 
@@ -206,9 +216,9 @@ impl InputFile<'_> {
         self.language
     }
 
-    /// Expose query path for input
-    pub fn query(&self) -> &QuerySource {
-        &self.query
+    /// Expose formatting query path for input
+    pub fn formatting_query(&self) -> &QuerySource {
+        &self.formatting_query
     }
 }
 
@@ -226,7 +236,7 @@ pub(crate) async fn to_language_from_config<T: AsRef<str>>(
 
     Ok(Language {
         name: name.as_ref().to_string(),
-        query,
+        formatting_query: query,
         grammar,
         indent: config_language.indent(),
         injection_query: None,
@@ -276,11 +286,11 @@ impl<'cfg, 'i> Inputs<'cfg> {
                         // The user did not specify a file, try the default locations
                         None => to_query_from_language(language)?,
                     };
-
                     Ok(InputFile {
                         source: InputSource::Stdin,
                         language,
-                        query: query_source,
+                        formatting_query: query_source,
+                        injection_query: None,
                     })
                 })()]
             }
@@ -294,7 +304,8 @@ impl<'cfg, 'i> Inputs<'cfg> {
                     Ok(InputFile {
                         source: InputSource::Disk(path.into(), None),
                         language,
-                        query,
+                        formatting_query: query,
+                        injection_query: None,
                     })
                 })
                 .collect(),

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -286,11 +286,12 @@ impl<'cfg, 'i> Inputs<'cfg> {
                         // The user did not specify a file, try the default locations
                         None => to_query_from_language(language)?,
                     };
+                    let injection_query = to_injection_query_from_language(language);
                     Ok(InputFile {
                         source: InputSource::Stdin,
                         language,
                         formatting_query: query_source,
-                        injection_query: None,
+                        injection_query,
                     })
                 })()]
             }
@@ -300,12 +301,13 @@ impl<'cfg, 'i> Inputs<'cfg> {
                 .map(|path| {
                     let language = config.detect(&path)?;
                     let query: QuerySource = to_query_from_language(language)?;
+                    let injection_query = to_injection_query_from_language(language);
 
                     Ok(InputFile {
                         source: InputSource::Disk(path.into(), None),
                         language,
                         formatting_query: query,
-                        injection_query: None,
+                        injection_query,
                     })
                 })
                 .collect(),
@@ -331,6 +333,27 @@ fn to_query_from_language(language: &topiary_config::language::Language) -> CLIR
         }
     };
     Ok(query)
+}
+
+fn to_injection_query_from_language(
+    language: &topiary_config::language::Language,
+) -> Option<QuerySource> {
+    language
+        .find_injections_file()
+        .map(Into::into)
+        .or_else(|| to_injection_query(&language.name))
+}
+
+fn to_injection_query<T>(name: T) -> Option<QuerySource>
+where
+    T: AsRef<str>,
+{
+    match name.as_ref() {
+        #[cfg(feature = "ocamllex")]
+        "ocamllex" => Some(topiary_queries::ocamllex_injections().into()),
+
+        _ => None,
+    }
 }
 
 impl<'cfg> Iterator for Inputs<'cfg> {

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -102,10 +102,7 @@ impl LanguageResolver {
 
         let language = to_language_from_config_sync(&self.config, name).ok()?;
         let language: &'static Language = Box::leak(Box::new(language));
-        self.cache
-            .lock()
-            .ok()?
-            .insert(name.to_owned(), language);
+        self.cache.lock().ok()?.insert(name.to_owned(), language);
 
         Some(language)
     }

--- a/topiary-cli/src/language.rs
+++ b/topiary-cli/src/language.rs
@@ -27,7 +27,7 @@ impl LanguageDefinitionCache {
         let key = {
             let mut hash = DefaultHasher::new();
             input.language().name.hash(&mut hash);
-            input.query().hash(&mut hash);
+            input.formatting_query().hash(&mut hash);
 
             hash.finish()
         };
@@ -44,7 +44,7 @@ impl LanguageDefinitionCache {
                     self,
                     key,
                     input.language().name,
-                    input.query()
+                    input.formatting_query()
                 );
 
                 lang_def.get().to_owned()
@@ -57,7 +57,7 @@ impl LanguageDefinitionCache {
                     self,
                     key,
                     input.language().name,
-                    input.query()
+                    input.formatting_query()
                 );
 
                 let lang_def = Arc::new(input.to_language().await?);

--- a/topiary-cli/src/language.rs
+++ b/topiary-cli/src/language.rs
@@ -4,37 +4,58 @@ use std::{
         hash_map::{DefaultHasher, Entry},
     },
     hash::{Hash, Hasher},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
-use tokio::sync::Mutex;
+use topiary_config::Configuration;
 use topiary_core::Language;
 
-use crate::{error::CLIResult, io::InputFile};
+use crate::{
+    error::CLIResult,
+    io::{
+        InputFile, to_injection_query_from_language, to_language_from_config_sync,
+        to_query_from_language,
+    },
+};
 
 /// Thread-safe language definition cache
-pub struct LanguageDefinitionCache(Mutex<HashMap<u64, Arc<Language>>>);
+pub struct LanguageDefinitionCache {
+    cache: Mutex<HashMap<u64, Arc<Language>>>,
+}
 
 impl LanguageDefinitionCache {
     pub fn new() -> Self {
-        LanguageDefinitionCache(Mutex::new(HashMap::new()))
+        LanguageDefinitionCache {
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn key_for_parts(
+        language_name: &str,
+        formatting_query: &impl Hash,
+        injection_query: Option<&impl Hash>,
+    ) -> u64 {
+        let mut hash = DefaultHasher::new();
+        language_name.hash(&mut hash);
+        formatting_query.hash(&mut hash);
+        injection_query.hash(&mut hash);
+
+        hash.finish()
     }
 
     /// Fetch the language definition from the cache, populating if necessary, with thread-safety
-    pub async fn fetch<'i>(&self, input: &'i InputFile<'i>) -> CLIResult<Arc<Language>> {
+    pub fn fetch_input<'i>(&self, input: &'i InputFile<'i>) -> CLIResult<Arc<Language>> {
         // There's no need to store the input's identifying information (language name and query)
         // in the key, so we use its hash directly. This side-steps any awkward lifetime issues.
-        let key = {
-            let mut hash = DefaultHasher::new();
-            input.language().name.hash(&mut hash);
-            input.formatting_query().hash(&mut hash);
-
-            hash.finish()
-        };
+        let key = Self::key_for_parts(
+            &input.language().name,
+            input.formatting_query(),
+            input.injection_query(),
+        );
 
         // Lock the entire `HashMap` on access. (This may seem blunt, but is necessary for the
         // correct behaviour when we have near-simultaneous cache access; see issue #605.)
-        let mut cache = self.0.lock().await;
+        let mut cache = self.cache.lock().expect("language cache mutex poisoned");
 
         Ok(match cache.entry(key) {
             // Return the language definition from the cache, if it exists...
@@ -60,7 +81,34 @@ impl LanguageDefinitionCache {
                     input.formatting_query()
                 );
 
-                let lang_def = Arc::new(input.to_language().await?);
+                let lang_def = Arc::new(input.to_language_sync()?);
+                slot.insert(lang_def).to_owned()
+            }
+        })
+    }
+
+    /// Fetch an injected language definition by name from the same cache used for input languages.
+    pub fn fetch_from_config(
+        &self,
+        config: &Configuration,
+        name: &str,
+    ) -> CLIResult<Arc<Language>> {
+        let config_language = config.get_language(name)?;
+        let formatting_query = to_query_from_language(config_language)?;
+        let injection_query = to_injection_query_from_language(config_language);
+        let key = Self::key_for_parts(name, &formatting_query, injection_query.as_ref());
+
+        let mut cache = self.cache.lock().expect("language cache mutex poisoned");
+
+        Ok(match cache.entry(key) {
+            Entry::Occupied(lang_def) => {
+                log::debug!("Cache {:p}: Hit at {:#016x} ({name})", self, key);
+                lang_def.get().to_owned()
+            }
+
+            Entry::Vacant(slot) => {
+                log::debug!("Cache {:p}: Insert at {:#016x} ({name})", self, key);
+                let lang_def = Arc::new(to_language_from_config_sync(config, name)?);
                 slot.insert(lang_def).to_owned()
             }
         })

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -60,7 +60,13 @@ async fn run() -> CLIResult<()> {
                     input.query(),
                 );
 
-                check::check_input(input, &language, skip_idempotence, tolerate_parsing_errors)
+                check::check_input(
+                    input,
+                    &language,
+                    skip_idempotence,
+                    tolerate_parsing_errors,
+                    None, // TODO(Erin): Language Injection
+                )
             })
             .await?;
         }
@@ -101,6 +107,7 @@ async fn run() -> CLIResult<()> {
                             skip_idempotence,
                             tolerate_parsing_errors,
                         },
+                        None, // TODO(Erin): Language Injection
                     )?;
                 }
 
@@ -155,6 +162,7 @@ async fn run() -> CLIResult<()> {
                 Operation::Visualise {
                     output_format: format.into(),
                 },
+                None, // TODO(Erin): Language Injection
             )
             .attach_filepath(buf_input.get_ref().filepath())?;
         }

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -14,8 +14,11 @@ use std::{
 
 use error::Benign;
 use tabled::{Table, settings::Style};
-use topiary_config::source::Source;
-use topiary_core::{Operation, SpanAttachment, check_query_coverage, formatter};
+use topiary_config::{Configuration, source::Source};
+use topiary_core::{
+    FormatterError, FormatterResult, Language, Operation, SpanAttachment, check_query_coverage,
+    formatter,
+};
 
 use crate::{
     cli::Commands,
@@ -25,6 +28,21 @@ use crate::{
 };
 
 use miette::{NamedSource, Report};
+
+fn resolve_injected_language(
+    cache: &LanguageDefinitionCache,
+    config: &Configuration,
+    name: &str,
+) -> FormatterResult<Option<Arc<Language>>> {
+    cache
+        .fetch_from_config(config, name)
+        .map(Some)
+        .map_err(|_| {
+            rootcause::report!(FormatterError::InjectionLanguageResolution {
+                language: name.to_owned(),
+            })
+        })
+}
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -71,7 +89,7 @@ async fn run() -> CLIResult<()> {
                         &language,
                         skip_idempotence,
                         tolerate_parsing_errors,
-                        Some(&|name| cache.fetch_from_config(&config, name).ok()),
+                        Some(&|name| resolve_injected_language(&cache, &config, name)),
                     )
                 },
                 cache,
@@ -119,7 +137,7 @@ async fn run() -> CLIResult<()> {
                                 skip_idempotence,
                                 tolerate_parsing_errors,
                             },
-                            Some(&|name| cache.fetch_from_config(&config, name).ok()),
+                            Some(&|name| resolve_injected_language(&cache, &config, name)),
                         )?;
                     }
 

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -41,12 +41,12 @@ fn resolve_injected_language(
                 language: name.to_owned(),
             }))
         }
-        Err(err) => Err(rootcause::report!(
-            FormatterError::InjectionLanguageResolution {
+        Err(err) => Err(
+            rootcause::report!(FormatterError::InjectionLanguageResolution {
                 language: name.to_owned(),
-            }
-        )
-        .attach(err.to_string())),
+            })
+            .attach(err.to_string()),
+        ),
     }
 }
 
@@ -270,10 +270,13 @@ async fn run() -> CLIResult<()> {
 
             let input_content = read_input(&mut buf_input)?;
 
-            let coverage_data =
-                check_query_coverage(&input_content, &language.formatting_query, &language.grammar)
-                    .attach_source(input_content.as_str())
-                    .attach_filepath(buf_input.get_ref().filepath())?;
+            let coverage_data = check_query_coverage(
+                &input_content,
+                &language.formatting_query,
+                &language.grammar,
+            )
+            .attach_source(input_content.as_str())
+            .attach_filepath(buf_input.get_ref().filepath())?;
             let coverage_res = coverage_data.get_result();
 
             let query_source = NamedSource::new(

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -22,7 +22,7 @@ use topiary_core::{
 
 use crate::{
     cli::Commands,
-    error::{CLIResult, print_error},
+    error::{CLIResult, TopiaryError, print_error},
     io::{Inputs, OutputFile, process_inputs, read_input},
     language::LanguageDefinitionCache,
 };
@@ -34,14 +34,20 @@ fn resolve_injected_language(
     config: &Configuration,
     name: &str,
 ) -> FormatterResult<Option<Arc<Language>>> {
-    cache
-        .fetch_from_config(config, name)
-        .map(Some)
-        .map_err(|_| {
-            rootcause::report!(FormatterError::InjectionLanguageResolution {
+    match cache.fetch_from_config(config, name) {
+        Ok(language) => Ok(Some(language)),
+        Err(TopiaryError::Lib(report)) => {
+            Err(report.context(FormatterError::InjectionLanguageResolution {
                 language: name.to_owned(),
-            })
-        })
+            }))
+        }
+        Err(err) => Err(rootcause::report!(
+            FormatterError::InjectionLanguageResolution {
+                language: name.to_owned(),
+            }
+        )
+        .attach(err.to_string())),
+    }
 }
 
 #[tokio::main]

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -20,7 +20,8 @@ use topiary_core::{Operation, SpanAttachment, check_query_coverage, formatter};
 use crate::{
     cli::Commands,
     error::{CLIResult, print_error},
-    io::{Inputs, LanguageResolver, OutputFile, process_inputs, read_input},
+    io::{Inputs, OutputFile, process_inputs, read_input},
+    language::LanguageDefinitionCache,
 };
 
 use miette::{NamedSource, Report};
@@ -53,23 +54,28 @@ async fn run() -> CLIResult<()> {
             inputs,
         } => {
             let inputs = Inputs::new(&config, &inputs);
-            let resolver = Arc::new(LanguageResolver::new(config.clone()));
-            process_inputs(inputs, move |input, language| {
-                log::info!(
-                    "Checking {}, as {} using {}",
-                    input.source(),
-                    input.language().name,
-                    input.formatting_query(),
-                );
+            let cache = Arc::new(LanguageDefinitionCache::new());
+            let config = config.clone();
+            process_inputs(
+                inputs,
+                move |input, language, cache| {
+                    log::info!(
+                        "Checking {}, as {} using {}",
+                        input.source(),
+                        input.language().name,
+                        input.formatting_query(),
+                    );
 
-                check::check_input(
-                    input,
-                    &language,
-                    skip_idempotence,
-                    tolerate_parsing_errors,
-                    Some(&|name| resolver.resolve(name)),
-                )
-            })
+                    check::check_input(
+                        input,
+                        &language,
+                        skip_idempotence,
+                        tolerate_parsing_errors,
+                        Some(&|name| cache.fetch_from_config(&config, name).ok()),
+                    )
+                },
+                cache,
+            )
             .await?;
         }
         Commands::Format {
@@ -79,63 +85,72 @@ async fn run() -> CLIResult<()> {
             ..
         } => {
             let inputs = Inputs::new(&config, &inputs);
-            let resolver = Arc::new(LanguageResolver::new(config.clone()));
+            let cache = Arc::new(LanguageDefinitionCache::new());
+            let config = config.clone();
 
-            process_inputs(inputs, move |input, language| {
-                let output = OutputFile::try_from(&input)?;
+            process_inputs(
+                inputs,
+                move |input, language, cache| {
+                    let output = OutputFile::try_from(&input)?;
 
-                log::info!(
-                    "Formatting {}, as {} using {}, to {}",
-                    input.source(),
-                    input.language().name,
-                    input.formatting_query(),
-                    output
-                );
+                    log::info!(
+                        "Formatting {}, as {} using {}, to {}",
+                        input.source(),
+                        input.language().name,
+                        input.formatting_query(),
+                        output
+                    );
 
-                let mut buf_output = BufWriter::new(output);
+                    let mut buf_output = BufWriter::new(output);
 
-                {
-                    // NOTE This newly opened scope is important! `buf_input` takes
-                    // ownership of `input`, which -- upon reading -- contains an
-                    // open file handle. We need to close this file, by dropping
-                    // `buf_input`, before we attempt to persist our output.
-                    // Otherwise, we get an exclusive lock problem on Windows.
-                    let mut buf_input = BufReader::new(input);
+                    {
+                        // NOTE This newly opened scope is important! `buf_input` takes
+                        // ownership of `input`, which -- upon reading -- contains an
+                        // open file handle. We need to close this file, by dropping
+                        // `buf_input`, before we attempt to persist our output.
+                        // Otherwise, we get an exclusive lock problem on Windows.
+                        let mut buf_input = BufReader::new(input);
 
-                    formatter(
-                        &mut buf_input,
-                        &mut buf_output,
-                        &language,
-                        Operation::Format {
-                            skip_idempotence,
-                            tolerate_parsing_errors,
-                        },
-                        Some(&|name| resolver.resolve(name)),
-                    )?;
-                }
+                        formatter(
+                            &mut buf_input,
+                            &mut buf_output,
+                            &language,
+                            Operation::Format {
+                                skip_idempotence,
+                                tolerate_parsing_errors,
+                            },
+                            Some(&|name| cache.fetch_from_config(&config, name).ok()),
+                        )?;
+                    }
 
-                buf_output.into_inner()?.persist()?;
+                    buf_output.into_inner()?.persist()?;
 
-                CLIResult::Ok(())
-            })
+                    CLIResult::Ok(())
+                },
+                cache,
+            )
             .await?;
         }
 
         Commands::CheckGrammar { inputs } => {
             let inputs = Inputs::new(&config, &inputs);
 
-            process_inputs(inputs, |mut input, language| {
-                let input_content = read_input(&mut input)?;
-                log::debug!(
-                    "Checking {}, as {} for grammar correctness",
-                    input.source(),
-                    input.language().name,
-                );
+            process_inputs(
+                inputs,
+                |mut input, language, _cache| {
+                    let input_content = read_input(&mut input)?;
+                    log::debug!(
+                        "Checking {}, as {} for grammar correctness",
+                        input.source(),
+                        input.language().name,
+                    );
 
-                topiary_core::parse(&input_content, &language.grammar, false)?;
+                    topiary_core::parse(&input_content, &language.grammar, false)?;
 
-                Ok(())
-            })
+                    Ok(())
+                },
+                Arc::new(LanguageDefinitionCache::new()),
+            )
             .await?;
         }
 
@@ -144,9 +159,8 @@ async fn run() -> CLIResult<()> {
             let input = Inputs::new(&config, &input).next().unwrap()?;
             let output = OutputFile::Stdout;
 
-            // We don't need a `LanguageDefinitionCache` when there's only one input,
-            // which saves us the thread-safety overhead
-            let language = input.to_language().await?;
+            let cache = LanguageDefinitionCache::new();
+            let language = tokio::task::block_in_place(|| cache.fetch_input(&input))?;
 
             log::info!(
                 "Visualising {}, as {}, to {}",
@@ -218,9 +232,8 @@ async fn run() -> CLIResult<()> {
             let input = Inputs::new(&config, &input).next().unwrap()?;
             let output = OutputFile::Stdout;
 
-            // We don't need a `LanguageDefinitionCache` when there's only one input,
-            // which saves us the thread-safety overhead
-            let language = input.to_language().await?;
+            let cache = LanguageDefinitionCache::new();
+            let language = tokio::task::block_in_place(|| cache.fetch_input(&input))?;
 
             log::info!(
                 "Checking query coverage of {}, as {}",
@@ -241,7 +254,7 @@ async fn run() -> CLIResult<()> {
 
             let query_source = NamedSource::new(
                 buf_input.get_ref().formatting_query.to_string(),
-                language.formatting_query.query_content,
+                language.formatting_query.query_content.clone(),
             )
             .with_language(&language.name);
             write!(

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -275,7 +275,7 @@ async fn run() -> CLIResult<()> {
                 &language.formatting_query,
                 &language.grammar,
             )
-            .attach_source(input_content.as_str())
+            .attach_source(Some(input_content.as_str()))
             .attach_filepath(buf_input.get_ref().filepath())?;
             let coverage_res = coverage_data.get_result();
 

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -203,7 +203,7 @@ async fn run() -> CLIResult<()> {
                 Operation::Visualise {
                     output_format: format.into(),
                 },
-                None, // TODO(Erin): Language Injection
+                None,
             )
             .attach_filepath(buf_input.get_ref().filepath())?;
         }

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -9,6 +9,7 @@ mod visualisation;
 use std::{
     io::{BufReader, BufWriter, Write},
     process::ExitCode,
+    sync::Arc,
 };
 
 use error::Benign;
@@ -19,7 +20,7 @@ use topiary_core::{Operation, SpanAttachment, check_query_coverage, formatter};
 use crate::{
     cli::Commands,
     error::{CLIResult, print_error},
-    io::{Inputs, OutputFile, process_inputs, read_input},
+    io::{Inputs, LanguageResolver, OutputFile, process_inputs, read_input},
 };
 
 use miette::{NamedSource, Report};
@@ -52,6 +53,7 @@ async fn run() -> CLIResult<()> {
             inputs,
         } => {
             let inputs = Inputs::new(&config, &inputs);
+            let resolver = Arc::new(LanguageResolver::new(config.clone()));
             process_inputs(inputs, move |input, language| {
                 log::info!(
                     "Checking {}, as {} using {}",
@@ -65,7 +67,7 @@ async fn run() -> CLIResult<()> {
                     &language,
                     skip_idempotence,
                     tolerate_parsing_errors,
-                    None, // TODO(Erin): Language Injection
+                    Some(&|name| resolver.resolve(name)),
                 )
             })
             .await?;
@@ -77,6 +79,7 @@ async fn run() -> CLIResult<()> {
             ..
         } => {
             let inputs = Inputs::new(&config, &inputs);
+            let resolver = Arc::new(LanguageResolver::new(config.clone()));
 
             process_inputs(inputs, move |input, language| {
                 let output = OutputFile::try_from(&input)?;
@@ -107,7 +110,7 @@ async fn run() -> CLIResult<()> {
                             skip_idempotence,
                             tolerate_parsing_errors,
                         },
-                        None, // TODO(Erin): Language Injection
+                        Some(&|name| resolver.resolve(name)),
                     )?;
                 }
 

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -57,7 +57,7 @@ async fn run() -> CLIResult<()> {
                     "Checking {}, as {} using {}",
                     input.source(),
                     input.language().name,
-                    input.query(),
+                    input.formatting_query(),
                 );
 
                 check::check_input(
@@ -85,7 +85,7 @@ async fn run() -> CLIResult<()> {
                     "Formatting {}, as {} using {}, to {}",
                     input.source(),
                     input.language().name,
-                    input.query(),
+                    input.formatting_query(),
                     output
                 );
 
@@ -231,14 +231,14 @@ async fn run() -> CLIResult<()> {
             let input_content = read_input(&mut buf_input)?;
 
             let coverage_data =
-                check_query_coverage(&input_content, &language.query, &language.grammar)
+                check_query_coverage(&input_content, &language.formatting_query, &language.grammar)
                     .attach_source(input_content.as_str())
                     .attach_filepath(buf_input.get_ref().filepath())?;
             let coverage_res = coverage_data.get_result();
 
             let query_source = NamedSource::new(
-                buf_input.get_ref().query.to_string(),
-                language.query.query_content,
+                buf_input.get_ref().formatting_query.to_string(),
+                language.formatting_query.query_content,
             )
             .with_language(&language.name);
             write!(

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -301,9 +301,10 @@ fn test_fmt_invalid() {
 
 #[test]
 #[cfg(all(feature = "ocamllex", feature = "ocaml"))]
-fn test_fmt_ocamllex_invalid_inner_ocaml_passthrough() {
+fn test_fmt_ocamllex_invalid_inner_ocaml_fails() {
+    use predicates::str::contains;
+
     let input = fs::read_to_string("tests/samples/input/ocamllex_invalid_inner.mll").unwrap();
-    let expected = fs::read_to_string("tests/samples/expected/ocamllex_invalid_inner.mll").unwrap();
 
     let mut topiary = cargo_bin_cmd!("topiary");
 
@@ -314,8 +315,35 @@ fn test_fmt_ocamllex_invalid_inner_ocaml_passthrough() {
         .arg("ocamllex")
         .write_stdin(input)
         .assert()
-        .success()
-        .stdout(expected);
+        .failure()
+        .stderr(contains("Parsing"));
+}
+
+#[test]
+#[cfg(all(feature = "ocamllex", feature = "ocaml"))]
+fn test_fmt_ocamllex_broken_inner_language_resolution_fails() {
+    use predicates::str::contains;
+
+    let tmp_dir = TempDir::new().unwrap();
+    let ocaml_dir = tmp_dir.path().join("ocaml");
+    fs::create_dir_all(&ocaml_dir).unwrap();
+    fs::write(
+        ocaml_dir.join("formatting.scm"),
+        "this is not a tree-sitter query",
+    )
+    .unwrap();
+
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", tmp_dir.path())
+        .arg("fmt")
+        .arg("--language")
+        .arg("ocamllex")
+        .write_stdin(r#"rule token = parse | "x" { let values=[1;2;3] in values }"#)
+        .assert()
+        .failure()
+        .stderr(contains(r#"Could not resolve injected language "ocaml""#));
 }
 
 #[test]

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -322,7 +322,7 @@ fn test_fmt_ocamllex_invalid_inner_ocaml_fails() {
 #[test]
 #[cfg(all(feature = "ocamllex", feature = "ocaml"))]
 fn test_fmt_ocamllex_broken_inner_language_resolution_fails() {
-    use predicates::str::contains;
+    use predicates::{prelude::PredicateBooleanExt, str::contains};
 
     let tmp_dir = TempDir::new().unwrap();
     let ocaml_dir = tmp_dir.path().join("ocaml");
@@ -343,7 +343,12 @@ fn test_fmt_ocamllex_broken_inner_language_resolution_fails() {
         .write_stdin(r#"rule token = parse | "x" { let values=[1;2;3] in values }"#)
         .assert()
         .failure()
-        .stderr(contains(r#"Could not resolve injected language "ocaml""#));
+        .stderr(
+            contains(r#"Could not resolve injected language "ocaml""#)
+                .and(contains("Query error"))
+                .and(contains("ocaml/formatting.scm"))
+                .and(contains("this is not a tree-sitter query")),
+        );
 }
 
 #[test]

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -346,7 +346,10 @@ fn test_fmt_ocamllex_broken_inner_language_resolution_fails() {
         .stderr(
             contains(r#"Could not resolve injected language "ocaml""#)
                 .and(contains("Query error"))
-                .and(contains("ocaml/formatting.scm"))
+                .and(contains(format!(
+                    "ocaml{}formatting.scm",
+                    std::path::MAIN_SEPARATOR
+                )))
                 .and(contains("this is not a tree-sitter query")),
         );
 }

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -1,5 +1,5 @@
 use std::{fmt, sync::Once};
-#[cfg(any(feature = "json", feature = "toml"))]
+#[cfg(any(feature = "json", feature = "toml", all(feature = "ocamllex", feature = "ocaml")))]
 use {
     std::{fs, fs::File, io::Write, path::PathBuf},
     tempfile::TempDir,
@@ -293,6 +293,27 @@ fn test_fmt_invalid() {
         .arg("/path/to/query")
         .assert()
         .failure();
+}
+
+#[test]
+#[cfg(all(feature = "ocamllex", feature = "ocaml"))]
+fn test_fmt_ocamllex_invalid_inner_ocaml_passthrough() {
+    let input =
+        fs::read_to_string("tests/samples/input/ocamllex_invalid_inner.mll").unwrap();
+    let expected =
+        fs::read_to_string("tests/samples/expected/ocamllex_invalid_inner.mll").unwrap();
+
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
+        .arg("fmt")
+        .arg("--language")
+        .arg("ocamllex")
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(expected);
 }
 
 #[test]

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -1,5 +1,9 @@
 use std::{fmt, sync::Once};
-#[cfg(any(feature = "json", feature = "toml", all(feature = "ocamllex", feature = "ocaml")))]
+#[cfg(any(
+    feature = "json",
+    feature = "toml",
+    all(feature = "ocamllex", feature = "ocaml")
+))]
 use {
     std::{fs, fs::File, io::Write, path::PathBuf},
     tempfile::TempDir,
@@ -298,10 +302,8 @@ fn test_fmt_invalid() {
 #[test]
 #[cfg(all(feature = "ocamllex", feature = "ocaml"))]
 fn test_fmt_ocamllex_invalid_inner_ocaml_passthrough() {
-    let input =
-        fs::read_to_string("tests/samples/input/ocamllex_invalid_inner.mll").unwrap();
-    let expected =
-        fs::read_to_string("tests/samples/expected/ocamllex_invalid_inner.mll").unwrap();
+    let input = fs::read_to_string("tests/samples/input/ocamllex_invalid_inner.mll").unwrap();
+    let expected = fs::read_to_string("tests/samples/expected/ocamllex_invalid_inner.mll").unwrap();
 
     let mut topiary = cargo_bin_cmd!("topiary");
 

--- a/topiary-cli/tests/samples/expected/ocamllex.mll
+++ b/topiary-cli/tests/samples/expected/ocamllex.mll
@@ -9,12 +9,13 @@
   exception UnexpectedCharacter of char
   exception UnterminatedQuote
 
-  let keywords =
-    [ "true",   TRUE;
-      "false",  FALSE;
-      "and",    AND;
-      "or",     OR;
-      "not",    NOT ]
+  let keywords = [
+    "true", TRUE;
+    "false", FALSE;
+    "and", AND;
+    "or", OR;
+    "not", NOT
+  ]
 }
 
 let alpha = ['a'-'z' 'A'-'Z']

--- a/topiary-cli/tests/samples/expected/ocamllex_invalid_inner.mll
+++ b/topiary-cli/tests/samples/expected/ocamllex_invalid_inner.mll
@@ -1,3 +1,0 @@
-(* Regression test: invalid injected OCaml should pass through unchanged. *)
-{ let x = } rule token = parse
-  | eof { EOF }

--- a/topiary-cli/tests/samples/expected/ocamllex_invalid_inner.mll
+++ b/topiary-cli/tests/samples/expected/ocamllex_invalid_inner.mll
@@ -1,0 +1,3 @@
+(* Regression test: invalid injected OCaml should pass through unchanged. *)
+{ let x = } rule token = parse
+  | eof { EOF }

--- a/topiary-cli/tests/samples/input/ocamllex.mll
+++ b/topiary-cli/tests/samples/input/ocamllex.mll
@@ -62,4 +62,3 @@ and string buf = parse
   | eof    { raise UnterminatedQuote }
 
 and ocaml = parse "ocaml" { OCaml }
-

--- a/topiary-cli/tests/samples/input/ocamllex_invalid_inner.mll
+++ b/topiary-cli/tests/samples/input/ocamllex_invalid_inner.mll
@@ -1,0 +1,2 @@
+(* Regression test: invalid injected OCaml should pass through unchanged. *)
+{ let x = } rule token = parse | eof { EOF }

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -121,6 +121,28 @@ impl Language {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    pub fn find_injections_file(&self) -> Option<PathBuf> {
+        use crate::source::Source;
+
+        let name = self.name.as_str();
+
+        #[rustfmt::skip]
+        let potentials: [Option<PathBuf>; 5] = [
+            std::env::var("TOPIARY_LANGUAGE_DIR").map(PathBuf::from).ok(),
+            option_env!("TOPIARY_LANGUAGE_DIR").map(PathBuf::from),
+            Source::fetch_one(&None).queries_dir(),
+            Some(PathBuf::from("./topiary-queries/queries")),
+            Some(PathBuf::from("../topiary-queries/queries")),
+        ];
+
+        potentials
+            .into_iter()
+            .flatten()
+            .map(|path| path.join(name).join(topiary_queries::INJECTIONS_QUERY))
+            .find(|path| path.exists())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     // Returns the library path, and ensures the parent directories exist.
     pub fn library_path(&self) -> std::io::Result<PathBuf> {
         match &self.config.grammar.source {

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -31,7 +31,7 @@ pub use source::Source;
 /// Contains information on how to format every language the user is interested in, modulo what is
 /// supported. It can be provided by the user of the library, or alternatively, Topiary ships with
 /// default configuration that can be accessed using `Configuration::default`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Configuration {
     languages: Vec<Language>,
 }

--- a/topiary-core/Cargo.toml
+++ b/topiary-core/Cargo.toml
@@ -36,7 +36,7 @@ env_logger = { workspace = true }
 test-log = { workspace = true }
 tokio-test = { workspace = true }
 topiary-config = { workspace = true, features = ["ocaml", "ocamllex"] }
-topiary-queries.workspace = true
+topiary-queries = { workspace = true, features = ["json", "ocaml", "ocamllex"] }
 tree-sitter-json.workspace = true
 tree-sitter-nickel.workspace = true
 

--- a/topiary-core/Cargo.toml
+++ b/topiary-core/Cargo.toml
@@ -35,10 +35,15 @@ criterion = { workspace = true, features = ["async_futures"] }
 env_logger = { workspace = true }
 test-log = { workspace = true }
 tokio-test = { workspace = true }
+topiary-config = { workspace = true, features = ["ocaml", "ocamllex"] }
 topiary-queries.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-nickel.workspace = true
 
 [[bench]]
 name = "benchmark"
+harness = false
+
+[[bench]]
+name = "injections"
 harness = false

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -17,6 +17,7 @@ fn setup() -> (String, Language) {
         query: TopiaryQuery::new(&nickel.into(), &query_content).unwrap(),
         grammar: tree_sitter_nickel::LANGUAGE.into(),
         indent: None,
+        injection_query: None,
     };
 
     (input, language)
@@ -37,6 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     skip_idempotence: true,
                     tolerate_parsing_errors: false,
                 },
+                None,
             )
             .unwrap();
         });

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -14,7 +14,7 @@ fn setup() -> (String, Language) {
 
     let language: Language = Language {
         name: "nickel".to_owned(),
-        query: TopiaryQuery::new(&nickel.into(), &query_content).unwrap(),
+        formatting_query: TopiaryQuery::new(&nickel.into(), &query_content).unwrap(),
         grammar: tree_sitter_nickel::LANGUAGE.into(),
         indent: None,
         injection_query: None,

--- a/topiary-core/benches/injections.rs
+++ b/topiary-core/benches/injections.rs
@@ -1,0 +1,111 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::io;
+use topiary_config::Configuration;
+use topiary_core::{formatter_str, InjectionQuery, Language, Operation, TopiaryQuery};
+
+const OCAMLLEX_FORMATTING_QUERY: &str =
+    include_str!("../../topiary-queries/queries/ocamllex/formatting.scm");
+const OCAMLLEX_INJECTION_QUERY: &str =
+    include_str!("../../topiary-queries/queries/ocamllex/injections.scm");
+const OCAML_FORMATTING_QUERY: &str =
+    include_str!("../../topiary-queries/queries/ocaml/formatting.scm");
+
+fn language_from_config(
+    config: &Configuration,
+    name: &str,
+    formatting_query_content: &str,
+    injection_query_content: Option<&str>,
+) -> Language {
+    let config_language = config.get_language(name).unwrap();
+    let grammar = config_language.grammar().unwrap();
+
+    Language {
+        name: name.to_owned(),
+        formatting_query: TopiaryQuery::new(&grammar, formatting_query_content).unwrap(),
+        injection_query: injection_query_content
+            .map(|query_content| InjectionQuery::new(&grammar, query_content).unwrap()),
+        grammar,
+        indent: config_language.indent(),
+    }
+}
+
+fn input_with_actions(count: usize) -> String {
+    let actions = (0..count)
+        .map(|i| {
+            format!(r#"  | "token{i}" {{ let values=[1;2;3] in List.map (fun x->x+{i}) values }}"#)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"{{
+  type token = Value of int list | Eof
+}}
+
+rule token = parse
+{actions}
+  | eof {{ Eof }}
+"#
+    )
+}
+
+fn format_ocamllex(
+    input: &str,
+    language: &Language,
+    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+) {
+    let mut output = io::BufWriter::new(Vec::new());
+    formatter_str(
+        input,
+        &mut output,
+        language,
+        Operation::Format {
+            skip_idempotence: true,
+            tolerate_parsing_errors: false,
+        },
+        resolve,
+    )
+    .unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let config = Configuration::default();
+    let baseline = language_from_config(&config, "ocamllex", OCAMLLEX_FORMATTING_QUERY, None);
+    let injected = language_from_config(
+        &config,
+        "ocamllex",
+        OCAMLLEX_FORMATTING_QUERY,
+        Some(OCAMLLEX_INJECTION_QUERY),
+    );
+    let ocaml: &'static Language = Box::leak(Box::new(language_from_config(
+        &config,
+        "ocaml",
+        OCAML_FORMATTING_QUERY,
+        None,
+    )));
+
+    let mut group = c.benchmark_group("injections_ocamllex");
+
+    for count in [1, 10, 100] {
+        let input = input_with_actions(count);
+
+        group.bench_with_input(BenchmarkId::new("baseline", count), &input, |b, input| {
+            b.iter(|| format_ocamllex(input, &baseline, None));
+        });
+
+        group.bench_with_input(BenchmarkId::new("injected", count), &input, |b, input| {
+            b.iter(|| {
+                format_ocamllex(
+                    input,
+                    &injected,
+                    Some(&|name| (name == "ocaml").then_some(&ocaml)),
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/topiary-core/benches/injections.rs
+++ b/topiary-core/benches/injections.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use std::io;
+use std::{io, sync::Arc};
 use topiary_config::Configuration;
 use topiary_core::{InjectionQuery, Language, Operation, TopiaryQuery, formatter_str};
 
@@ -52,7 +52,7 @@ rule token = parse
 fn format_ocamllex(
     input: &str,
     language: &Language,
-    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
 ) {
     let mut output = io::BufWriter::new(Vec::new());
     formatter_str(
@@ -77,12 +77,12 @@ fn criterion_benchmark(c: &mut Criterion) {
         OCAMLLEX_FORMATTING_QUERY,
         Some(OCAMLLEX_INJECTION_QUERY),
     );
-    let ocaml: &'static Language = Box::leak(Box::new(language_from_config(
+    let ocaml = Arc::new(language_from_config(
         &config,
         "ocaml",
         OCAML_FORMATTING_QUERY,
         None,
-    )));
+    ));
 
     let mut group = c.benchmark_group("injections_ocamllex");
 
@@ -98,7 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 format_ocamllex(
                     input,
                     &injected,
-                    Some(&|name| (name == "ocaml").then_some(&ocaml)),
+                    Some(&|name| (name == "ocaml").then_some(ocaml.clone())),
                 )
             });
         });

--- a/topiary-core/benches/injections.rs
+++ b/topiary-core/benches/injections.rs
@@ -1,7 +1,9 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::{io, sync::Arc};
 use topiary_config::Configuration;
-use topiary_core::{InjectionQuery, Language, Operation, TopiaryQuery, formatter_str};
+use topiary_core::{
+    InjectionQuery, Language, LanguageResolver, Operation, TopiaryQuery, formatter_str,
+};
 
 const OCAMLLEX_FORMATTING_QUERY: &str =
     include_str!("../../topiary-queries/queries/ocamllex/formatting.scm");
@@ -49,11 +51,7 @@ rule token = parse
     )
 }
 
-fn format_ocamllex(
-    input: &str,
-    language: &Language,
-    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
-) {
+fn format_ocamllex(input: &str, language: &Language, resolve: Option<&LanguageResolver<'_>>) {
     let mut output = io::BufWriter::new(Vec::new());
     formatter_str(
         input,
@@ -98,7 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 format_ocamllex(
                     input,
                     &injected,
-                    Some(&|name| (name == "ocaml").then_some(ocaml.clone())),
+                    Some(&|name| Ok((name == "ocaml").then_some(ocaml.clone()))),
                 )
             });
         });

--- a/topiary-core/benches/injections.rs
+++ b/topiary-core/benches/injections.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::io;
 use topiary_config::Configuration;
-use topiary_core::{formatter_str, InjectionQuery, Language, Operation, TopiaryQuery};
+use topiary_core::{InjectionQuery, Language, Operation, TopiaryQuery, formatter_str};
 
 const OCAMLLEX_FORMATTING_QUERY: &str =
     include_str!("../../topiary-queries/queries/ocamllex/formatting.scm");

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -116,6 +116,24 @@ impl AtomCollection {
         Ok(atoms)
     }
 
+    /// Replace the `content` of the [`Atom::Leaf`] whose tree-sitter `id`
+    /// matches `node_id`. Returns whether a matching leaf was found.
+    ///
+    /// Used by the injection flow to splice formatted inner-language text
+    /// into a host leaf atom after the host's atom collection has been
+    /// built but before rendering.
+    pub fn rewrite_leaf_content(&mut self, node_id: usize, new_content: String) -> bool {
+        for atom in &mut self.atoms {
+            if let Atom::Leaf { id, content, .. } = atom
+                && *id == node_id
+            {
+                *content = new_content;
+                return true;
+            }
+        }
+        false
+    }
+
     // wrap inside a conditional atom if #single/multi_line_scope_only! is set
     fn wrap(&mut self, atom: Atom, predicates: &QueryPredicates) -> Atom {
         if let Some(scope_id) = &predicates.single_line_scope_only {

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -122,12 +122,20 @@ impl AtomCollection {
     /// Used by the injection flow to splice formatted inner-language text
     /// into a host leaf atom after the host's atom collection has been
     /// built but before rendering.
-    pub fn rewrite_leaf_content(&mut self, node_id: usize, new_content: String) -> bool {
+    pub fn rewrite_injected_leaf_content(&mut self, node_id: usize, new_content: String) -> bool {
         for atom in &mut self.atoms {
-            if let Atom::Leaf { id, content, .. } = atom
+            if let Atom::Leaf {
+                id,
+                content,
+                original_position,
+                ..
+            } = atom
                 && *id == node_id
             {
                 *content = new_content;
+                // Injected formatters return column-zero text; let the host
+                // leaf indentation account for the current render column.
+                original_position.column = 1;
                 return true;
             }
         }

--- a/topiary-core/src/error/error_span.rs
+++ b/topiary-core/src/error/error_span.rs
@@ -74,11 +74,11 @@ impl ErrorSpan {
         self
     }
 
-    pub fn set_language(&mut self, language: impl Into<String>) {
-        self.language = Some(language.into());
+    pub fn set_language(&mut self, language: &str) {
+        self.language = Some(language.to_owned());
     }
 
-    pub fn with_language(mut self, language: impl Into<String>) -> Self {
+    pub fn with_language(mut self, language: &str) -> Self {
         self.set_language(language);
         self
     }
@@ -160,9 +160,9 @@ impl std::error::Error for ErrorSpan {}
 /// that allow for rendering of the error location for use
 /// in libraries such as `miette`.
 pub trait SpanAttachment {
-    fn attach_filepath<'a>(self, filepath: impl Into<Option<&'a Path>>) -> Self;
-    fn attach_source<'a>(self, source: impl Into<Option<&'a str>>) -> Self;
-    fn attach_language(self, language: impl Into<Option<String>>) -> Self;
+    fn attach_filepath(self, filepath: Option<&Path>) -> Self;
+    fn attach_source(self, source: Option<&str>) -> Self;
+    fn attach_language(self, language: Option<&str>) -> Self;
     fn attach_range(self, range: Range) -> Self;
     fn get_span(&mut self) -> Option<&mut ErrorSpan>;
 }
@@ -171,8 +171,8 @@ impl<C, T> SpanAttachment for rootcause::Report<C, rootcause::markers::Mutable, 
 where
     ErrorSpan: ObjectMarkerFor<T>,
 {
-    fn attach_filepath<'a>(mut self, filepath: impl Into<Option<&'a Path>>) -> Self {
-        let Some(filepath) = filepath.into() else {
+    fn attach_filepath(mut self, filepath: Option<&Path>) -> Self {
+        let Some(filepath) = filepath else {
             return self;
         };
         if let Some(span) = self.get_span() {
@@ -182,8 +182,8 @@ where
         self.attach_custom::<MietteHandler, _>(ErrorSpan::default().with_filepath(filepath))
     }
 
-    fn attach_source<'a>(mut self, source: impl Into<Option<&'a str>>) -> Self {
-        let Some(source) = source.into() else {
+    fn attach_source(mut self, source: Option<&str>) -> Self {
+        let Some(source) = source else {
             return self;
         };
         if let Some(span) = self.get_span() {
@@ -193,12 +193,12 @@ where
         self.attach_custom::<MietteHandler, _>(ErrorSpan::default().with_source(source))
     }
 
-    fn attach_language(mut self, language: impl Into<Option<String>>) -> Self {
-        let Some(language) = language.into() else {
+    fn attach_language(mut self, language: Option<&str>) -> Self {
+        let Some(language) = language else {
             return self;
         };
         if let Some(span) = self.get_span() {
-            span.language = Some(language);
+            span.language = Some(language.to_owned());
             return self;
         }
         self.attach_custom::<MietteHandler, _>(ErrorSpan::default().with_language(language))
@@ -225,21 +225,21 @@ impl<V, E> SpanAttachment for Result<V, E>
 where
     E: SpanAttachment,
 {
-    fn attach_filepath<'a>(self, filepath: impl Into<Option<&'a Path>>) -> Self {
+    fn attach_filepath(self, filepath: Option<&Path>) -> Self {
         match self {
             Ok(v) => Ok(v),
             Err(e) => Err(e.attach_filepath(filepath)),
         }
     }
 
-    fn attach_source<'a>(self, source: impl Into<Option<&'a str>>) -> Self {
+    fn attach_source(self, source: Option<&str>) -> Self {
         match self {
             Ok(v) => Ok(v),
             Err(e) => Err(e.attach_source(source)),
         }
     }
 
-    fn attach_language(self, language: impl Into<Option<String>>) -> Self {
+    fn attach_language(self, language: Option<&str>) -> Self {
         match self {
             Ok(v) => Ok(v),
             Err(e) => Err(e.attach_language(language)),

--- a/topiary-core/src/error/error_span.rs
+++ b/topiary-core/src/error/error_span.rs
@@ -34,7 +34,7 @@ pub struct ErrorSpan {
     source: Option<String>,
     // original
     filepath: Option<PathBuf>,
-    language: Option<&'static str>,
+    language: Option<String>,
     pub(crate) range: Option<Range>,
 
     // label for our immediate `SourceSpan`
@@ -74,11 +74,11 @@ impl ErrorSpan {
         self
     }
 
-    pub fn set_language(&mut self, language: &'static str) {
-        self.language = Some(language);
+    pub fn set_language(&mut self, language: impl Into<String>) {
+        self.language = Some(language.into());
     }
 
-    pub fn with_language(mut self, language: &'static str) -> Self {
+    pub fn with_language(mut self, language: impl Into<String>) -> Self {
         self.set_language(language);
         self
     }
@@ -141,8 +141,8 @@ impl SourceCode for ErrorSpan {
             inner_contents.column(),
             inner_contents.line_count(),
         );
-        if let Some(language) = self.language {
-            contents = contents.with_language(language);
+        if let Some(language) = &self.language {
+            contents = contents.with_language(language.clone());
         }
         Ok(Box::new(contents))
     }
@@ -162,7 +162,7 @@ impl std::error::Error for ErrorSpan {}
 pub trait SpanAttachment {
     fn attach_filepath<'a>(self, filepath: impl Into<Option<&'a Path>>) -> Self;
     fn attach_source<'a>(self, source: impl Into<Option<&'a str>>) -> Self;
-    fn attach_language(self, language: impl Into<Option<&'static str>>) -> Self;
+    fn attach_language(self, language: impl Into<Option<String>>) -> Self;
     fn attach_range(self, range: Range) -> Self;
     fn get_span(&mut self) -> Option<&mut ErrorSpan>;
 }
@@ -193,7 +193,7 @@ where
         self.attach_custom::<MietteHandler, _>(ErrorSpan::default().with_source(source))
     }
 
-    fn attach_language(mut self, language: impl Into<Option<&'static str>>) -> Self {
+    fn attach_language(mut self, language: impl Into<Option<String>>) -> Self {
         let Some(language) = language.into() else {
             return self;
         };
@@ -239,7 +239,7 @@ where
         }
     }
 
-    fn attach_language(self, language: impl Into<Option<&'static str>>) -> Self {
+    fn attach_language(self, language: impl Into<Option<String>>) -> Self {
         match self {
             Ok(v) => Ok(v),
             Err(e) => Err(e.attach_language(language)),

--- a/topiary-core/src/error/mod.rs
+++ b/topiary-core/src/error/mod.rs
@@ -1,7 +1,7 @@
 //! This module defines all errors that might be propagated out of the library,
 //! including all of the trait implementations one might expect for Errors.
 
-use std::{error::Error, fmt, io, str};
+use std::{error::Error, fmt, io};
 
 use rootcause::{Report, ReportConversion, markers};
 
@@ -24,6 +24,9 @@ pub enum FormatterError {
 
     /// An internal error occurred. This is a bug. Please log an issue.
     Internal(String),
+
+    /// An injected language could not be resolved.
+    InjectionLanguageResolution { language: String },
 
     // Tree-sitter could not parse the input without errors.
     Parsing,
@@ -72,6 +75,10 @@ impl fmt::Display for FormatterError {
             }
             Self::Internal(message) | Self::Query(message) => {
                 write!(f, "{message}")
+            }
+
+            Self::InjectionLanguageResolution { language, .. } => {
+                write!(f, "Could not resolve injected language \"{language}\"")
             }
         }
     }

--- a/topiary-core/src/error/mod.rs
+++ b/topiary-core/src/error/mod.rs
@@ -26,7 +26,9 @@ pub enum FormatterError {
     Internal(String),
 
     /// An injected language could not be resolved.
-    InjectionLanguageResolution { language: String },
+    InjectionLanguageResolution {
+        language: String,
+    },
 
     // Tree-sitter could not parse the input without errors.
     Parsing,

--- a/topiary-core/src/language.rs
+++ b/topiary-core/src/language.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::TopiaryQuery;
+use crate::{InjectionQuery, TopiaryQuery};
 
 /// A Language contains all the information Topiary requires to format that
 /// specific languages.
@@ -19,6 +19,9 @@ pub struct Language {
     /// if not provided. Any string can be provided, but in most instances will be
     /// some whitespace: "  ", "    ", or "\t".
     pub indent: Option<String>,
+    /// Optional injection query identifying regions of source that should be
+    /// formatted as a different language.
+    pub injection_query: Option<InjectionQuery>,
 }
 
 impl fmt::Display for Language {

--- a/topiary-core/src/language.rs
+++ b/topiary-core/src/language.rs
@@ -12,16 +12,16 @@ pub struct Language {
     pub name: String,
     /// The Query Topiary will use to get the formatting captures, must be
     /// present. The topiary engine does not include any formatting queries.
-    pub query: TopiaryQuery,
+    pub formatting_query: TopiaryQuery,
+    /// Optional injection query identifying regions of source that should be
+    /// formatted as a different language.
+    pub injection_query: Option<InjectionQuery>,
     /// The tree-sitter Language. Topiary will use this Language for parsing.
     pub grammar: topiary_tree_sitter_facade::Language,
     /// The indentation string used for that particular language. Defaults to "  "
     /// if not provided. Any string can be provided, but in most instances will be
     /// some whitespace: "  ", "    ", or "\t".
     pub indent: Option<String>,
-    /// Optional injection query identifying regions of source that should be
-    /// formatted as a different language.
-    pub injection_query: Option<InjectionQuery>,
 }
 
 impl fmt::Display for Language {

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -13,7 +13,7 @@
 use std::{io, sync::Arc};
 
 use pretty_assertions::StrComparison;
-use rootcause::{prelude::ResultExt, report};
+use rootcause::{option_ext::OptionExt, prelude::ResultExt, report};
 use tree_sitter::Position;
 
 pub use crate::{
@@ -394,12 +394,11 @@ fn rewrite_injected_leaves(
     for span in spans {
         let inner_source = input_content
             .get(span.start_byte..span.end_byte)
-            .ok_or_else(|| {
-                report!(FormatterError::Internal(format!(
-                    "Injected {} span is not on UTF-8 boundaries",
-                    span.language
-                )))
-            })?;
+            .ok_or_report()
+            .context(FormatterError::Internal(
+                "Injected span is not on UTF-8 boundaries".into(),
+            ))
+            .attach_language(span.language.clone())?;
 
         let inner_language = resolve_injected_language(resolve, &span.language)?;
 

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -398,7 +398,7 @@ fn rewrite_injected_leaves(
             .context(FormatterError::Internal(
                 "Injected span is not on UTF-8 boundaries".into(),
             ))
-            .attach_language(span.language.clone())?;
+            .attach_language(Some(span.language.as_str()))?;
 
         let inner_language = resolve_injected_language(resolve, &span.language)?;
 

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -704,9 +704,11 @@ mod tests {
                 skip_idempotence: true,
                 tolerate_parsing_errors: false,
             },
-            Some(&|_| Err(rootcause::report!(FormatterError::Query(
-                "resolver failed while loading language".into()
-            )))),
+            Some(&|_| {
+                Err(rootcause::report!(FormatterError::Query(
+                    "resolver failed while loading language".into()
+                )))
+            }),
         );
 
         assert!(matches!(

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -476,13 +476,50 @@ fn idempotence_check(
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use test_log::test;
 
     use crate::{
-        Language, Operation, SpanAttachment, TopiaryQuery, formatter, test_utils::pretty_assert_eq,
+        FormatterError, InjectionQuery, Language, Operation, SpanAttachment, TopiaryQuery,
+        collect_injections, formatter, formatter_str, parse, test_utils::pretty_assert_eq,
     };
+
+    fn language(name: &str, formatting_query: &str, injection_query: Option<&str>) -> Language {
+        let config = topiary_config::Configuration::default();
+        let config_language = config.get_language(name).unwrap();
+        let grammar = config_language.grammar().unwrap();
+
+        Language {
+            name: name.to_owned(),
+            formatting_query: TopiaryQuery::new(&grammar, formatting_query).unwrap(),
+            injection_query: injection_query
+                .map(|query_content| InjectionQuery::new(&grammar, query_content).unwrap()),
+            grammar,
+            indent: config_language.indent(),
+        }
+    }
+
+    fn ocamllex_language() -> Language {
+        language(
+            "ocamllex",
+            topiary_queries::ocamllex(),
+            Some(topiary_queries::ocamllex_injections()),
+        )
+    }
+
+    fn ocaml_language() -> Language {
+        language("ocaml", topiary_queries::ocaml(), None)
+    }
+
+    fn unstable_ocaml_language() -> Language {
+        language(
+            "ocaml",
+            r#"
+((value_name) @append_delimiter
+ (#delimiter! "x"))
+"#,
+            None,
+        )
+    }
 
     /// Attempt to parse invalid json, expecting a failure
     #[test(tokio::test)]
@@ -529,15 +566,11 @@ mod tests {
         let expected = "{ \"one\": {\"bar\"   \"baz\"}, \"two\": \"bar\" }\n";
 
         let mut output = Vec::new();
-        let query_content = fs::read_to_string(format!(
-            "../topiary-queries/queries/json/{}",
-            topiary_queries::FORMATTING_QUERY
-        ))
-        .unwrap();
+        let query_content = topiary_queries::json();
         let grammar = tree_sitter_json::LANGUAGE.into();
         let language = Language {
             name: "json".to_owned(),
-            formatting_query: TopiaryQuery::new(&grammar, &query_content).unwrap(),
+            formatting_query: TopiaryQuery::new(&grammar, query_content).unwrap(),
             grammar,
             indent: None,
             injection_query: None,
@@ -559,5 +592,105 @@ mod tests {
         log::debug!("{formatted}");
 
         pretty_assert_eq(expected, &formatted);
+    }
+
+    #[test(tokio::test)]
+    async fn collect_injections_returns_content_span() {
+        let input = r#"rule token = parse
+  | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }
+"#;
+        let language = ocamllex_language();
+        let tree = parse(input, &language.grammar, false).unwrap();
+        let spans =
+            collect_injections(&tree, input, language.injection_query.as_ref().unwrap()).unwrap();
+
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].language, "ocaml");
+        assert_eq!(
+            &input[spans[0].start_byte..spans[0].end_byte],
+            r#"let values=[1;2;3] in List.map (fun x->x+1) values"#
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn unresolved_injection_preserves_inner_source() {
+        let input = r#"rule token = parse
+  | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }
+"#;
+        let language = ocamllex_language();
+        let mut output = Vec::new();
+
+        formatter_str(
+            input,
+            &mut output,
+            &language,
+            Operation::Format {
+                skip_idempotence: true,
+                tolerate_parsing_errors: false,
+            },
+            None,
+        )
+        .unwrap();
+
+        let formatted = String::from_utf8(output).unwrap();
+        pretty_assert_eq(
+            r#"rule token = parse
+  | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }"#,
+            formatted.trim_end(),
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn resolved_injection_rewrites_forced_leaf() {
+        let input = r#"rule token = parse
+  | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }
+"#;
+        let language = ocamllex_language();
+        let inner_language: &'static Language = Box::leak(Box::new(ocaml_language()));
+        let mut output = Vec::new();
+
+        formatter_str(
+            input,
+            &mut output,
+            &language,
+            Operation::Format {
+                skip_idempotence: true,
+                tolerate_parsing_errors: false,
+            },
+            Some(&|name| (name == "ocaml").then_some(inner_language)),
+        )
+        .unwrap();
+
+        let formatted = String::from_utf8(output).unwrap();
+        pretty_assert_eq(
+            r#"rule token = parse
+  | "x" { let values = [1; 2; 3] in List.map (fun x -> x + 1) values }"#,
+            formatted.trim_end(),
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn non_idempotent_injection_fails_outer_idempotence() {
+        let input = r#"rule token = parse
+  | "x" { value }
+"#;
+        let language = ocamllex_language();
+        let inner_language: &'static Language = Box::leak(Box::new(unstable_ocaml_language()));
+        let mut output = Vec::new();
+
+        let result = formatter_str(
+            input,
+            &mut output,
+            &language,
+            Operation::Format {
+                skip_idempotence: false,
+                tolerate_parsing_errors: false,
+            },
+            Some(&|name| (name == "ocaml").then_some(inner_language)),
+        );
+
+        assert!(
+            matches!(result, Err(ref report) if report.current_context() == &FormatterError::Idempotence)
+        );
     }
 }

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -20,8 +20,8 @@ pub use crate::{
     error::{ErrorSpan, FormatterError, SpanAttachment},
     language::Language,
     tree_sitter::{
-        CoverageData, SyntaxNode, TopiaryQuery, Visualisation, apply_query, check_query_coverage,
-        parse,
+        CoverageData, InjectionQuery, InjectionSpan, SyntaxNode, TopiaryQuery, Visualisation,
+        apply_query, check_query_coverage, collect_injections, parse,
     },
 };
 
@@ -215,9 +215,10 @@ pub enum Operation {
 ///     query: TopiaryQuery::new(&json.clone().into(), &query_content).unwrap(),
 ///     grammar: json.into(),
 ///     indent: None,
+///     injection_query: None,
 /// };
 ///
-/// match formatter(&mut input, &mut output, &language, Operation::Format{ skip_idempotence: false, tolerate_parsing_errors: false }) {
+/// match formatter(&mut input, &mut output, &language, Operation::Format{ skip_idempotence: false, tolerate_parsing_errors: false }, None) {
 ///   Ok(()) => {
 ///     let formatted = String::from_utf8(output).expect("valid utf-8");
 ///   }
@@ -235,12 +236,13 @@ pub fn formatter(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
+    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
 ) -> FormatterResult<()> {
     let content = read_input(input)
         .context_to()
         .attach("Failed to read input contents")?;
 
-    formatter_str(&content, output, language, operation)
+    formatter_str(&content, output, language, operation, resolve)
 }
 
 /// The function that takes a string slice and formats, or visualises an output.
@@ -253,6 +255,7 @@ pub fn formatter_str(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
+    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
 ) -> FormatterResult<()> {
     let tolerate_parsing_errors = match operation {
         Operation::Format {
@@ -264,7 +267,7 @@ pub fn formatter_str(
 
     let tree = tree_sitter::parse(input, &language.grammar, tolerate_parsing_errors)?;
 
-    formatter_tree(tree, input, output, language, operation)?;
+    formatter_tree(tree, input, output, language, operation, resolve)?;
 
     Ok(())
 }
@@ -280,16 +283,40 @@ pub fn formatter_tree(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
+    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
 ) -> FormatterResult<()> {
     match operation {
         Operation::Format {
             skip_idempotence,
             tolerate_parsing_errors,
         } => {
+            log::debug!("Discovering potentially injected languages");
+            let spans = match &language.injection_query {
+                Some(injection_query) => collect_injections(&tree, input_content, injection_query)?,
+                None => Vec::new(),
+            };
+
+            // Create a list of nodes that are injection formatted.
+            // These must will be treated as leaves (although, in all likelihood, they already are).
+            let injection_leaf_nodes = spans.iter().map(|span| span.node_id);
+
             // All the work related to tree-sitter and the query is done here
             log::debug!("Apply Tree-sitter query");
 
-            let mut atoms = tree_sitter::apply_query_tree(tree, input_content, &language.query)?;
+            let mut atoms = tree_sitter::apply_query_tree_with_forced_leaves(
+                tree,
+                input_content,
+                &language.query,
+                injection_leaf_nodes,
+            )?;
+
+            rewrite_injected_leaves(
+                &mut atoms,
+                input_content,
+                spans,
+                resolve,
+                tolerate_parsing_errors,
+            );
 
             // Various post-processing of whitespace
             atoms.post_process();
@@ -306,7 +333,7 @@ pub fn formatter_tree(
             let rendered = format!("{}\n", rendered.trim());
 
             if !skip_idempotence {
-                idempotence_check(&rendered, language, tolerate_parsing_errors)?;
+                idempotence_check(&rendered, language, tolerate_parsing_errors, resolve)?;
             }
 
             write!(output, "{rendered}").context_to()?;
@@ -322,6 +349,70 @@ pub fn formatter_tree(
         }
     };
     Ok(())
+}
+
+fn rewrite_injected_leaves(
+    atoms: &mut atom_collection::AtomCollection,
+    input_content: &str,
+    spans: Vec<InjectionSpan>,
+    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    tolerate_parsing_errors: bool,
+) {
+    for span in spans {
+        let Some(inner_source) = input_content.get(span.start_byte..span.end_byte) else {
+            log::warn!(
+                "Injected {} span is not on UTF-8 boundaries; skipping",
+                span.language
+            );
+            continue;
+        };
+
+        let Some(inner_language) = resolve.and_then(|resolve| resolve(&span.language)) else {
+            log::warn!(
+                "No language definition available for injected {}; skipping",
+                span.language
+            );
+            continue;
+        };
+
+        let mut formatted_inner = Vec::new();
+        if let Err(err) = formatter_str(
+            inner_source,
+            &mut formatted_inner,
+            inner_language,
+            Operation::Format {
+                skip_idempotence: true,
+                tolerate_parsing_errors,
+            },
+            resolve,
+        ) {
+            log::warn!(
+                "Failed to format injected {} span: {}; skipping",
+                span.language,
+                err
+            );
+            continue;
+        }
+
+        let formatted_inner = match String::from_utf8(formatted_inner) {
+            Ok(formatted_inner) => formatted_inner.trim_end_matches('\n').to_owned(),
+            Err(err) => {
+                log::warn!(
+                    "Injected {} formatter produced invalid UTF-8: {}; skipping",
+                    span.language,
+                    err
+                );
+                continue;
+            }
+        };
+
+        if !atoms.rewrite_leaf_content(span.node_id, formatted_inner) {
+            log::warn!(
+                "Could not find leaf for injected {} span; skipping",
+                span.language
+            );
+        }
+    }
 }
 
 /// Simple helper function to read the full content of an io Read stream
@@ -344,6 +435,7 @@ fn idempotence_check(
     content: &str,
     language: &Language,
     tolerate_parsing_errors: bool,
+    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
 ) -> FormatterResult<()> {
     log::info!("Checking for idempotence ...");
 
@@ -358,6 +450,7 @@ fn idempotence_check(
             skip_idempotence: true,
             tolerate_parsing_errors,
         },
+        resolve,
     ) {
         Ok(()) => {
             let reformatted = output
@@ -403,6 +496,7 @@ mod tests {
             query: TopiaryQuery::new(&grammar, query_content).unwrap(),
             grammar,
             indent: None,
+            injection_query: None,
         };
 
         let mut result = formatter(
@@ -413,6 +507,7 @@ mod tests {
                 skip_idempotence: true,
                 tolerate_parsing_errors: false,
             },
+            None,
         );
 
         if let Some(range) = result
@@ -445,6 +540,7 @@ mod tests {
             query: TopiaryQuery::new(&grammar, &query_content).unwrap(),
             grammar,
             indent: None,
+            injection_query: None,
         };
 
         formatter(
@@ -455,6 +551,7 @@ mod tests {
                 skip_idempotence: true,
                 tolerate_parsing_errors: true,
             },
+            None,
         )
         .unwrap();
 

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -167,6 +167,9 @@ pub enum ScopeCondition {
 /// A convenience wrapper around `std::result::Result<T, FormatterError>`.
 pub type FormatterResult<T, E = FormatterError> = Result<T, rootcause::Report<E>>;
 
+/// Resolves an injected language name to a Topiary language definition.
+pub type LanguageResolver<'a> = dyn Fn(&str) -> FormatterResult<Option<Arc<Language>>> + 'a;
+
 /// Operations that can be performed by the formatter.
 #[derive(Clone, Copy, Debug)]
 pub enum Operation {
@@ -236,7 +239,7 @@ pub fn formatter(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
-    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
+    resolve: Option<&LanguageResolver<'_>>,
 ) -> FormatterResult<()> {
     let content = read_input(input)
         .context_to()
@@ -255,7 +258,7 @@ pub fn formatter_str(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
-    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
+    resolve: Option<&LanguageResolver<'_>>,
 ) -> FormatterResult<()> {
     let tolerate_parsing_errors = match operation {
         Operation::Format {
@@ -283,7 +286,7 @@ pub fn formatter_tree(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
-    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
+    resolve: Option<&LanguageResolver<'_>>,
 ) -> FormatterResult<()> {
     match operation {
         Operation::Format {
@@ -316,7 +319,7 @@ pub fn formatter_tree(
                 spans,
                 resolve,
                 tolerate_parsing_errors,
-            );
+            )?;
 
             // Various post-processing of whitespace
             atoms.post_process();
@@ -355,28 +358,23 @@ fn rewrite_injected_leaves(
     atoms: &mut atom_collection::AtomCollection,
     input_content: &str,
     spans: Vec<InjectionSpan>,
-    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
+    resolve: Option<&LanguageResolver<'_>>,
     tolerate_parsing_errors: bool,
-) {
+) -> FormatterResult<()> {
     for span in spans {
-        let Some(inner_source) = input_content.get(span.start_byte..span.end_byte) else {
-            log::warn!(
-                "Injected {} span is not on UTF-8 boundaries; skipping",
-                span.language
-            );
-            continue;
-        };
+        let inner_source = input_content
+            .get(span.start_byte..span.end_byte)
+            .ok_or_else(|| {
+                report!(FormatterError::Internal(format!(
+                    "Injected {} span is not on UTF-8 boundaries",
+                    span.language
+                )))
+            })?;
 
-        let Some(inner_language) = resolve.and_then(|resolve| resolve(&span.language)) else {
-            log::warn!(
-                "No language definition available for injected {}; skipping",
-                span.language
-            );
-            continue;
-        };
+        let inner_language = resolve_injected_language(resolve, &span.language)?;
 
         let mut formatted_inner = Vec::new();
-        if let Err(err) = formatter_str(
+        formatter_str(
             inner_source,
             &mut formatted_inner,
             &inner_language,
@@ -385,33 +383,50 @@ fn rewrite_injected_leaves(
                 tolerate_parsing_errors,
             },
             resolve,
-        ) {
-            log::warn!(
-                "Failed to format injected {} span: {}; skipping",
-                span.language,
-                err
-            );
-            continue;
-        }
+        )?;
 
-        let formatted_inner = match String::from_utf8(formatted_inner) {
-            Ok(formatted_inner) => formatted_inner.trim_end_matches('\n').to_owned(),
-            Err(err) => {
-                log::warn!(
-                    "Injected {} formatter produced invalid UTF-8: {}; skipping",
-                    span.language,
-                    err
-                );
-                continue;
-            }
-        };
+        let formatted_inner = String::from_utf8(formatted_inner)
+            .context_to()?
+            .trim_end_matches('\n')
+            .to_owned();
 
         if !atoms.rewrite_injected_leaf_content(span.node_id, formatted_inner) {
-            log::warn!(
-                "Could not find leaf for injected {} span; skipping",
+            return Err(report!(FormatterError::Internal(format!(
+                "Could not find leaf for injected {} span",
                 span.language
-            );
+            ))));
         }
+    }
+
+    Ok(())
+}
+
+fn resolve_injected_language(
+    resolve: Option<&LanguageResolver<'_>>,
+    language: &str,
+) -> FormatterResult<Arc<Language>> {
+    let Some(resolve) = resolve else {
+        return Err(report!(FormatterError::InjectionLanguageResolution {
+            language: language.to_owned(),
+        }));
+    };
+
+    match resolve(language) {
+        Ok(Some(language)) => Ok(language),
+        Ok(None) => Err(report!(FormatterError::InjectionLanguageResolution {
+            language: language.to_owned(),
+        })),
+        Err(err)
+            if matches!(
+                err.current_context(),
+                FormatterError::InjectionLanguageResolution { .. }
+            ) =>
+        {
+            Err(err)
+        }
+        Err(err) => Err(err.context(FormatterError::InjectionLanguageResolution {
+            language: language.to_owned(),
+        })),
     }
 }
 
@@ -435,7 +450,7 @@ fn idempotence_check(
     content: &str,
     language: &Language,
     tolerate_parsing_errors: bool,
-    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
+    resolve: Option<&LanguageResolver<'_>>,
 ) -> FormatterResult<()> {
     log::info!("Checking for idempotence ...");
 
@@ -615,14 +630,14 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn unresolved_injection_preserves_inner_source() {
+    async fn unresolved_injection_fails_formatting() {
         let input = r#"rule token = parse
   | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }
 "#;
         let language = ocamllex_language();
         let mut output = Vec::new();
 
-        formatter_str(
+        let result = formatter_str(
             input,
             &mut output,
             &language,
@@ -631,15 +646,47 @@ mod tests {
                 tolerate_parsing_errors: false,
             },
             None,
-        )
-        .unwrap();
-
-        let formatted = String::from_utf8(output).unwrap();
-        pretty_assert_eq(
-            r#"rule token = parse
-  | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }"#,
-            formatted.trim_end(),
         );
+
+        assert!(matches!(
+            result,
+            Err(ref report)
+                if matches!(
+                    report.current_context(),
+                    FormatterError::InjectionLanguageResolution { language } if language == "ocaml"
+                )
+        ));
+    }
+
+    #[test(tokio::test)]
+    async fn resolver_error_fails_formatting() {
+        let input = r#"rule token = parse
+  | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }
+"#;
+        let language = ocamllex_language();
+        let mut output = Vec::new();
+
+        let result = formatter_str(
+            input,
+            &mut output,
+            &language,
+            Operation::Format {
+                skip_idempotence: true,
+                tolerate_parsing_errors: false,
+            },
+            Some(&|_| Err(rootcause::report!(FormatterError::Query(
+                "resolver failed while loading language".into()
+            )))),
+        );
+
+        assert!(matches!(
+            result,
+            Err(ref report)
+                if matches!(
+                    report.current_context(),
+                    FormatterError::InjectionLanguageResolution { language } if language == "ocaml"
+                )
+        ));
     }
 
     #[test(tokio::test)]
@@ -659,7 +706,7 @@ mod tests {
                 skip_idempotence: true,
                 tolerate_parsing_errors: false,
             },
-            Some(&|name| (name == "ocaml").then_some(inner_language.clone())),
+            Some(&|name| Ok((name == "ocaml").then_some(inner_language.clone()))),
         )
         .unwrap();
 
@@ -668,6 +715,31 @@ mod tests {
             r#"rule token = parse
   | "x" { let values = [1; 2; 3] in List.map (fun x -> x + 1) values }"#,
             formatted.trim_end(),
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn invalid_injected_source_fails_formatting() {
+        let input = r#"rule token = parse
+  | "x" { let x = }
+"#;
+        let language = ocamllex_language();
+        let inner_language: Arc<Language> = Arc::new(ocaml_language());
+        let mut output = Vec::new();
+
+        let result = formatter_str(
+            input,
+            &mut output,
+            &language,
+            Operation::Format {
+                skip_idempotence: true,
+                tolerate_parsing_errors: false,
+            },
+            Some(&|name| Ok((name == "ocaml").then_some(inner_language.clone()))),
+        );
+
+        assert!(
+            matches!(result, Err(ref report) if report.current_context() == &FormatterError::Parsing)
         );
     }
 
@@ -688,7 +760,7 @@ mod tests {
                 skip_idempotence: false,
                 tolerate_parsing_errors: false,
             },
-            Some(&|name| (name == "ocaml").then_some(inner_language.clone())),
+            Some(&|name| Ok((name == "ocaml").then_some(inner_language.clone()))),
         );
 
         assert!(

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -10,7 +10,7 @@
 //! More details can be found on
 //! [GitHub](https://github.com/topiary/topiary).
 
-use std::io;
+use std::{io, sync::Arc};
 
 use pretty_assertions::StrComparison;
 use rootcause::{prelude::ResultExt, report};
@@ -236,7 +236,7 @@ pub fn formatter(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
-    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
 ) -> FormatterResult<()> {
     let content = read_input(input)
         .context_to()
@@ -255,7 +255,7 @@ pub fn formatter_str(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
-    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
 ) -> FormatterResult<()> {
     let tolerate_parsing_errors = match operation {
         Operation::Format {
@@ -283,7 +283,7 @@ pub fn formatter_tree(
     output: &mut impl io::Write,
     language: &Language,
     operation: Operation,
-    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
 ) -> FormatterResult<()> {
     match operation {
         Operation::Format {
@@ -355,7 +355,7 @@ fn rewrite_injected_leaves(
     atoms: &mut atom_collection::AtomCollection,
     input_content: &str,
     spans: Vec<InjectionSpan>,
-    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
     tolerate_parsing_errors: bool,
 ) {
     for span in spans {
@@ -379,7 +379,7 @@ fn rewrite_injected_leaves(
         if let Err(err) = formatter_str(
             inner_source,
             &mut formatted_inner,
-            inner_language,
+            &inner_language,
             Operation::Format {
                 skip_idempotence: true,
                 tolerate_parsing_errors,
@@ -435,7 +435,7 @@ fn idempotence_check(
     content: &str,
     language: &Language,
     tolerate_parsing_errors: bool,
-    resolve: Option<&dyn Fn(&str) -> Option<&Language>>,
+    resolve: Option<&dyn Fn(&str) -> Option<Arc<Language>>>,
 ) -> FormatterResult<()> {
     log::info!("Checking for idempotence ...");
 
@@ -476,6 +476,8 @@ fn idempotence_check(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use test_log::test;
 
     use crate::{
@@ -646,7 +648,7 @@ mod tests {
   | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }
 "#;
         let language = ocamllex_language();
-        let inner_language: &'static Language = Box::leak(Box::new(ocaml_language()));
+        let inner_language: Arc<Language> = Arc::new(ocaml_language());
         let mut output = Vec::new();
 
         formatter_str(
@@ -657,7 +659,7 @@ mod tests {
                 skip_idempotence: true,
                 tolerate_parsing_errors: false,
             },
-            Some(&|name| (name == "ocaml").then_some(inner_language)),
+            Some(&|name| (name == "ocaml").then_some(inner_language.clone())),
         )
         .unwrap();
 
@@ -675,7 +677,7 @@ mod tests {
   | "x" { value }
 "#;
         let language = ocamllex_language();
-        let inner_language: &'static Language = Box::leak(Box::new(unstable_ocaml_language()));
+        let inner_language: Arc<Language> = Arc::new(unstable_ocaml_language());
         let mut output = Vec::new();
 
         let result = formatter_str(
@@ -686,7 +688,7 @@ mod tests {
                 skip_idempotence: false,
                 tolerate_parsing_errors: false,
             },
-            Some(&|name| (name == "ocaml").then_some(inner_language)),
+            Some(&|name| (name == "ocaml").then_some(inner_language.clone())),
         );
 
         assert!(

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -406,7 +406,7 @@ fn rewrite_injected_leaves(
             }
         };
 
-        if !atoms.rewrite_leaf_content(span.node_id, formatted_inner) {
+        if !atoms.rewrite_injected_leaf_content(span.node_id, formatted_inner) {
             log::warn!(
                 "Could not find leaf for injected {} span; skipping",
                 span.language

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -168,6 +168,19 @@ pub enum ScopeCondition {
 pub type FormatterResult<T, E = FormatterError> = Result<T, rootcause::Report<E>>;
 
 /// Resolves an injected language name to a Topiary language definition.
+///
+/// The input is the language name declared by an injection query's
+/// `#injection_language!` predicate.
+///
+/// Return `Ok(Some(language))` when the language is available. Return
+/// `Ok(None)` when the resolver ran successfully but does not know that
+/// language. Return `Err` when resolution failed, for example because a query
+/// file, configuration entry, or grammar could not be loaded.
+///
+/// If a formatting operation encounters a matched injection, both `Ok(None)`
+/// and `Err` are hard failures. Callers may pass no resolver only when
+/// formatting languages without injection queries, or when using non-formatting
+/// operations such as visualisation.
 pub type LanguageResolver<'a> = dyn Fn(&str) -> FormatterResult<Option<Arc<Language>>> + 'a;
 
 /// Operations that can be performed by the formatter.
@@ -195,6 +208,15 @@ pub enum Operation {
 /// # Errors
 ///
 /// If formatting fails for any reason, a `FormatterError` will be returned.
+///
+/// # Language injections
+///
+/// When formatting a language with an injection query, `resolve` must provide
+/// definitions for every injected language that can be matched in the input.
+/// Matched injections are all-or-nothing: if an injected language cannot be
+/// resolved or its captured span cannot be formatted, this function returns an
+/// error. Pass `None` only for languages without injection queries, or for
+/// operations that do not format.
 ///
 /// # Examples
 ///
@@ -253,6 +275,10 @@ pub fn formatter(
 /// # Errors
 ///
 /// If formatting fails for any reason, a `FormatterError` will be returned.
+///
+/// # Language injections
+///
+/// See [`formatter`] for the `resolve` argument's semantics.
 pub fn formatter_str(
     input: &str,
     output: &mut impl io::Write,
@@ -280,6 +306,10 @@ pub fn formatter_str(
 /// # Errors
 ///
 /// If formatting fails for any reason, a `FormatterError` will be returned.
+///
+/// # Language injections
+///
+/// See [`formatter`] for the `resolve` argument's semantics.
 pub fn formatter_tree(
     tree: topiary_tree_sitter_facade::Tree,
     input_content: &str,

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -647,8 +647,7 @@ mod tests {
 "#;
         let language = ocamllex_language();
         let tree = parse(input, &language.grammar, false).unwrap();
-        let spans =
-            collect_injections(&tree, input, language.injection_query.as_ref().unwrap());
+        let spans = collect_injections(&tree, input, language.injection_query.as_ref().unwrap());
 
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].language, "ocaml");

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -325,7 +325,7 @@ pub fn formatter_tree(
         } => {
             log::debug!("Discovering potentially injected languages");
             let spans = match &language.injection_query {
-                Some(injection_query) => collect_injections(&tree, input_content, injection_query)?,
+                Some(injection_query) => collect_injections(&tree, input_content, injection_query),
                 None => Vec::new(),
             };
 
@@ -648,7 +648,7 @@ mod tests {
         let language = ocamllex_language();
         let tree = parse(input, &language.grammar, false).unwrap();
         let spans =
-            collect_injections(&tree, input, language.injection_query.as_ref().unwrap()).unwrap();
+            collect_injections(&tree, input, language.injection_query.as_ref().unwrap());
 
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].language, "ocaml");

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -212,7 +212,7 @@ pub enum Operation {
 ///
 /// let language: Language = Language {
 ///     name: "json".to_owned(),
-///     query: TopiaryQuery::new(&json.clone().into(), &query_content).unwrap(),
+///     formatting_query: TopiaryQuery::new(&json.clone().into(), &query_content).unwrap(),
 ///     grammar: json.into(),
 ///     indent: None,
 ///     injection_query: None,
@@ -306,7 +306,7 @@ pub fn formatter_tree(
             let mut atoms = tree_sitter::apply_query_tree_with_forced_leaves(
                 tree,
                 input_content,
-                &language.query,
+                &language.formatting_query,
                 injection_leaf_nodes,
             )?;
 
@@ -493,7 +493,7 @@ mod tests {
         let grammar = topiary_tree_sitter_facade::Language::from(tree_sitter_json::LANGUAGE);
         let language = Language {
             name: "json".to_owned(),
-            query: TopiaryQuery::new(&grammar, query_content).unwrap(),
+            formatting_query: TopiaryQuery::new(&grammar, query_content).unwrap(),
             grammar,
             indent: None,
             injection_query: None,
@@ -537,7 +537,7 @@ mod tests {
         let grammar = tree_sitter_json::LANGUAGE.into();
         let language = Language {
             name: "json".to_owned(),
-            query: TopiaryQuery::new(&grammar, &query_content).unwrap(),
+            formatting_query: TopiaryQuery::new(&grammar, &query_content).unwrap(),
             grammar,
             indent: None,
             injection_query: None,

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -393,7 +393,7 @@ fn rewrite_injected_leaves(
 ) -> FormatterResult<()> {
     for span in spans {
         let inner_source = input_content
-            .get(span.start_byte..span.end_byte)
+            .get(span.byte_range.clone())
             .ok_or_report()
             .context(FormatterError::Internal(
                 "Injected span is not on UTF-8 boundaries".into(),
@@ -652,7 +652,7 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].language, "ocaml");
         assert_eq!(
-            &input[spans[0].start_byte..spans[0].end_byte],
+            &input[spans[0].byte_range.clone()],
             r#"let values=[1;2;3] in List.map (fun x->x+1) values"#
         );
     }

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -121,12 +121,12 @@ fn current_column(s: &str) -> usize {
 fn add_spaces_after_newlines(s: &str, n: i32) -> String {
     let mut result = String::new();
 
-    let chars = s.chars().peekable();
+    let mut chars = s.chars().peekable();
 
-    for c in chars {
+    while let Some(c) = chars.next() {
         result.push(c);
 
-        if c == '\n' {
+        if c == '\n' && !matches!(chars.peek(), Some('\n') | None) {
             for _ in 0..n {
                 result.push(' ');
             }

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -134,9 +134,16 @@ impl InjectionQuery {
         grammar: &topiary_tree_sitter_facade::Language,
         query_content: &str,
     ) -> FormatterResult<InjectionQuery> {
-        let query = Query::new(grammar, query_content).map_err(|e| {
-            FormatterError::Query("Error parsing injection query file".into(), Some(e))
-        })?;
+        let query = Query::new(grammar, query_content)
+            .into_report()
+            .map_err(|e| {
+                let range = e.current_context().range;
+                e.attach_range(range)
+            })
+            .attach_source(query_content)
+            .context(FormatterError::Query(
+                "Error parsing injection query file".into(),
+            ))?;
 
         Ok(InjectionQuery {
             query,

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -105,6 +105,125 @@ impl TopiaryQuery {
     }
 }
 
+/// A pre-compiled query that identifies regions of a parsed source which
+/// should be formatted as a different ("injected") language.
+///
+/// An injection query captures the embedded source text with
+/// `@injection.content`, and declares the inner language via a
+/// `(#injection_language! "name")` predicate on the same pattern. For example,
+/// to mark every `(ocaml)` node within an `ocamllex` source as OCaml:
+///
+/// ```scheme
+/// ((ocaml) @injection.content
+///  (#injection_language! "ocaml"))
+/// ```
+#[derive(Debug)]
+pub struct InjectionQuery {
+    pub query: Query,
+    pub query_content: String,
+}
+
+impl InjectionQuery {
+    /// Compile `query_content` against `grammar` as an injection query.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatterError::Query`] if tree-sitter fails to parse the
+    /// query.
+    pub fn new(
+        grammar: &topiary_tree_sitter_facade::Language,
+        query_content: &str,
+    ) -> FormatterResult<InjectionQuery> {
+        let query = Query::new(grammar, query_content).map_err(|e| {
+            FormatterError::Query("Error parsing injection query file".into(), Some(e))
+        })?;
+
+        Ok(InjectionQuery {
+            query,
+            query_content: query_content.to_owned(),
+        })
+    }
+}
+
+/// A region of host source text that should be formatted as a different
+/// language, as determined by an [`InjectionQuery`].
+#[derive(Clone, Debug)]
+pub struct InjectionSpan {
+    /// Start byte (inclusive) within the host source.
+    pub start_byte: usize,
+    /// End byte (exclusive) within the host source.
+    pub end_byte: usize,
+    /// The injected language name, taken from the `#injection_language!`
+    /// predicate of the matching pattern.
+    pub language: String,
+    /// Tree-sitter id of the captured node. Valid only against the same
+    /// [`Tree`] from which these spans were collected: tree-sitter does not
+    /// guarantee node-id stability across edit-and-reparse, but within a
+    /// single parse IDs are stable. Used to locate and rewrite the
+    /// corresponding `Atom::Leaf` after the host has been atomised.
+    pub node_id: usize,
+}
+
+/// Run an [`InjectionQuery`] against a parsed `tree`, returning every
+/// `@injection.content` capture paired with the language declared by its
+/// pattern's `#injection_language!` predicate.
+///
+/// Patterns missing an `#injection_language!` predicate are skipped (with a
+/// warning logged).
+///
+/// # Errors
+///
+/// Returns an error only on internal tree-sitter failures; missing predicates
+/// or unmatched captures are logged, not raised.
+pub fn collect_injections(
+    tree: &Tree,
+    input_content: &str,
+    query: &InjectionQuery,
+) -> FormatterResult<Vec<InjectionSpan>> {
+    let root = tree.root_node();
+    let source = input_content.as_bytes();
+    let capture_names = query.query.capture_names();
+
+    let mut cursor = QueryCursor::new();
+    let mut spans = Vec::new();
+
+    let mut matches = query.query.matches(&root, source, &mut cursor);
+    #[allow(clippy::while_let_on_iterator)] // Not a normal iterator
+    while let Some(query_match) = matches.next() {
+        let language_name = query
+            .query
+            .general_predicates(query_match.pattern_index())
+            .into_iter()
+            .find_map(|p| {
+                (&*p.operator() == "injection_language!")
+                    .then(|| p.args().into_iter().next())
+                    .flatten()
+            });
+
+        let Some(language_name) = language_name else {
+            log::warn!(
+                "Injection query pattern {} has no #injection_language! predicate; skipping",
+                query_match.pattern_index()
+            );
+            continue;
+        };
+
+        for capture in query_match.captures() {
+            if capture.name(capture_names.as_slice()) == "injection.content" {
+                let node = capture.node();
+                spans.push(InjectionSpan {
+                    start_byte: node.start_byte() as usize,
+                    end_byte: node.end_byte() as usize,
+                    language: language_name.clone(),
+                    node_id: node.id() as usize,
+                });
+            }
+        }
+    }
+
+    Ok(spans)
+}
+
 impl From<Point> for Position {
     fn from(point: Point) -> Self {
         Self {
@@ -322,6 +441,15 @@ pub fn apply_query_tree(
     input_content: &str,
     query: &TopiaryQuery,
 ) -> FormatterResult<AtomCollection> {
+    apply_query_tree_with_forced_leaves(tree, input_content, query, std::iter::empty())
+}
+
+pub(crate) fn apply_query_tree_with_forced_leaves(
+    tree: Tree,
+    input_content: &str,
+    query: &TopiaryQuery,
+    forced_leaf_nodes: impl Iterator<Item = usize>,
+) -> FormatterResult<AtomCollection> {
     let root = tree.root_node();
     let source = input_content.as_bytes();
 
@@ -343,7 +471,9 @@ pub fn apply_query_tree(
 
     // Find the ids of all tree-sitter nodes that were identified as a leaf
     // We want to avoid recursing into them in the collect_leaves function.
-    let specified_leaf_nodes: HashSet<usize> = collect_leaf_ids(&matches, capture_names.clone());
+    let mut specified_leaf_nodes: HashSet<usize> =
+        collect_leaf_ids(&matches, capture_names.clone());
+    specified_leaf_nodes.extend(forced_leaf_nodes);
 
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
     let mut atoms = AtomCollection::collect_leaves(&root, source, specified_leaf_nodes)?;

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -599,7 +599,7 @@ fn check_for_error_nodes(node: &Node) -> FormatterResult<()> {
     if node.is_error() {
         return Err(report!(FormatterError::Parsing)
             .attach_range(node.range())
-            .attach_language(node.language_name()));
+            .attach_language(node.language_name().map(String::from)));
     }
 
     for child in node.children(&mut node.walk()) {

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -70,7 +70,7 @@ impl TopiaryQuery {
                 let range = e.current_context().range;
                 e.attach_range(range)
             })
-            .attach_source(query_content)?;
+            .attach_source(Some(query_content))?;
 
         Ok(TopiaryQuery {
             query,
@@ -140,7 +140,7 @@ impl InjectionQuery {
                 let range = e.current_context().range;
                 e.attach_range(range)
             })
-            .attach_source(query_content)
+            .attach_source(Some(query_content))
             .context(FormatterError::Query(
                 "Error parsing injection query file".into(),
             ))?;
@@ -582,7 +582,7 @@ pub fn parse(
 
     // Fail parsing if we don't get a complete syntax tree.
     if !tolerate_parsing_errors {
-        check_for_error_nodes(&tree.root_node()).attach_source(content)?;
+        check_for_error_nodes(&tree.root_node()).attach_source(Some(content))?;
     }
 
     Ok(tree)
@@ -593,7 +593,7 @@ fn check_for_error_nodes(node: &Node) -> FormatterResult<()> {
     if node.is_error() {
         return Err(report!(FormatterError::Parsing)
             .attach_range(node.range())
-            .attach_language(node.language_name().map(String::from)));
+            .attach_language(node.language_name()));
     }
 
     for child in node.children(&mut node.walk()) {

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -222,7 +222,7 @@ pub fn collect_injections(
                     start_byte: node.start_byte() as usize,
                     end_byte: node.end_byte() as usize,
                     language: language_name.clone(),
-                    node_id: node.id() as usize,
+                    node_id: node.id(),
                 });
             }
         }

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -156,10 +156,7 @@ impl InjectionQuery {
 /// language, as determined by an [`InjectionQuery`].
 #[derive(Clone, Debug)]
 pub struct InjectionSpan {
-    /// Start byte (inclusive) within the host source.
-    pub start_byte: usize,
-    /// End byte (exclusive) within the host source.
-    pub end_byte: usize,
+    pub byte_range: std::ops::Range<usize>,
     /// The injected language name, taken from the `#injection_language!`
     /// predicate of the matching pattern.
     pub language: String,
@@ -218,8 +215,7 @@ pub fn collect_injections(
         {
             let node = capture.node();
             spans.push(InjectionSpan {
-                start_byte: node.start_byte() as usize,
-                end_byte: node.end_byte() as usize,
+                byte_range: node.start_byte() as usize..node.end_byte() as usize,
                 language: language_name.clone(),
                 node_id: node.id(),
             });

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -178,15 +178,12 @@ pub struct InjectionSpan {
 /// Patterns missing an `#injection_language!` predicate are skipped (with a
 /// warning logged).
 ///
-/// # Errors
-///
-/// Returns an error only on internal tree-sitter failures; missing predicates
-/// or unmatched captures are logged, not raised.
+/// Missing predicates or unmatched captures are logged, not raised.
 pub fn collect_injections(
     tree: &Tree,
     input_content: &str,
     query: &InjectionQuery,
-) -> FormatterResult<Vec<InjectionSpan>> {
+) -> Vec<InjectionSpan> {
     let root = tree.root_node();
     let source = input_content.as_bytes();
     let capture_names = query.query.capture_names();
@@ -215,20 +212,21 @@ pub fn collect_injections(
             continue;
         };
 
-        for capture in query_match.captures() {
-            if capture.name(capture_names.as_slice()) == "injection.content" {
-                let node = capture.node();
-                spans.push(InjectionSpan {
-                    start_byte: node.start_byte() as usize,
-                    end_byte: node.end_byte() as usize,
-                    language: language_name.clone(),
-                    node_id: node.id(),
-                });
-            }
+        for capture in query_match
+            .captures()
+            .filter(|c| c.name(capture_names.as_slice()) == "injection.content")
+        {
+            let node = capture.node();
+            spans.push(InjectionSpan {
+                start_byte: node.start_byte() as usize,
+                end_byte: node.end_byte() as usize,
+                language: language_name.clone(),
+                node_id: node.id(),
+            });
         }
     }
 
-    Ok(spans)
+    spans
 }
 
 impl From<Point> for Position {

--- a/topiary-queries/queries/ocamllex/injections.scm
+++ b/topiary-queries/queries/ocamllex/injections.scm
@@ -1,0 +1,4 @@
+(
+  (ocaml) @injection.content
+  (#injection_language! "ocaml")
+)

--- a/topiary-queries/src/lib.rs
+++ b/topiary-queries/src/lib.rs
@@ -1,6 +1,9 @@
 /// The filename used for formatting queries within each language's query directory.
 pub const FORMATTING_QUERY: &str = "formatting.scm";
 
+/// The filename used for language injection queries within each language's query directory.
+pub const INJECTIONS_QUERY: &str = "injections.scm";
+
 /// Returns the Topiary-compatible query file for Bash.
 #[cfg(feature = "bash")]
 pub fn bash() -> &'static str {
@@ -41,6 +44,12 @@ pub fn ocaml_interface() -> &'static str {
 #[cfg(feature = "ocamllex")]
 pub fn ocamllex() -> &'static str {
     include_str!("../queries/ocamllex/formatting.scm")
+}
+
+/// Returns the Topiary-compatible injection query file for Ocamllex.
+#[cfg(feature = "ocamllex")]
+pub fn ocamllex_injections() -> &'static str {
+    include_str!("../queries/ocamllex/injections.scm")
 }
 
 /// Returns the Topiary-compatible query file for OpenSCAD.


### PR DESCRIPTION
# Add language injections for OCamllex

Resolves #579
References #400
References #573

## Description

This adds language injection support to Topiary, with OCamllex as the first supported use case. OCamllex action blocks are detected with a new `injections.scm` query and formatted using the existing OCaml formatter before being spliced back into the host OCamllex output.

The implementation adds injection-query loading, injected-language resolution in the CLI, hard-error behavior when matched injected languages cannot be resolved or formatted, and core tests covering resolution failures, parse failures, idempotence, and successful injected formatting.

This also updates the Topiary Book with language-injection documentation and adds an OCamllex injection benchmark.

## Checklist

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [x] Updated regression tests
