### PR TITLE
docs(book): add check-grammar subcommand to book navigation

### DIFF
--- a/bin/verify-documented-usage.sh
+++ b/bin/verify-documented-usage.sh
@@ -45,7 +45,7 @@ main() {
   # NOTE "index" is for the top-level usage documentation.
   # Each element in this array should correspond with a Markdown file in
   # docs/book/src/cli/usage
-  local -a subcommands=(index format visualise config completion coverage prefetch)
+  local -a subcommands=(index format visualise config completion coverage prefetch check-grammar)
 
   local _diff
   local _subcommand

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [`topiary completion`](cli/usage/completion.md)
   - [`topiary prefetch`](cli/usage/prefetch.md)
   - [`topiary coverage`](cli/usage/coverage.md)
+  - [`topiary check-grammar`](cli/usage/check-grammar.md)
 
 - [Configuration](cli/configuration.md)
 - [Runtime dialogue](cli/dialogue.md)

--- a/docs/book/src/cli/usage/check-grammar.md
+++ b/docs/book/src/cli/usage/check-grammar.md
@@ -10,15 +10,34 @@ Check if an input parses to the respective Tree-sitter grammar
 Usage: topiary check-grammar [OPTIONS] <--language <LANGUAGE>|FILES>
 
 Arguments:
-  [FILES]...  Input files and directories (omit to read from stdin)
+  [FILES]...
+          Input files and directories (omit to read from stdin)
+
+          Language detection and query selection is automatic, mapped from file extensions
+          defined in the Topiary configuration.
 
 Options:
-  -l, --language <LANGUAGE>            Topiary language identifier (when formatting stdin)
-  -q, --query <QUERY>                  Topiary query file override (when formatting stdin)
-  -L, --follow-symlinks                Follow symlinks (when formatting files)
-  -C, --configuration <CONFIGURATION>  Configuration file [env: TOPIARY_CONFIG_FILE]
-  -M, --merge-configuration            Enable merging for configuration files
-  -v, --verbose...                     Logging verbosity (increased per occurrence)
-  -h, --help                           Print help (see more with '--help')
+  -l, --language <LANGUAGE>
+          Topiary language identifier (when formatting stdin)
+
+  -q, --query <QUERY>
+          Topiary query file override (when formatting stdin)
+
+  -L, --follow-symlinks
+          Follow symlinks (when formatting files)
+
+  -C, --configuration <CONFIGURATION>
+          Configuration file
+
+          [env: TOPIARY_CONFIG_FILE]
+
+  -M, --merge-configuration
+          Enable merging for configuration files
+
+  -v, --verbose...
+          Logging verbosity (increased per occurrence)
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 <!-- usage:end -->


### PR DESCRIPTION
Closes #1218. The `check-grammar.md` usage page existed but was not linked from `SUMMARY.md`, so it never rendered in the Topiary Book as Xophmeister noted: "There is no documentation page for `topiary check-grammar` in the Topiary Book. There should be." This adds the chapter entry and includes `check-grammar` in `bin/verify-documented-usage.sh` so its usage block stays verified.