### PR TITLE
`(first|last)_leaf` memoization with FxHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,9 +3484,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -4394,6 +4394,7 @@ dependencies = [
  "prettydiff",
  "rayon",
  "rootcause",
+ "rustc-hash",
  "serde",
  "serde_json",
  "streaming-iterator",

--- a/topiary-core/Cargo.toml
+++ b/topiary-core/Cargo.toml
@@ -26,6 +26,7 @@ tree-sitter = { workspace = true }
 rayon = { workspace = true }
 thiserror = { workspace = true }
 rootcause = { workspace = true }
+rustc-hash = "2.1.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 topiary-web-tree-sitter-sys.workspace = true

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::{HashMap, HashSet},
     mem,
     ops::Deref,
@@ -62,6 +61,10 @@ pub struct AtomCollection {
     line_break_after: HashSet<usize>,
     /// Used to generate unique IDs
     counter: usize,
+    /// Cache of the first leaf for each node
+    first_leaf_cache: HashMap<usize, usize>,
+    /// Cache of the last leaf for each node
+    last_leaf_cache: HashMap<usize, usize>,
 }
 
 impl AtomCollection {
@@ -81,6 +84,8 @@ impl AtomCollection {
             line_break_before: HashSet::new(),
             line_break_after: HashSet::new(),
             counter: 0,
+            first_leaf_cache: HashMap::new(),
+            last_leaf_cache: HashMap::new(),
         }
     }
 
@@ -109,6 +114,8 @@ impl AtomCollection {
             line_break_before: line_break_nodes.before,
             line_break_after: line_break_nodes.after,
             counter: 0,
+            first_leaf_cache: HashMap::new(),
+            last_leaf_cache: HashMap::new(),
         };
 
         atoms.collect_leaves_inner(root, source, &Vec::new(), 0)?;
@@ -604,15 +611,14 @@ impl AtomCollection {
     fn prepend(&mut self, atom: Atom, node: &Node, predicates: &QueryPredicates) {
         let atom = self.expand_multiline(atom, node);
         let atom = self.wrap(atom, predicates);
-        // TODO: Pre-populate these
-        let target_node = self.first_leaf(node);
+        let target_node_id = self.first_leaf(node);
 
         log::debug!(
-            "Prepending {atom:?} to node {}",
-            target_node.display_one_based()
+            "Prepending {atom:?} to node ID {}",
+            target_node_id
         );
 
-        self.prepend.entry(target_node.id()).or_default().push(atom);
+        self.prepend.entry(target_node_id).or_default().push(atom);
     }
 
     /// Append an atom to the last leaf node in the subtree of a given node.
@@ -625,14 +631,14 @@ impl AtomCollection {
     fn append(&mut self, atom: Atom, node: &Node, predicates: &QueryPredicates) {
         let atom = self.expand_multiline(atom, node);
         let atom = self.wrap(atom, predicates);
-        let target_node = self.last_leaf(node);
+        let target_node_id = self.last_leaf(node);
 
         log::debug!(
-            "Appending {atom:?} to node {}",
-            target_node.display_one_based()
+            "Appending {atom:?} to node ID {}",
+            target_node_id
         );
 
-        self.append.entry(target_node.id()).or_default().push(atom);
+        self.append.entry(target_node_id).or_default().push(atom);
     }
 
     /// Expands a softline atom to a hardline, space or empty atom depending on
@@ -1067,13 +1073,33 @@ impl AtomCollection {
     ///
     /// # Returns
     ///
-    /// A `Cow` enum that wraps a borrowed node.
-    fn first_leaf<'tree, 'node: 'tree>(&self, node: &'node Node<'tree>) -> Cow<'node, Node<'tree>> {
-        let mut node = Cow::Borrowed(node);
-        while node.child_count() != 0 && !self.specified_leaf_nodes.contains(&node.id()) {
-            node = Cow::Owned(node.child(0).unwrap());
+    /// The ID of the first leaf node.
+    fn first_leaf(&mut self, node: &Node) -> usize {
+        if let Some(id) = self.first_leaf_cache.get(&node.id()) {
+            return *id;
         }
-        node
+
+        let mut path = Vec::new();
+        let mut current_node = std::borrow::Cow::Borrowed(node);
+
+        while current_node.child_count() != 0 && !self.specified_leaf_nodes.contains(&current_node.id()) {
+            if let Some(id) = self.first_leaf_cache.get(&current_node.id()) {
+                let leaf_id = *id;
+                for path_id in path {
+                    self.first_leaf_cache.insert(path_id, leaf_id);
+                }
+                return leaf_id;
+            }
+            path.push(current_node.id());
+            current_node = std::borrow::Cow::Owned(current_node.child(0).unwrap());
+        }
+
+        let leaf_id = current_node.id();
+        for path_id in path {
+            self.first_leaf_cache.insert(path_id, leaf_id);
+        }
+        self.first_leaf_cache.insert(leaf_id, leaf_id);
+        leaf_id
     }
 
     /// Returns the last leaf node of a given node's subtree.
@@ -1089,13 +1115,33 @@ impl AtomCollection {
     ///
     /// # Returns
     ///
-    /// A `Cow` enum that wraps a borrowed node.
-    fn last_leaf<'tree, 'node: 'tree>(&self, node: &'node Node<'tree>) -> Cow<'node, Node<'tree>> {
-        let mut node = Cow::Borrowed(node);
-        while node.child_count() != 0 && !self.specified_leaf_nodes.contains(&node.id()) {
-            node = Cow::Owned(node.child(node.child_count() - 1).unwrap());
+    /// The ID of the last leaf node.
+    fn last_leaf(&mut self, node: &Node) -> usize {
+        if let Some(id) = self.last_leaf_cache.get(&node.id()) {
+            return *id;
         }
-        node
+
+        let mut path = Vec::new();
+        let mut current_node = std::borrow::Cow::Borrowed(node);
+
+        while current_node.child_count() != 0 && !self.specified_leaf_nodes.contains(&current_node.id()) {
+            if let Some(id) = self.last_leaf_cache.get(&current_node.id()) {
+                let leaf_id = *id;
+                for path_id in path {
+                    self.last_leaf_cache.insert(path_id, leaf_id);
+                }
+                return leaf_id;
+            }
+            path.push(current_node.id());
+            current_node = std::borrow::Cow::Owned(current_node.child(current_node.child_count() - 1).unwrap());
+        }
+
+        let leaf_id = current_node.id();
+        for path_id in path {
+            self.last_leaf_cache.insert(path_id, leaf_id);
+        }
+        self.last_leaf_cache.insert(leaf_id, leaf_id);
+        leaf_id
     }
 }
 

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashMap;
 use std::{
     collections::{HashMap, HashSet},
     mem,
@@ -62,9 +63,9 @@ pub struct AtomCollection {
     /// Used to generate unique IDs
     counter: usize,
     /// Cache of the first leaf for each node
-    first_leaf_cache: HashMap<usize, usize>,
+    first_leaf_cache: FxHashMap<usize, usize>,
     /// Cache of the last leaf for each node
-    last_leaf_cache: HashMap<usize, usize>,
+    last_leaf_cache: FxHashMap<usize, usize>,
 }
 
 impl AtomCollection {
@@ -84,8 +85,8 @@ impl AtomCollection {
             line_break_before: HashSet::new(),
             line_break_after: HashSet::new(),
             counter: 0,
-            first_leaf_cache: HashMap::new(),
-            last_leaf_cache: HashMap::new(),
+            first_leaf_cache: FxHashMap::default(),
+            last_leaf_cache: FxHashMap::default(),
         }
     }
 
@@ -114,8 +115,8 @@ impl AtomCollection {
             line_break_before: line_break_nodes.before,
             line_break_after: line_break_nodes.after,
             counter: 0,
-            first_leaf_cache: HashMap::new(),
-            last_leaf_cache: HashMap::new(),
+            first_leaf_cache: FxHashMap::default(),
+            last_leaf_cache: FxHashMap::default(),
         };
 
         atoms.collect_leaves_inner(root, source, &Vec::new(), 0)?;
@@ -613,10 +614,7 @@ impl AtomCollection {
         let atom = self.wrap(atom, predicates);
         let target_node_id = self.first_leaf(node);
 
-        log::debug!(
-            "Prepending {atom:?} to node ID {}",
-            target_node_id
-        );
+        log::debug!("Prepending {atom:?} to node ID {}", target_node_id);
 
         self.prepend.entry(target_node_id).or_default().push(atom);
     }
@@ -633,10 +631,7 @@ impl AtomCollection {
         let atom = self.wrap(atom, predicates);
         let target_node_id = self.last_leaf(node);
 
-        log::debug!(
-            "Appending {atom:?} to node ID {}",
-            target_node_id
-        );
+        log::debug!("Appending {atom:?} to node ID {}", target_node_id);
 
         self.append.entry(target_node_id).or_default().push(atom);
     }
@@ -1082,7 +1077,9 @@ impl AtomCollection {
         let mut path = Vec::new();
         let mut current_node = std::borrow::Cow::Borrowed(node);
 
-        while current_node.child_count() != 0 && !self.specified_leaf_nodes.contains(&current_node.id()) {
+        while current_node.child_count() != 0
+            && !self.specified_leaf_nodes.contains(&current_node.id())
+        {
             if let Some(id) = self.first_leaf_cache.get(&current_node.id()) {
                 let leaf_id = *id;
                 for path_id in path {
@@ -1124,7 +1121,9 @@ impl AtomCollection {
         let mut path = Vec::new();
         let mut current_node = std::borrow::Cow::Borrowed(node);
 
-        while current_node.child_count() != 0 && !self.specified_leaf_nodes.contains(&current_node.id()) {
+        while current_node.child_count() != 0
+            && !self.specified_leaf_nodes.contains(&current_node.id())
+        {
             if let Some(id) = self.last_leaf_cache.get(&current_node.id()) {
                 let leaf_id = *id;
                 for path_id in path {
@@ -1133,7 +1132,9 @@ impl AtomCollection {
                 return leaf_id;
             }
             path.push(current_node.id());
-            current_node = std::borrow::Cow::Owned(current_node.child(current_node.child_count() - 1).unwrap());
+            current_node = std::borrow::Cow::Owned(
+                current_node.child(current_node.child_count() - 1).unwrap(),
+            );
         }
 
         let leaf_id = current_node.id();


### PR DESCRIPTION
# `(first|last)_leaf` memoization with FxHash

## Description
There was a TODO in `atom_collection` to prepopulate the `first_leaf` calls. I tried this, but measured a performance degration. Instead, I switched to a memoization approach. Calls to `(first|last)_leaf` are now stored in a hashmap and recalled from there on future invocations. The hashmap is backed by `rustc-hash`.

**Criterion Benchmarks (`cargo bench -p topiary-core` on `format_nickel`):**

**Before (main):**
```text
format_nickel           time:   [137.88 ms 138.35 ms 138.90 ms]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```

**After (Lazy Caching + FxHash):**
```text
format_nickel           time:   [135.46 ms 135.85 ms 136.29 ms]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

## Checklist
Checklist before merging, wherever relevant:

- [ ] `CHANGELOG.md` updated
- [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [ ] Updated regression tests
