### PR TITLE
slice instead of indexes in `InjectionSpan`

### DIFF
--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -13,7 +13,7 @@
 use std::{io, sync::Arc};
 
 use pretty_assertions::StrComparison;
-use rootcause::{option_ext::OptionExt, prelude::ResultExt, report};
+use rootcause::{prelude::ResultExt, report};
 use tree_sitter::Position;
 
 pub use crate::{
@@ -343,13 +343,7 @@ pub fn formatter_tree(
                 injection_leaf_nodes,
             )?;
 
-            rewrite_injected_leaves(
-                &mut atoms,
-                input_content,
-                spans,
-                resolve,
-                tolerate_parsing_errors,
-            )?;
+            rewrite_injected_leaves(&mut atoms, spans, resolve, tolerate_parsing_errors)?;
 
             // Various post-processing of whitespace
             atoms.post_process();
@@ -386,20 +380,11 @@ pub fn formatter_tree(
 
 fn rewrite_injected_leaves(
     atoms: &mut atom_collection::AtomCollection,
-    input_content: &str,
     spans: Vec<InjectionSpan>,
     resolve: Option<&LanguageResolver<'_>>,
     tolerate_parsing_errors: bool,
 ) -> FormatterResult<()> {
     for span in spans {
-        let inner_source = input_content
-            .get(span.byte_range.clone())
-            .ok_or_report()
-            .context(FormatterError::Internal(
-                "Injected span is not on UTF-8 boundaries".into(),
-            ))
-            .attach_language(Some(span.language.as_str()))?;
-
         // If the injected language is unsupported, skip formatting this injection
         // by continuing the loop. This leaves the original, unformatted text intact.
         let Some(inner_language) = resolve_injected_language(resolve, &span.language)? else {
@@ -412,7 +397,7 @@ fn rewrite_injected_leaves(
 
         let mut formatted_inner = Vec::new();
         formatter_str(
-            inner_source,
+            span.byte_range,
             &mut formatted_inner,
             &inner_language,
             Operation::Format {
@@ -661,7 +646,7 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].language, "ocaml");
         assert_eq!(
-            &input[spans[0].byte_range.clone()],
+            spans[0].byte_range,
             r#"let values=[1;2;3] in List.map (fun x->x+1) values"#
         );
     }

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -397,7 +397,7 @@ fn rewrite_injected_leaves(
 
         let mut formatted_inner = Vec::new();
         formatter_str(
-            span.byte_range,
+            span.content,
             &mut formatted_inner,
             &inner_language,
             Operation::Format {
@@ -646,7 +646,7 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].language, "ocaml");
         assert_eq!(
-            spans[0].byte_range,
+            spans[0].content,
             r#"let values=[1;2;3] in List.map (fun x->x+1) values"#
         );
     }

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -155,8 +155,8 @@ impl InjectionQuery {
 /// A region of host source text that should be formatted as a different
 /// language, as determined by an [`InjectionQuery`].
 #[derive(Clone, Debug)]
-pub struct InjectionSpan {
-    pub byte_range: std::ops::Range<usize>,
+pub struct InjectionSpan<'a> {
+    pub byte_range: &'a str,
     /// The injected language name, taken from the `#injection_language!`
     /// predicate of the matching pattern.
     pub language: String,
@@ -176,11 +176,11 @@ pub struct InjectionSpan {
 /// warning logged).
 ///
 /// Missing predicates or unmatched captures are logged, not raised.
-pub fn collect_injections(
+pub fn collect_injections<'a>(
     tree: &Tree,
-    input_content: &str,
+    input_content: &'a str,
     query: &InjectionQuery,
-) -> Vec<InjectionSpan> {
+) -> Vec<InjectionSpan<'a>> {
     let root = tree.root_node();
     let source = input_content.as_bytes();
     let capture_names = query.query.capture_names();
@@ -225,7 +225,9 @@ pub fn collect_injections(
         {
             let node = capture.node();
             spans.push(InjectionSpan {
-                byte_range: node.start_byte() as usize..node.end_byte() as usize,
+                byte_range: input_content
+                    .get(node.start_byte() as usize..node.end_byte() as usize)
+                    .expect("`tree-sitter::Node::{start_byte, end_byte}` should always return a valid string slice indexes range."),
                 language: language_name.clone(),
                 node_id: node.id(),
             });

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -226,7 +226,7 @@ pub fn collect_injections<'a>(
             let node = capture.node();
             spans.push(InjectionSpan {
                 content: input_content
-                    .get(node.start_byte() as usize..node.end_byte() as usize)
+                    .get(node.byte_range())
                     .expect("`tree-sitter::Node::{start_byte, end_byte}` should always return a valid string slice indexes range."),
                 language: language_name.clone(),
                 node_id: node.id(),

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -156,7 +156,7 @@ impl InjectionQuery {
 /// language, as determined by an [`InjectionQuery`].
 #[derive(Clone, Debug)]
 pub struct InjectionSpan<'a> {
-    pub byte_range: &'a str,
+    pub content: &'a str,
     /// The injected language name, taken from the `#injection_language!`
     /// predicate of the matching pattern.
     pub language: String,
@@ -225,7 +225,7 @@ pub fn collect_injections<'a>(
         {
             let node = capture.node();
             spans.push(InjectionSpan {
-                byte_range: input_content
+                content: input_content
                     .get(node.start_byte() as usize..node.end_byte() as usize)
                     .expect("`tree-sitter::Node::{start_byte, end_byte}` should always return a valid string slice indexes range."),
                 language: language_name.clone(),

--- a/topiary-tree-sitter-facade/src/node.rs
+++ b/topiary-tree-sitter-facade/src/node.rs
@@ -13,11 +13,8 @@ mod native {
 
     impl<'tree> Node<'tree> {
         #[inline]
-        pub fn byte_range(&self) -> std::ops::Range<u32> {
-            let range = self.inner.byte_range();
-            let start = u32::try_from(range.start).unwrap();
-            let end = u32::try_from(range.end).unwrap();
-            start..end
+        pub fn byte_range(&self) -> std::ops::Range<usize> {
+            self.inner.byte_range()
         }
 
         #[inline]
@@ -301,9 +298,17 @@ mod wasm {
     impl<'tree> Node<'tree> {
         // FIXME: check that this is correct
         #[inline]
-        pub fn byte_range(&self) -> std::ops::Range<u32> {
-            let start = self.inner.start_index();
-            let end = self.inner.end_index();
+        pub fn byte_range(&self) -> std::ops::Range<usize> {
+            let start = self
+                .inner
+                .start_index()
+                .try_into()
+                .expect("`usize` and `u32` should be the same on `wasm32`.");
+            let end = self
+                .inner
+                .end_index()
+                .try_into()
+                .expect("`usize` and `u32` should be the same on `wasm32`.");
             start..end
         }
 


### PR DESCRIPTION
<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
References #1244

## Description

tiny suggestion for #1244. #1244 is merged already. so i am giving this suggestion its own pull request.

the suggestion is to pass around a string slice as opposed to an indexes in order to make the error of indexing a different or mutated string impossible. and in order to make the impossibility of the error of indexing off utf-8 boundaries so locally self evident that we can just panic.

under the hood, slices are basically just indexes too plus a reference to the source string. the indexes can even be recovered from a slice via [`std::slice::element_offset`](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.element_offset) if that was ever needed.