### PR TITLE
Unpin `wasm-bindgen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ This name should be decided amongst the team before the release.
 ### Fixed
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.
 - [#1253](https://github.com/topiary/topiary/pull/1253) Handle linebreak preservation in OpenSCAD let chains
+- [#1255](https://github.com/topiary/topiary/pull/1255) Unpinned outdated wasm-bindgen dependency
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,11 +2435,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2786,9 +2798,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nickel-lang-core"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ec3efee570877109c89bd23e5a44ff7b4a60f1d3c6394945a2520ebda84117"
+checksum = "692d8a2ba34c633bc37e704dc94f4ca33edaa8fbf6d08efdcadb81db333ccdb6"
 dependencies = [
  "base64",
  "bumpalo",
@@ -2829,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-parser"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f405189a72d136913a3ec470a27def520e93784b611578c2e4f3dd909b3fc75"
+checksum = "d7aaf73e60b66ef4fffc969b0e4e419a15a029525f9b53f2f5cc0ca41bbe17ff"
 dependencies = [
  "bumpalo",
  "codespan",
@@ -2855,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-vector"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870c323d81061fc47db4aa7346f6f3492f3e4bb8bd5dd8b7c85ac9d0c9709f0c"
+checksum = "36f243832286908d8873add24a905d6732ffabd6cfb2bf74cb18d667e892e279"
 dependencies = [
  "imbl-sized-chunks",
  "serde",
@@ -2891,6 +2903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4864,48 +4877,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4913,49 +4910,64 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.50"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+checksum = "e28a0782b173cf2e98f62aacb487c5c021b7c5925df46098675f28e1fa85e159"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.50"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+checksum = "ee997551ce1ad5adda03f7ce37ec34b4140fe9f547fd07b46d55901d1ba1a06b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0f005eb61f765eff31a79ef71df7e21819731268a868df41192c1e41d6d3e5"
 
 [[package]]
 name = "wasm-encoder"
@@ -4993,9 +5005,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -755,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2345,7 +2345,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2893,7 +2893,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3575,7 +3575,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3632,7 +3632,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4097,7 +4097,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4106,7 +4106,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4125,7 +4125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5064,7 +5064,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,9 @@ tree-sitter-json = "0.24"
 tree-sitter-language = "0.1"
 tree-sitter-nickel = "0.5"
 unescape = "0.1"
-wasm-bindgen = "0.2.100"
-wasm-bindgen-futures = "0.4"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3"
 web-sys = "0.3"
 
 # NOTE Keep these versions aligned

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,8 @@ tree-sitter-nickel = "0.5"
 unescape = "0.1"
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4"
-wasm-bindgen-test = "0.3"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
 
 # NOTE Keep these versions aligned

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ js-sys = "0.3"
 libloading = "0.9.0"
 log = "0.4"
 miette = "7.6.0"
-nickel-lang-core = { version = "0.17.0", default-features = false }
+nickel-lang-core = { version = "0.18.0", default-features = false }
 pastey = "0.2.0"
 predicates = "3.0"
 pretty_assertions = "1.3"
@@ -66,9 +66,9 @@ tree-sitter-json = "0.24"
 tree-sitter-language = "0.1"
 tree-sitter-nickel = "0.5"
 unescape = "0.1"
-wasm-bindgen = "=0.2.100"
-wasm-bindgen-futures = "=0.4"
-wasm-bindgen-test = "=0.3"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3"
 web-sys = "0.3"
 
 # NOTE Keep these versions aligned

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1781141223,
+        "narHash": "sha256-Eye4UQJjC4TLobclolFCMl6MrjgiF6Bk1cOI5x8SH00=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "b503dde361500433ca25a32e8f4d218bf58fb659",
         "type": "github"
       },
       "original": {

--- a/nix/overlays/wasm-bindgen-cli.nix
+++ b/nix/overlays/wasm-bindgen-cli.nix
@@ -24,13 +24,13 @@ in
     src = final.fetchCrate {
       pname = "wasm-bindgen-cli";
       version = wasmBindgenVersion;
-      hash = "sha256-3RJzK7mkYFrs7C/WkhW9Rr4LdP5ofb2FdYGz1P7Uxog=";
+      hash = "sha256-vO4RSxi/sMWxmsEs3GuljdMfIRSu75A+Q+c5wgYToRU=";
     };
 
     cargoDeps = final.rustPlatform.fetchCargoVendor {
       inherit src;
       pname = "${src.pname}-${src.version}";
-      hash = "sha256-qsO12332HSjWCVKtf1cUePWWb9IdYUmT+8OPj/XP2WE=";
+      hash = "sha256-Inup6vvJSG5ghNyeDPyZbfZo4d0LsMG2OJfStoaeDBs=";
     };
   };
 }

--- a/nix/overlays/wasm-bindgen-cli.nix
+++ b/nix/overlays/wasm-bindgen-cli.nix
@@ -24,13 +24,13 @@ in
     src = final.fetchCrate {
       pname = "wasm-bindgen-cli";
       version = wasmBindgenVersion;
-      hash = "sha256-vO4RSxi/sMWxmsEs3GuljdMfIRSu75A+Q+c5wgYToRU=";
+      hash = "sha256-ymeAEYsr7OnupWYJWjSeVGvq3+s+zxSNkODbzY62rYs=";
     };
 
     cargoDeps = final.rustPlatform.fetchCargoVendor {
       inherit src;
       pname = "${src.pname}-${src.version}";
-      hash = "sha256-Inup6vvJSG5ghNyeDPyZbfZo4d0LsMG2OJfStoaeDBs=";
+      hash = "sha256-d7x6gtx5OqEE4MyT6yjYn/qtgjx7GroTpXJewnBV2dU=";
     };
   };
 }

--- a/topiary-config/src/error.rs
+++ b/topiary-config/src/error.rs
@@ -114,6 +114,17 @@ impl From<nickel_lang_core::error::Error> for TopiaryConfigError {
     }
 }
 
+impl From<nickel_lang_core::program::BuilderError> for TopiaryConfigError {
+    fn from(e: nickel_lang_core::program::BuilderError) -> Self {
+        match e {
+            nickel_lang_core::program::BuilderError::Io { error, .. } => Self::Io(error),
+            nickel_lang_core::program::BuilderError::NoInputs => {
+                Self::Io(io::Error::other("ProgramBuilder: no inputs were added"))
+            }
+        }
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl From<TopiaryConfigFetchingError> for TopiaryConfigError {
     fn from(e: TopiaryConfigFetchingError) -> Self {

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 
 use language::{Language, LanguageConfiguration};
 use nickel_lang_core::{
-    error::NullReporter, eval::cache::CacheImpl, eval::value::NickelValue, program::Program,
+    error::NullReporter, eval::cache::CacheImpl, eval::value::NickelValue, program::ProgramBuilder,
 };
 use serde::Deserialize;
 
@@ -219,10 +219,13 @@ impl Configuration {
 
     #[allow(clippy::result_large_err)]
     fn parse_and_merge(sources: &[Source]) -> TopiaryConfigResult<(Self, NickelValue)> {
-        let inputs = sources.iter().map(|s| s.clone().into());
-
-        let mut program =
-            Program::<CacheImpl>::new_from_inputs(inputs, std::io::stderr(), NullReporter {})?;
+        let mut builder = ProgramBuilder::new()
+            .with_trace(std::io::stderr())
+            .with_reporter(NullReporter {});
+        for source in sources {
+            builder = source.clone().add_to(builder);
+        }
+        let mut program = builder.build::<CacheImpl>()?;
 
         let term = program.eval_full_for_export()?;
 
@@ -233,11 +236,13 @@ impl Configuration {
 
     #[allow(clippy::result_large_err)]
     fn parse(source: Source) -> TopiaryConfigResult<(Self, NickelValue)> {
-        let mut program = Program::<CacheImpl>::new_from_input(
-            source.into(),
-            std::io::stderr(),
-            NullReporter {},
-        )?;
+        let mut program = source
+            .add_to(
+                ProgramBuilder::new()
+                    .with_trace(std::io::stderr())
+                    .with_reporter(NullReporter {}),
+            )
+            .build::<CacheImpl>()?;
 
         let term = program.eval_full_for_export()?;
 
@@ -251,16 +256,14 @@ impl Default for Configuration {
     /// Return the built-in configuration
     // This is particularly useful for testing
     fn default() -> Self {
-        let mut program = Program::<CacheImpl>::new_from_source(
-            Source::Builtin
-                .read()
-                .expect("Evaluating the builtin configuration should be safe")
-                .as_slice(),
-            "built-in",
-            std::io::empty(),
-            NullReporter {},
-        )
-        .expect("Evaluating the builtin configuration should be safe");
+        let mut program = Source::Builtin
+            .add_to(
+                ProgramBuilder::new()
+                    .with_trace(std::io::empty())
+                    .with_reporter(NullReporter {}),
+            )
+            .build::<CacheImpl>()
+            .expect("Evaluating the builtin configuration should be safe");
         let term = program
             .eval_full_for_export()
             .expect("Evaluating the builtin configuration should be safe");

--- a/topiary-config/src/source.rs
+++ b/topiary-config/src/source.rs
@@ -2,11 +2,12 @@
 
 use std::{
     env::current_dir,
-    ffi::OsString,
     fmt,
     io::Cursor,
     path::{Path, PathBuf},
 };
+
+use nickel_lang_core::program::ProgramBuilder;
 
 use crate::error::{TopiaryConfigError, TopiaryConfigResult};
 
@@ -18,17 +19,17 @@ pub enum Source {
     File(PathBuf),
 }
 
-impl From<Source> for nickel_lang_core::program::Input<Cursor<String>, OsString> {
-    fn from(source: Source) -> Self {
+impl Source {
+    /// Register this source as an input on the given [`ProgramBuilder`].
+    pub fn add_to<R, W>(self, builder: ProgramBuilder<R, W>) -> ProgramBuilder<R, W> {
         use nickel_lang_core::cache::InputFormat;
-        match source {
-            Source::Builtin => Self::Source(
-                Cursor::new(source.builtin_nickel()),
-                "built-in".into(),
+        match self {
+            Source::Builtin => builder.add_source_with_format(
+                Cursor::new(Self::Builtin.builtin_nickel()),
+                "built-in",
                 InputFormat::Nickel,
             ),
-            Source::Directory(path) => Self::Path(path.into()),
-            Source::File(path) => Self::Path(path.into()),
+            Source::Directory(path) | Source::File(path) => builder.add_path(path.into_os_string()),
         }
     }
 }


### PR DESCRIPTION
# Bump `nickel-lang-core` to unpin `wasm-bindgen`

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #1128

## Description

`wasm-bindgen` was a pinned dependency, which was causing problems for downstream users. Now that Nickel has unpinned its dependency on this crate, Topiary can do the same.

> [!NOTE]
> A new release is planned in the coming weeks that will include this PR, but this PR itself will not be in a more-imminent patch release.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~
