### PR TITLE
fix(openscad): Handle linebreak preservation in let chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ This name should be decided amongst the team before the release.
 
 ### Fixed
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.
-- [#1253](https://github.com/topiary/topiary/pull/1253) Handle linebreak preservation in let chains.
+- [#1253](https://github.com/topiary/topiary/pull/1253) Handle linebreak preservation in OpenSCAD let chains
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This name should be decided amongst the team before the release.
 
 ### Fixed
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.
+- [#1253](https://github.com/topiary/topiary/pull/1253) Handle linebreak preservation in let chains.
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/topiary-cli/tests/samples/expected/openscad.scad
+++ b/topiary-cli/tests/samples/expected/openscad.scad
@@ -41,14 +41,9 @@ let (a = 1, b = 2) {};
 // Functions
 // ================================================================================
 function line(point1, point2, width = 1) =
-
   let (angle = 90 - atan((point2[1] - point1[1]) / (point2[0] - point1[0])))
-
   let (offset_x = 0.5 * width * cos(angle), offset_y = 0.5 * width * sin(angle))
-
   let (offset1 = [-offset_x, offset_y], offset2 = [offset_x, -offset_y])
-
-  // [P1a, P2a, P2b, P1b]
   [point1 + offset1, point2 + offset1, point2 + offset2, point1 + offset2];
 
 eager = (function(z) identity)(4);

--- a/topiary-cli/tests/samples/input/openscad.scad
+++ b/topiary-cli/tests/samples/input/openscad.scad
@@ -39,14 +39,9 @@ let (a = 1, b = 2,) {};
 // Functions
 // ================================================================================
 function line(point1, point2, width = 1,) =
-
   let (angle = 90 - atan((point2[1] - point1[1]) / (point2[0] - point1[0])))
-
   let (offset_x = 0.5 * width * cos(angle), offset_y = 0.5 * width * sin(angle))
-
   let (offset1 = [ -offset_x, offset_y], offset2 = [offset_x, -offset_y])
-
-  // [P1a, P2a, P2b, P1b]
   [point1 + offset1, point2 + offset1, point2 + offset2, point1 + offset2];
 
 eager = (function(z) identity)(4);
@@ -190,7 +185,7 @@ function affine3d_rot_from_to(from, to) =
   let (
     from = unit(point3d(from)),
     to = unit(point3d(to))
-  ) approx(from, to) ? affine3d_identity()
+  )approx(from, to) ? affine3d_identity()
   : from.z == 0 && to.z == 0 ? affine3d_zrot(v_theta(point2d(to)) - v_theta(point2d(from)))
   : let (u = vector_axis(from, to),
     ang = vector_angle(from, to),

--- a/topiary-queries/queries/openscad/formatting.scm
+++ b/topiary-queries/queries/openscad/formatting.scm
@@ -204,7 +204,8 @@
 ; Let child nodes handle indentation
 (var_declaration . (assignment . (identifier) . "=" @append_input_softline))
 
-(assignments) @append_space
+; we want the node following an assignment to determine space/newline separation
+((assignments) . (_) @prepend_input_softline)
 ; OS2021 does not support trailing commas in assignments
 ; https://github.com/Leathong/openscad-LSP/issues/51#issuecomment-2891821939
 ; (assignments


### PR DESCRIPTION
# OpenSCAD: Handle line-break preservation in let chains

## Description



Previously, the code below would have the let chain collapse down to one line, this issue is now fixed:

```openscad
function line(point1, point2, width = 1,) =
  let (angle = 90 - atan((point2[1] - point1[1]) / (point2[0] - point1[0])))
  let (offset_x = 0.5 * width * cos(angle), offset_y = 0.5 * width * sin(angle))
  let (offset1 = [ -offset_x, offset_y], offset2 = [offset_x, -offset_y])
  [point1 + offset1, point2 + offset1, point2 + offset2, point1 + offset2];
```

## Checklist

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [x] Updated regression tests
