### PR TITLE
bench(core): Remove async calls and setup from `format_nickel` benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ This name should be decided amongst the team before the release.
 - [#1174](https://github.com/topiary/topiary/pull/1174) Split out the Topiary Playground into its own repository.
 - [#1191](https://github.com/topiary/topiary/pull/1191) Split out the Topiary website into its own repository.
 - [#1226](https://github.com/topiary/topiary/pull/1226) Query files moved from `queries/<lang>.scm` to `queries/<lang>/formatting.scm` in preparation for language injection support. The old flat layout is still supported as a fallback.
-- [#1226](https://github.com/topiary/topiary/pull/1232) Rework `topiary_core::ErrorSpan` to handle `QueryError`s as well as `Node` errors by introducing `rootcause::Report`
+- [#1232](https://github.com/topiary/topiary/pull/1232) Rework `topiary_core::ErrorSpan` to handle `QueryError`s as well as `Node` errors by introducing `rootcause::Report`
+- [#1249](https://github.com/topiary/topiary/pull/1249) Remove async calls and setup from `format_nickel` benchmark
 
 ### Fixed
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -25,7 +25,8 @@ fn setup() -> (String, Language) {
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("format_nickel", |b| {
         let (input, language) = setup();
-        b.iter(|| {
+        // https://criterion-rs.github.io/book/user_guide/timing_loops.html#iter_with_large_drop
+        b.iter_with_large_drop(|| {
             let mut input = input.as_bytes();
             let mut output = io::BufWriter::new(Vec::new());
             formatter(
@@ -37,7 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     tolerate_parsing_errors: false,
                 },
             )
-            .unwrap()
+            .unwrap();
         });
     });
 }

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -1,10 +1,9 @@
-use criterion::async_executor::FuturesExecutor;
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::fs;
 use std::io;
 use topiary_core::{Language, Operation, TopiaryQuery, formatter};
 
-async fn format() {
+fn setup() -> (String, Language) {
     let input = fs::read_to_string("../topiary-cli/tests/samples/input/nickel.ncl").unwrap();
     let query_content = fs::read_to_string(format!(
         "../topiary-queries/queries/nickel/{}",
@@ -13,9 +12,6 @@ async fn format() {
     .unwrap();
     let nickel = tree_sitter_nickel::LANGUAGE;
 
-    let mut input = input.as_bytes();
-    let mut output = io::BufWriter::new(Vec::new());
-
     let language: Language = Language {
         name: "nickel".to_owned(),
         query: TopiaryQuery::new(&nickel.into(), &query_content).unwrap(),
@@ -23,21 +19,26 @@ async fn format() {
         indent: None,
     };
 
-    formatter(
-        &mut input,
-        &mut output,
-        &language,
-        Operation::Format {
-            skip_idempotence: true,
-            tolerate_parsing_errors: false,
-        },
-    )
-    .unwrap();
+    (input, language)
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("format_nickel", |b| {
-        b.to_async(FuturesExecutor).iter(format);
+        let (input, language) = setup();
+        b.iter(|| {
+            let mut input = input.as_bytes();
+            let mut output = io::BufWriter::new(Vec::new());
+            formatter(
+                &mut input,
+                &mut output,
+                &language,
+                Operation::Format {
+                    skip_idempotence: true,
+                    tolerate_parsing_errors: false,
+                },
+            )
+            .unwrap()
+        });
     });
 }
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
# Remove async calls and setup from `format_nickel` benchmark

References https://github.com/topiary/topiary/pull/1247

## Description

https://github.com/topiary/topiary/pull/1247#issuecomment-4576895778

Attempt to remove noise from current formatting benchmark by converting the bencher to be synchronous and move the setup steps (grammar creation and file reads) outside of the benchmark iteration

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date