### PR TITLE
refactor!: remove TOPIARY_LANGUAGE_DIR and shift query_dir to Configur…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This name should be decided amongst the team before the release.
 
 ### Removed
 - <Removed features>
+- [#1250](https://github.com/topiary/topiary/pull/1250) The `TOPIARY_LANGUAGE_DIR` environment variable has been completely removed in favor of the new `--query-dir` CLI flag and `topiary-config`'s auto-detection.
 
 ### Fixed
 - <Bug fixes>
@@ -63,6 +64,7 @@ This name should be decided amongst the team before the release.
 - [#1217](https://github.com/topiary/topiary/pull/1217) Add `--check` flag to `topiary fmt` for CI formatting verification.
 - [#1227](https://github.com/topiary/topiary/pull/1227) Add `@append_empty_input_softline` and `@prepend_empty_input_softline` captures, thanks to @BirdeeHub
 - [#1244](https://github.com/topiary/topiary/pull/1244) Add language injection support for injection languages known at query writing.
+- [#1250](https://github.com/topiary/topiary/pull/1250) Added `--query-dir` CLI flag to override the default query directory.
 - [#1254](https://github.com/topiary/topiary/pull/1254) Add Markdown formatting support with dynamic language injections for fenced code blocks (via the `@injection.language` capture).
 
 ### Removed

--- a/docs/book/src/cli/dialogue.md
+++ b/docs/book/src/cli/dialogue.md
@@ -9,9 +9,10 @@ However, if you are developing custom queries or need to override the default qu
 
 1. The `--query-dir` CLI argument, if provided.
 2. An adjacent `queries/` folder in the same directory as the loaded configuration file (e.g., `~/.config/topiary/queries/`).
-3. `topiary-queries/queries` in the current working directory.
-4. `topiary-queries/queries` in the parent of the current directory.
-5. The compiled-in default queries.
+3. The `query_dir` explicitly set inside the configuration file.
+4. `topiary-queries/queries` in the current working directory.
+5. `topiary-queries/queries` in the parent of the current directory.
+6. The compiled-in default queries.
 
 That is to say, you can easily use your own queries by either placing them in a `queries/` folder next to your `languages.ncl` configuration file, or by explicitly passing `--query-dir` to the CLI:
 

--- a/docs/book/src/cli/dialogue.md
+++ b/docs/book/src/cli/dialogue.md
@@ -3,36 +3,21 @@
 ## Environment variables
 
 Topiary needs to find [language query files](../getting-started/on-tree-sitter.md)
-(`*.scm`) to function properly. By default, Topiary looks for these
-under the following search paths, from highest to lowest priority:
+(`*.scm`) to function properly. By default, Topiary includes standard queries bundled directly into the binary at compile time.
 
-<!-- This probably should change: see Issue #1003 -->
-1. Per the `TOPIARY_LANGUAGE_DIR` environment variable, as set at
-   runtime.
-2. A built-in value, which was set by the `TOPIARY_LANGUAGE_DIR`
-   environment variable at build time.
+However, if you are developing custom queries or need to override the default queries, Topiary looks for query directories in the following priority order:
+
+1. The `--query-dir` CLI argument, if provided.
+2. An adjacent `queries/` folder in the same directory as the loaded configuration file (e.g., `~/.config/topiary/queries/`).
 3. `topiary-queries/queries` in the current working directory.
 4. `topiary-queries/queries` in the parent of the current directory.
+5. The compiled-in default queries.
 
-That is to say, if you are running Topiary from a directory other than
-its repository, **you must set the environment variable
-`TOPIARY_LANGUAGE_DIR` to point to the directory where Topiary's
-language query files are located**.
-
-By default, you should set it to `<local path of the Topiary
-repository>/topiary-queries/queries`, for example:
+That is to say, you can easily use your own queries by either placing them in a `queries/` folder next to your `languages.ncl` configuration file, or by explicitly passing `--query-dir` to the CLI:
 
 ```sh
-export TOPIARY_LANGUAGE_DIR=/home/me/tools/topiary/topiary-queries/queries
-topiary format ./projects/helloworld/hello.ml
+topiary format --query-dir /home/me/tools/topiary/topiary-queries/queries ./projects/helloworld/hello.ml
 ```
-
-`TOPIARY_LANGUAGE_DIR` can alternatively be set at build time. Topiary
-will pick the correspond path up and embed it into the `topiary` binary.
-In that case, you don't have to worry about making
-`TOPIARY_LANGUAGE_DIR` available at runtime any more. When
-`TOPIARY_LANGUAGE_DIR` has been set at build time and is set at runtime
-as well, the runtime value takes precedence.
 
 See [the contributor's guide](../guides/contributing.md) for details on
 setting up a development environment.

--- a/docs/book/src/cli/usage/check-grammar.md
+++ b/docs/book/src/cli/usage/check-grammar.md
@@ -34,6 +34,9 @@ Options:
   -M, --merge-configuration
           Enable merging for configuration files
 
+      --query-dir <QUERY_DIR>
+          Override the directory where queries are found
+
   -v, --verbose...
           Logging verbosity (increased per occurrence)
 

--- a/docs/book/src/cli/usage/completion.md
+++ b/docs/book/src/cli/usage/completion.md
@@ -18,6 +18,7 @@ Arguments:
 Options:
   -C, --configuration <CONFIGURATION>  Configuration file [env: TOPIARY_CONFIG_FILE]
   -M, --merge-configuration            Enable merging for configuration files
+      --query-dir <QUERY_DIR>          Override the directory where queries are found
   -v, --verbose...                     Logging verbosity (increased per occurrence)
   -h, --help                           Print help
 ```

--- a/docs/book/src/cli/usage/config.md
+++ b/docs/book/src/cli/usage/config.md
@@ -14,6 +14,7 @@ Commands:
 Options:
   -C, --configuration <CONFIGURATION>  Configuration file [env: TOPIARY_CONFIG_FILE]
   -M, --merge-configuration            Enable merging for configuration files
+      --query-dir <QUERY_DIR>          Override the directory where queries are found
   -v, --verbose...                     Logging verbosity (increased per occurrence)
   -h, --help                           Print help
 ```

--- a/docs/book/src/cli/usage/coverage.md
+++ b/docs/book/src/cli/usage/coverage.md
@@ -34,6 +34,9 @@ Options:
   -M, --merge-configuration
           Enable merging for configuration files
 
+      --query-dir <QUERY_DIR>
+          Override the directory where queries are found
+
   -v, --verbose...
           Logging verbosity (increased per occurrence)
 

--- a/docs/book/src/cli/usage/format.md
+++ b/docs/book/src/cli/usage/format.md
@@ -41,6 +41,9 @@ Options:
   -M, --merge-configuration
           Enable merging for configuration files
 
+      --query-dir <QUERY_DIR>
+          Override the directory where queries are found
+
   -v, --verbose...
           Logging verbosity (increased per occurrence)
 

--- a/docs/book/src/cli/usage/index.md
+++ b/docs/book/src/cli/usage/index.md
@@ -24,6 +24,7 @@ Commands:
 Options:
   -C, --configuration <CONFIGURATION>  Configuration file [env: TOPIARY_CONFIG_FILE]
   -M, --merge-configuration            Enable merging for configuration files
+      --query-dir <QUERY_DIR>          Override the directory where queries are found
   -v, --verbose...                     Logging verbosity (increased per occurrence)
   -h, --help                           Print help
   -V, --version                        Print version

--- a/docs/book/src/cli/usage/prefetch.md
+++ b/docs/book/src/cli/usage/prefetch.md
@@ -18,6 +18,7 @@ Options:
   -f, --force                          Re-fetch existing grammars if they already exist
   -C, --configuration <CONFIGURATION>  Configuration file [env: TOPIARY_CONFIG_FILE]
   -M, --merge-configuration            Enable merging for configuration files
+      --query-dir <QUERY_DIR>          Override the directory where queries are found
   -v, --verbose...                     Logging verbosity (increased per occurrence)
   -h, --help                           Print help
 ```

--- a/docs/book/src/cli/usage/visualise.md
+++ b/docs/book/src/cli/usage/visualise.md
@@ -48,6 +48,9 @@ Options:
   -M, --merge-configuration
           Enable merging for configuration files
 
+      --query-dir <QUERY_DIR>
+          Override the directory where queries are found
+
   -v, --verbose...
           Logging verbosity (increased per occurrence)
 

--- a/nix/packages/topiary.nix
+++ b/nix/packages/topiary.nix
@@ -123,15 +123,7 @@ let
           cp -r topiary-queries/queries/* $out/share/queries
         '';
 
-        # Set TOPIARY_LANGUAGE_DIR to the Nix store
-        # for the build
-        TOPIARY_LANGUAGE_DIR = "${placeholder "out"}/share/queries";
-
-        # Set TOPIARY_LANGUAGE_DIR to the working directory
-        # in a development shell
-        shellHook = ''
-          export TOPIARY_LANGUAGE_DIR=$PWD/queries
-        '';
+        # No longer using TOPIARY_LANGUAGE_DIR
 
         meta.mainProgram = "topiary";
       }

--- a/nix/packages/topiary.nix
+++ b/nix/packages/topiary.nix
@@ -118,12 +118,7 @@ let
         preConfigurePhases = optional prefetchGrammars "prepareTopiaryDefaultConfiguration";
         inherit prepareTopiaryDefaultConfiguration;
 
-        postInstall = ''
-          mkdir -p $out/share/queries
-          cp -r topiary-queries/queries/* $out/share/queries
-        '';
 
-        # No longer using TOPIARY_LANGUAGE_DIR
 
         meta.mainProgram = "topiary";
       }

--- a/topiary-cli/src/cli.rs
+++ b/topiary-cli/src/cli.rs
@@ -41,6 +41,10 @@ pub struct GlobalArgs {
     )]
     pub configuration: Option<PathBuf>,
 
+    /// Override the directory where queries are found
+    #[arg(long, display_order = 101, global = true)]
+    pub query_dir: Option<PathBuf>,
+
     /// Enable merging for configuration files
     #[arg(alias = "merge", short = 'M', long, display_order = 101, global = true)]
     pub merge_configuration: bool,

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -241,12 +241,12 @@ pub(crate) async fn to_language_from_config<T: AsRef<str>>(
 ) -> CLIResult<Language> {
     let config_language = config.get_language(name.as_ref())?;
     let grammar = config_language.grammar()?;
-    let query_source = to_query_from_language(config_language)?;
+    let query_source = to_query_from_config(config, &config_language.name)?;
     let query_content = query_source.get_content().await?;
     let formatting_query = TopiaryQuery::new(&grammar, &query_content)
         .attach_filepath(query_source.filepath())
         .context(FormatterError::Parsing)?;
-    let injection_query = match to_injection_query_from_language(config_language) {
+    let injection_query = match to_injection_query_from_config(config, &config_language.name) {
         Some(source) => {
             let contents = source.get_content().await?;
             Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
@@ -269,12 +269,12 @@ pub(crate) fn to_language_from_config_sync<T: AsRef<str> + fmt::Display>(
 ) -> CLIResult<Language> {
     let config_language = config.get_language(name.as_ref())?;
     let grammar = config_language.grammar()?;
-    let query_source = to_query_from_language(config_language)?;
+    let query_source = to_query_from_config(config, &config_language.name)?;
     let query_content = query_source.get_content_sync()?;
     let formatting_query = TopiaryQuery::new(&grammar, &query_content)
         .attach_filepath(query_source.filepath())
         .context(FormatterError::Parsing)?;
-    let injection_query = match to_injection_query_from_language(config_language) {
+    let injection_query = match to_injection_query_from_config(config, &config_language.name) {
         Some(source) => {
             let contents = source.get_content_sync()?;
             Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
@@ -332,9 +332,9 @@ impl<'cfg, 'i> Inputs<'cfg> {
                         // The user specified a query file
                         Some(p) => p,
                         // The user did not specify a file, try the default locations
-                        None => to_query_from_language(language)?,
+                        None => to_query_from_config(config, &language.name)?,
                     };
-                    let injection_query = to_injection_query_from_language(language);
+                    let injection_query = to_injection_query_from_config(config, &language.name);
                     Ok(InputFile {
                         source: InputSource::Stdin,
                         language,
@@ -348,8 +348,8 @@ impl<'cfg, 'i> Inputs<'cfg> {
                 .into_iter()
                 .map(|path| {
                     let language = config.detect(&path)?;
-                    let query: QuerySource = to_query_from_language(language)?;
-                    let injection_query = to_injection_query_from_language(language);
+                    let query: QuerySource = to_query_from_config(config, &language.name)?;
+                    let injection_query = to_injection_query_from_config(config, &language.name);
 
                     Ok(InputFile {
                         source: InputSource::Disk(path.into(), None),
@@ -366,10 +366,11 @@ impl<'cfg, 'i> Inputs<'cfg> {
 }
 
 #[allow(clippy::result_large_err)]
-pub(crate) fn to_query_from_language(
-    language: &topiary_config::language::Language,
+pub(crate) fn to_query_from_config(
+    config: &Configuration,
+    language_name: &str,
 ) -> CLIResult<QuerySource> {
-    let query: QuerySource = match language.find_query_file() {
+    let query: QuerySource = match config.find_query_file(language_name) {
         Ok(p) => p.into(),
         // For some reason, Topiary could not find any
         // matching file in a default location. As a final attempt, try the
@@ -379,19 +380,20 @@ pub(crate) fn to_query_from_language(
             log::warn!(
                 "No query files found in any of the expected locations. Falling back to compile-time included files."
             );
-            to_query(&language.name).map_err(|_| e)?
+            to_query(language_name).map_err(|_| e)?
         }
     };
     Ok(query)
 }
 
-pub(crate) fn to_injection_query_from_language(
-    language: &topiary_config::language::Language,
+pub(crate) fn to_injection_query_from_config(
+    config: &Configuration,
+    language_name: &str,
 ) -> Option<QuerySource> {
-    language
-        .find_injections_file()
+    config
+        .find_injections_file(language_name)
         .map(Into::into)
-        .or_else(|| to_injection_query(&language.name))
+        .or_else(|| to_injection_query(language_name))
 }
 
 fn to_injection_query<T>(name: T) -> Option<QuerySource>

--- a/topiary-cli/src/language.rs
+++ b/topiary-cli/src/language.rs
@@ -13,8 +13,8 @@ use topiary_core::Language;
 use crate::{
     error::CLIResult,
     io::{
-        InputFile, to_injection_query_from_language, to_language_from_config_sync,
-        to_query_from_language,
+        InputFile, to_injection_query_from_config, to_language_from_config_sync,
+        to_query_from_config,
     },
 };
 
@@ -93,9 +93,9 @@ impl LanguageDefinitionCache {
         config: &Configuration,
         name: &str,
     ) -> CLIResult<Arc<Language>> {
-        let config_language = config.get_language(name)?;
-        let formatting_query = to_query_from_language(config_language)?;
-        let injection_query = to_injection_query_from_language(config_language);
+        config.ensure_language(name)?;
+        let formatting_query = to_query_from_config(config, name)?;
+        let injection_query = to_injection_query_from_config(config, name);
         let key = Self::key_for_parts(name, &formatting_query, injection_query.as_ref());
 
         let mut cache = self.cache.lock().expect("language cache mutex poisoned");

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -71,11 +71,12 @@ async fn run() -> CLIResult<()> {
     let query_dir = args.global.query_dir.clone();
 
     let file_config = &args.global.configuration;
-    let (config, nickel_config) = topiary_config::Configuration::fetch(
-        args.global.merge_configuration,
-        file_config,
-        query_dir,
-    )?;
+    let (mut config, nickel_config) =
+        topiary_config::Configuration::fetch(args.global.merge_configuration, file_config)?;
+
+    if let Some(query_dir) = query_dir {
+        config.set_query_dir(query_dir);
+    }
 
     // Delegate by subcommand
     match args.command {

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -68,9 +68,14 @@ async fn main() -> ExitCode {
 async fn run() -> CLIResult<()> {
     let args = cli::get_args()?;
 
+    let query_dir = args.global.query_dir.clone();
+
     let file_config = &args.global.configuration;
-    let (config, nickel_config) =
-        topiary_config::Configuration::fetch(args.global.merge_configuration, file_config)?;
+    let (config, nickel_config) = topiary_config::Configuration::fetch(
+        args.global.merge_configuration,
+        file_config,
+        query_dir,
+    )?;
 
     // Delegate by subcommand
     match args.command {

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -88,7 +88,6 @@ fn test_fmt_stdin() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg("--language")
         .arg("json")
@@ -105,7 +104,6 @@ fn test_fmt_stdin_query() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg("--language")
         .arg("json")
@@ -127,8 +125,6 @@ fn test_fmt_stdin_query_fallback() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        // run in topiary-cli/tests directory so that it couldn't find the
-        // default TOPIARY_LANGUAGE_DIR
         .current_dir("tests")
         .arg("fmt")
         .arg("--language")
@@ -149,7 +145,6 @@ fn test_fmt_files() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg(json.path())
         .arg(toml.path())
@@ -170,8 +165,6 @@ fn test_fmt_files_query_fallback() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        // run in topiary-cli/tests directory so that it couldn't find the
-        // default TOPIARY_LANGUAGE_DIR
         .current_dir("tests")
         .arg("fmt")
         .arg(json.path())
@@ -192,7 +185,6 @@ fn test_fmt_dir() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg(json.path().parent().unwrap())
         .assert()
@@ -208,7 +200,6 @@ fn test_check_stdin_clean() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg("--check")
         .arg("--language")
@@ -225,7 +216,6 @@ fn test_check_stdin_dirty() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg("--check")
         .arg("--language")
@@ -245,7 +235,6 @@ fn test_check_file_dirty_no_modify() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg("--check")
         .arg(json.path())
@@ -265,7 +254,6 @@ fn test_check_file_clean() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg("--check")
         .arg(json.path())
@@ -281,7 +269,6 @@ fn test_fmt_invalid() {
 
     // Can't specify --language with input files
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
         .arg("--language")
         .arg("json")
@@ -291,7 +278,6 @@ fn test_fmt_invalid() {
 
     // Can't specify --query without --language
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../whatever")
         .arg("fmt")
         .arg("--query")
         .arg("/path/to/query")
@@ -369,7 +355,6 @@ fn test_vis() {
     let is_graph = starts_with("graph {").and(ends_with("}\n"));
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("vis")
         .arg("--language")
         .arg("json")
@@ -387,7 +372,6 @@ fn test_vis_invalid() {
 
     // Can't specify --language with input file
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("vis")
         .arg("--language")
         .arg("json")
@@ -397,7 +381,6 @@ fn test_vis_invalid() {
 
     // Can't specify --query without --language
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("vis")
         .arg("--query")
         .arg("/path/to/query")
@@ -406,7 +389,6 @@ fn test_vis_invalid() {
 
     // Can't specify multiple input files
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("vis")
         .arg("/path/to/some/input")
         .arg("/path/to/another/input")
@@ -418,12 +400,7 @@ fn test_vis_invalid() {
 fn test_cfg() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
-    topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
-        .arg("cfg")
-        .assert()
-        .success()
-        .stdout(IsToml);
+    topiary.arg("cfg").assert().success().stdout(IsToml);
 }
 
 struct IsToml;

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -295,8 +295,9 @@ fn test_fmt_ocamllex_invalid_inner_ocaml_fails() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
         .arg("fmt")
+        .arg("--query-dir")
+        .arg("../topiary-queries/queries")
         .arg("--language")
         .arg("ocamllex")
         .write_stdin(input)
@@ -322,8 +323,9 @@ fn test_fmt_ocamllex_broken_inner_language_resolution_fails() {
     let mut topiary = cargo_bin_cmd!("topiary");
 
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", tmp_dir.path())
         .arg("fmt")
+        .arg("--query-dir")
+        .arg(tmp_dir.path())
         .arg("--language")
         .arg("ocamllex")
         .write_stdin(r#"rule token = parse | "x" { let values=[1;2;3] in values }"#)

--- a/topiary-cli/tests/sample-tester.rs
+++ b/topiary-cli/tests/sample-tester.rs
@@ -63,7 +63,6 @@ mod test_fmt {
         // Run Topiary against the staged input file
         let mut topiary = cargo_bin_cmd!("topiary");
         let output = topiary
-            .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
             .arg("fmt")
             .arg(&staged)
             .output()
@@ -123,12 +122,7 @@ mod test_fmt {
 
                 // Run topiary on the input file in the temp dir
                 let mut topiary = cargo_bin_cmd!("topiary");
-                topiary
-                    .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
-                    .arg("fmt")
-                    .arg(&input_file)
-                    .assert()
-                    .success();
+                topiary.arg("fmt").arg(&input_file).assert().success();
 
                 // Read the file after formatting
                 let formatted = fs::read_to_string(input_file).unwrap();
@@ -155,7 +149,6 @@ mod test_check {
         // The input file is unformatted, so --check should fail
         let mut topiary = cargo_bin_cmd!("topiary");
         topiary
-            .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
             .arg("fmt")
             .arg("--check")
             .arg(&input)
@@ -165,7 +158,6 @@ mod test_check {
         // The expected file is already formatted, so --check should succeed
         let mut topiary = cargo_bin_cmd!("topiary");
         topiary
-            .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
             .arg("fmt")
             .arg("--check")
             .arg(&expected)
@@ -207,7 +199,6 @@ mod test_coverage {
         // Run `topiary coverage` against the input file
         let mut topiary = cargo_bin_cmd!("topiary");
         let output = topiary
-            .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
             .arg("coverage")
             .arg(&input)
             .output()
@@ -263,12 +254,7 @@ fn formatted_query_tester() {
 
             // Run topiary on the input file in the temp dir
             let mut topiary = cargo_bin_cmd!("topiary");
-            topiary
-                .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries/")
-                .arg("fmt")
-                .arg(&input_file)
-                .assert()
-                .success();
+            topiary.arg("fmt").arg(&input_file).assert().success();
 
             // Read the file after formatting
             let formatted = fs::read_to_string(input_file).unwrap();

--- a/topiary-config/src/error.rs
+++ b/topiary-config/src/error.rs
@@ -10,7 +10,7 @@ pub enum TopiaryConfigError {
     UnknownExtension(String),
     NoExtension(path::PathBuf),
     #[cfg(not(target_arch = "wasm32"))]
-    QueryFileNotFound(path::PathBuf),
+    QueryFileNotFound(String),
     Io(io::Error),
     Missing,
     TreeSitterFacade(topiary_tree_sitter_facade::LanguageError),
@@ -57,10 +57,10 @@ impl fmt::Display for TopiaryConfigError {
                 path.display()
             ),
             #[cfg(not(target_arch = "wasm32"))]
-            TopiaryConfigError::QueryFileNotFound(path) => write!(
+            TopiaryConfigError::QueryFileNotFound(language_name) => write!(
                 f,
-                "We could not find the query file: \"{}\" anywhere. If you use the TOPIARY_LANGUAGE_DIR environment variable, make sure it set set correctly.",
-                path.display()
+                "We could not find the query file for the language \"{}\" anywhere. Please ensure it exists or use the --query-dir flag to specify the directory.",
+                language_name
             ),
             TopiaryConfigError::Io(error) => write!(f, "We encountered an io error: {error}"),
             TopiaryConfigError::Missing => write!(

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -17,9 +17,8 @@ use std::num::NonZero;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 
-use crate::error::TopiaryConfigResult;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::error::{TopiaryConfigError, TopiaryConfigFetchingError};
+use crate::error::TopiaryConfigFetchingError;
 
 /// Language definitions, as far as the CLI and configuration are concerned, contain everything
 /// needed to configure formatting for that language.
@@ -90,59 +89,7 @@ impl Language {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(clippy::result_large_err)]
-    pub fn find_query_file(&self) -> TopiaryConfigResult<PathBuf> {
-        use crate::source::Source;
 
-        let name = self.name.as_str();
-
-        #[rustfmt::skip]
-        let potentials: [Option<PathBuf>; 5] = [
-            std::env::var("TOPIARY_LANGUAGE_DIR").map(PathBuf::from).ok(),
-            option_env!("TOPIARY_LANGUAGE_DIR").map(PathBuf::from),
-            Source::fetch_one(&None).queries_dir(),
-            Some(PathBuf::from("./topiary-queries/queries")),
-            Some(PathBuf::from("../topiary-queries/queries")),
-        ];
-
-        potentials
-            .into_iter()
-            .flatten()
-            .flat_map(|path| {
-                [
-                    // New layout: <dir>/<lang>/formatting.scm
-                    path.join(name).join(topiary_queries::FORMATTING_QUERY),
-                    // Old layout: <dir>/<lang>.scm
-                    path.join(format!("{name}.scm")),
-                ]
-            })
-            .find(|path| path.exists())
-            .ok_or_else(|| TopiaryConfigError::QueryFileNotFound(PathBuf::from(name)))
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn find_injections_file(&self) -> Option<PathBuf> {
-        use crate::source::Source;
-
-        let name = self.name.as_str();
-
-        #[rustfmt::skip]
-        let potentials: [Option<PathBuf>; 5] = [
-            std::env::var("TOPIARY_LANGUAGE_DIR").map(PathBuf::from).ok(),
-            option_env!("TOPIARY_LANGUAGE_DIR").map(PathBuf::from),
-            Source::fetch_one(&None).queries_dir(),
-            Some(PathBuf::from("./topiary-queries/queries")),
-            Some(PathBuf::from("../topiary-queries/queries")),
-        ];
-
-        potentials
-            .into_iter()
-            .flatten()
-            .map(|path| path.join(name).join(topiary_queries::INJECTIONS_QUERY))
-            .find(|path| path.exists())
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
     // Returns the library path, and ensures the parent directories exist.
     pub fn library_path(&self) -> std::io::Result<PathBuf> {
         match &self.config.grammar.source {

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -89,7 +89,6 @@ impl Language {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-
     // Returns the library path, and ensures the parent directories exist.
     pub fn library_path(&self) -> std::io::Result<PathBuf> {
         match &self.config.grammar.source {

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -56,11 +56,7 @@ impl Configuration {
     /// If the configuration file exists, but cannot be parsed, this function will return a
     /// `TopiaryConfigError` with the error that occurred.
     #[allow(clippy::result_large_err)]
-    pub fn fetch(
-        merge: bool,
-        file: &Option<PathBuf>,
-        query_dir_override: Option<PathBuf>,
-    ) -> TopiaryConfigResult<(Self, NickelValue)> {
+    pub fn fetch(merge: bool, file: &Option<PathBuf>) -> TopiaryConfigResult<(Self, NickelValue)> {
         // If we have an explicit file, fail if it doesn't exist
         if let Some(path) = file
             && !path.exists()
@@ -72,24 +68,25 @@ impl Configuration {
             // Get all available configuration sources
             let sources: Vec<Source> = Source::fetch_all(file);
 
-            let query_dir = query_dir_override.or_else(|| {
-                sources
-                    .iter()
-                    .find_map(|s| s.queries_dir().filter(|p| p.exists()))
-            });
+            let implicit_query_dir = sources
+                .iter()
+                .find_map(|s| s.queries_dir().filter(|p| p.exists()));
 
             // And ask Nickel to parse and merge them
-            Self::parse_and_merge(&sources, query_dir)
+            let (mut config, term) = Self::parse_and_merge(&sources)?;
+            config.query_dir = config.query_dir.or(implicit_query_dir);
+            Ok((config, term))
         } else {
             // Get the available configuration with best priority
             let source = Source::fetch_one(file);
-            let query_dir =
-                query_dir_override.or_else(|| source.queries_dir().filter(|p| p.exists()));
+            let implicit_query_dir = source.queries_dir().filter(|p| p.exists());
 
-            match source {
-                Source::Builtin => Self::parse(Source::Builtin, query_dir),
-                source => Self::parse_and_merge(&[source, Source::Builtin], query_dir),
-            }
+            let (mut config, term) = match source {
+                Source::Builtin => Self::parse(Source::Builtin)?,
+                source => Self::parse_and_merge(&[source, Source::Builtin])?,
+            };
+            config.query_dir = config.query_dir.or(implicit_query_dir);
+            Ok((config, term))
         }
     }
 
@@ -128,6 +125,11 @@ impl Configuration {
         self.query_dir.as_deref()
     }
 
+    /// Sets the query directory for this Configuration
+    pub fn set_query_dir(&mut self, query_dir: PathBuf) {
+        self.query_dir = Some(query_dir);
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn query_search_paths(&self) -> Vec<PathBuf> {
         if let Some(query_dir) = &self.query_dir {
@@ -162,7 +164,10 @@ impl Configuration {
     pub fn find_injections_file(&self, language_name: &str) -> Option<PathBuf> {
         self.query_search_paths()
             .into_iter()
-            .map(|path| path.join(language_name).join(topiary_queries::INJECTIONS_QUERY))
+            .map(|path| {
+                path.join(language_name)
+                    .join(topiary_queries::INJECTIONS_QUERY)
+            })
             .find(|path| path.exists())
     }
 
@@ -291,10 +296,7 @@ impl Configuration {
     }
 
     #[allow(clippy::result_large_err)]
-    fn parse_and_merge(
-        sources: &[Source],
-        query_dir: Option<PathBuf>,
-    ) -> TopiaryConfigResult<(Self, NickelValue)> {
+    fn parse_and_merge(sources: &[Source]) -> TopiaryConfigResult<(Self, NickelValue)> {
         let mut builder = ProgramBuilder::new()
             .with_trace(std::io::stderr())
             .with_reporter(NullReporter {});
@@ -306,17 +308,13 @@ impl Configuration {
         let term = program.eval_full_for_export()?;
 
         let serde_config = SerdeConfiguration::deserialize(term.clone())?;
-        let mut config: Configuration = serde_config.into();
-        config.query_dir = query_dir.or(config.query_dir);
+        let config: Configuration = serde_config.into();
 
         Ok((config, term))
     }
 
     #[allow(clippy::result_large_err)]
-    fn parse(
-        source: Source,
-        query_dir: Option<PathBuf>,
-    ) -> TopiaryConfigResult<(Self, NickelValue)> {
+    fn parse(source: Source) -> TopiaryConfigResult<(Self, NickelValue)> {
         let mut program = source
             .add_to(
                 ProgramBuilder::new()
@@ -328,8 +326,7 @@ impl Configuration {
         let term = program.eval_full_for_export()?;
 
         let serde_config = SerdeConfiguration::deserialize(term.clone())?;
-        let mut config: Configuration = serde_config.into();
-        config.query_dir = query_dir.or(config.query_dir);
+        let config: Configuration = serde_config.into();
 
         Ok((config, term))
     }

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -34,6 +34,7 @@ pub use source::Source;
 #[derive(Debug, Clone)]
 pub struct Configuration {
     languages: Vec<Language>,
+    query_dir: Option<PathBuf>,
 }
 
 /// Internal struct to help with deserialisation, converted to the actual Configuration in deserialization
@@ -53,7 +54,11 @@ impl Configuration {
     /// If the configuration file exists, but cannot be parsed, this function will return a
     /// `TopiaryConfigError` with the error that occurred.
     #[allow(clippy::result_large_err)]
-    pub fn fetch(merge: bool, file: &Option<PathBuf>) -> TopiaryConfigResult<(Self, NickelValue)> {
+    pub fn fetch(
+        merge: bool,
+        file: &Option<PathBuf>,
+        query_dir_override: Option<PathBuf>,
+    ) -> TopiaryConfigResult<(Self, NickelValue)> {
         // If we have an explicit file, fail if it doesn't exist
         if let Some(path) = file
             && !path.exists()
@@ -65,13 +70,23 @@ impl Configuration {
             // Get all available configuration sources
             let sources: Vec<Source> = Source::fetch_all(file);
 
+            let query_dir = query_dir_override.or_else(|| {
+                sources
+                    .iter()
+                    .find_map(|s| s.queries_dir().filter(|p| p.exists()))
+            });
+
             // And ask Nickel to parse and merge them
-            Self::parse_and_merge(&sources)
+            Self::parse_and_merge(&sources, query_dir)
         } else {
             // Get the available configuration with best priority
-            match Source::fetch_one(file) {
-                Source::Builtin => Self::parse(Source::Builtin),
-                source => Self::parse_and_merge(&[source, Source::Builtin]),
+            let source = Source::fetch_one(file);
+            let query_dir =
+                query_dir_override.or_else(|| source.queries_dir().filter(|p| p.exists()));
+
+            match source {
+                Source::Builtin => Self::parse(Source::Builtin, query_dir),
+                source => Self::parse_and_merge(&[source, Source::Builtin], query_dir),
             }
         }
     }
@@ -91,6 +106,53 @@ impl Configuration {
             .iter()
             .find(|language| language.name == name.as_ref())
             .ok_or(TopiaryConfigError::UnknownLanguage(name.to_string()))
+    }
+
+    /// Gets the query directory configured for this Configuration
+    pub fn query_dir(&self) -> Option<&Path> {
+        self.query_dir.as_deref()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[allow(clippy::result_large_err)]
+    pub fn find_query_file(&self, language_name: &str) -> TopiaryConfigResult<PathBuf> {
+        #[rustfmt::skip]
+        let potentials: [Option<PathBuf>; 3] = [
+            self.query_dir.clone(),
+            Some(PathBuf::from("./topiary-queries/queries")),
+            Some(PathBuf::from("../topiary-queries/queries")),
+        ];
+
+        potentials
+            .into_iter()
+            .flatten()
+            .flat_map(|path| {
+                [
+                    // New layout: <dir>/<lang>/formatting.scm
+                    path.join(language_name)
+                        .join(topiary_queries::FORMATTING_QUERY),
+                    // Old layout: <dir>/<lang>.scm
+                    path.join(format!("{language_name}.scm")),
+                ]
+            })
+            .find(|path| path.exists())
+            .ok_or_else(|| TopiaryConfigError::QueryFileNotFound(language_name.to_string()))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn find_injections_file(&self, language_name: &str) -> Option<PathBuf> {
+        #[rustfmt::skip]
+        let potentials: [Option<PathBuf>; 3] = [
+            self.query_dir.clone(),
+            Some(PathBuf::from("./topiary-queries/queries")),
+            Some(PathBuf::from("../topiary-queries/queries")),
+        ];
+
+        potentials
+            .into_iter()
+            .flatten()
+            .map(|path| path.join(language_name).join(topiary_queries::INJECTIONS_QUERY))
+            .find(|path| path.exists())
     }
 
     /// Prefetch a language per its configuration
@@ -218,7 +280,10 @@ impl Configuration {
     }
 
     #[allow(clippy::result_large_err)]
-    fn parse_and_merge(sources: &[Source]) -> TopiaryConfigResult<(Self, NickelValue)> {
+    fn parse_and_merge(
+        sources: &[Source],
+        query_dir: Option<PathBuf>,
+    ) -> TopiaryConfigResult<(Self, NickelValue)> {
         let mut builder = ProgramBuilder::new()
             .with_trace(std::io::stderr())
             .with_reporter(NullReporter {});
@@ -230,12 +295,26 @@ impl Configuration {
         let term = program.eval_full_for_export()?;
 
         let serde_config = SerdeConfiguration::deserialize(term.clone())?;
+        let languages = serde_config
+            .languages
+            .into_iter()
+            .map(|(name, config)| Language::new(name, config))
+            .collect();
 
-        Ok((serde_config.into(), term))
+        Ok((
+            Self {
+                languages,
+                query_dir,
+            },
+            term,
+        ))
     }
 
     #[allow(clippy::result_large_err)]
-    fn parse(source: Source) -> TopiaryConfigResult<(Self, NickelValue)> {
+    fn parse(
+        source: Source,
+        query_dir: Option<PathBuf>,
+    ) -> TopiaryConfigResult<(Self, NickelValue)> {
         let mut program = source
             .add_to(
                 ProgramBuilder::new()
@@ -247,8 +326,19 @@ impl Configuration {
         let term = program.eval_full_for_export()?;
 
         let serde_config = SerdeConfiguration::deserialize(term.clone())?;
+        let languages = serde_config
+            .languages
+            .into_iter()
+            .map(|(name, config)| Language::new(name, config))
+            .collect();
 
-        Ok((serde_config.into(), term))
+        Ok((
+            Self {
+                languages,
+                query_dir,
+            },
+            term,
+        ))
     }
 }
 
@@ -270,7 +360,16 @@ impl Default for Configuration {
         let serde_config = SerdeConfiguration::deserialize(term)
             .expect("Evaluating the builtin configuration should be safe");
 
-        serde_config.into()
+        let languages = serde_config
+            .languages
+            .into_iter()
+            .map(|(name, config)| Language::new(name, config))
+            .collect();
+
+        Self {
+            languages,
+            query_dir: None,
+        }
     }
 }
 
@@ -293,18 +392,6 @@ impl PartialEq for Configuration {
         let rhs: HashMap<String, Language> = other.into();
 
         lhs == rhs
-    }
-}
-
-impl From<SerdeConfiguration> for Configuration {
-    fn from(value: SerdeConfiguration) -> Self {
-        let languages = value
-            .languages
-            .into_iter()
-            .map(|(name, config)| Language::new(name, config))
-            .collect();
-
-        Self { languages }
     }
 }
 

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -41,6 +41,8 @@ pub struct Configuration {
 #[derive(Debug, serde::Deserialize, PartialEq, serde::Serialize, Clone)]
 struct SerdeConfiguration {
     languages: HashMap<String, LanguageConfiguration>,
+    #[serde(default)]
+    query_dir: Option<PathBuf>,
 }
 
 impl Configuration {
@@ -106,6 +108,19 @@ impl Configuration {
             .iter()
             .find(|language| language.name == name.as_ref())
             .ok_or(TopiaryConfigError::UnknownLanguage(name.to_string()))
+    }
+
+    /// Ensures that a language is configured.
+    ///
+    /// # Errors
+    ///
+    /// If the provided language name cannot be found in the `Configuration`, this
+    /// function returns a `TopiaryConfigError`
+    pub fn ensure_language<T>(&self, name: T) -> TopiaryConfigResult<()>
+    where
+        T: AsRef<str> + fmt::Display,
+    {
+        self.get_language(name).map(|_| ())
     }
 
     /// Gets the query directory configured for this Configuration
@@ -295,19 +310,10 @@ impl Configuration {
         let term = program.eval_full_for_export()?;
 
         let serde_config = SerdeConfiguration::deserialize(term.clone())?;
-        let languages = serde_config
-            .languages
-            .into_iter()
-            .map(|(name, config)| Language::new(name, config))
-            .collect();
+        let mut config: Configuration = serde_config.into();
+        config.query_dir = query_dir.or(config.query_dir);
 
-        Ok((
-            Self {
-                languages,
-                query_dir,
-            },
-            term,
-        ))
+        Ok((config, term))
     }
 
     #[allow(clippy::result_large_err)]
@@ -326,19 +332,10 @@ impl Configuration {
         let term = program.eval_full_for_export()?;
 
         let serde_config = SerdeConfiguration::deserialize(term.clone())?;
-        let languages = serde_config
-            .languages
-            .into_iter()
-            .map(|(name, config)| Language::new(name, config))
-            .collect();
+        let mut config: Configuration = serde_config.into();
+        config.query_dir = query_dir.or(config.query_dir);
 
-        Ok((
-            Self {
-                languages,
-                query_dir,
-            },
-            term,
-        ))
+        Ok((config, term))
     }
 }
 
@@ -360,16 +357,7 @@ impl Default for Configuration {
         let serde_config = SerdeConfiguration::deserialize(term)
             .expect("Evaluating the builtin configuration should be safe");
 
-        let languages = serde_config
-            .languages
-            .into_iter()
-            .map(|(name, config)| Language::new(name, config))
-            .collect();
-
-        Self {
-            languages,
-            query_dir: None,
-        }
+        serde_config.into()
     }
 }
 
@@ -398,4 +386,19 @@ impl PartialEq for Configuration {
 pub(crate) fn project_dirs() -> directories::ProjectDirs {
     directories::ProjectDirs::from("", "", "topiary")
         .expect("Could not access the OS's Home directory")
+}
+
+impl From<SerdeConfiguration> for Configuration {
+    fn from(value: SerdeConfiguration) -> Self {
+        let languages = value
+            .languages
+            .into_iter()
+            .map(|(name, config)| Language::new(name, config))
+            .collect();
+
+        Self {
+            languages,
+            query_dir: value.query_dir,
+        }
+    }
 }

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -129,18 +129,22 @@ impl Configuration {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    fn query_search_paths(&self) -> Vec<PathBuf> {
+        if let Some(query_dir) = &self.query_dir {
+            vec![query_dir.clone()]
+        } else {
+            vec![
+                PathBuf::from("./topiary-queries/queries"),
+                PathBuf::from("../topiary-queries/queries"),
+            ]
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     #[allow(clippy::result_large_err)]
     pub fn find_query_file(&self, language_name: &str) -> TopiaryConfigResult<PathBuf> {
-        #[rustfmt::skip]
-        let potentials: [Option<PathBuf>; 3] = [
-            self.query_dir.clone(),
-            Some(PathBuf::from("./topiary-queries/queries")),
-            Some(PathBuf::from("../topiary-queries/queries")),
-        ];
-
-        potentials
+        self.query_search_paths()
             .into_iter()
-            .flatten()
             .flat_map(|path| {
                 [
                     // New layout: <dir>/<lang>/formatting.scm
@@ -156,16 +160,8 @@ impl Configuration {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn find_injections_file(&self, language_name: &str) -> Option<PathBuf> {
-        #[rustfmt::skip]
-        let potentials: [Option<PathBuf>; 3] = [
-            self.query_dir.clone(),
-            Some(PathBuf::from("./topiary-queries/queries")),
-            Some(PathBuf::from("../topiary-queries/queries")),
-        ];
-
-        potentials
+        self.query_search_paths()
             .into_iter()
-            .flatten()
             .map(|path| path.join(language_name).join(topiary_queries::INJECTIONS_QUERY))
             .find(|path| path.exists())
     }


### PR DESCRIPTION
> [!IMPORTANT]
> In draft and awaiting https://github.com/topiary/bud/discussions/9

# Remove `TOPIARY_LANGUAGE_DIR` and simplify query resolution architecture

## Description
Completely remove TOPIARY_LANGUAGE_DIR, and generally cleanup the query resolution strategy. I started implementing this realizing that it was kind of annoying to have topiary-config access environment variables. However, this quickly shifted into realizing that the TOPIARY_LANGUAGE_DIR doesn't really have a point anymore.

So, it has been removed. Additionally, the query resolution has been moved away from Language and into Config. This, IMHO makes more sense.

### Background
`TOPIARY_LANGUAGE_DIR` was introduced sometime 2022 as a workaround for Nix packaging issues to allow Topiary to find detached query files on disk. This is now obsolete because standard queries are compiled directly into the binary, and the Nickel `Configuration` system automatically infers local `queries/` folders dynamically.

### Changes
* **Removed side-effectful state:** Completely stripped `TOPIARY_LANGUAGE_DIR`r from the codebase.
* **Separation of Concerns:** Moved `query_dir` and `find_query_file()` away `Language` and onto `Configuration`. `Language` is now purely a data struct describing parsing details, and is fully agnostic to the fs.
* **New CLI argument:** Introduced a `--query-dir <PATH>` CLI argument to override the directory where queries are found.

## Checklist

Checklist before merging, wherever relevant:

- [ ] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [ ] Updated regression tests