### PR TITLE
multi line strings where the closing column is insignificant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ This name should be decided amongst the team before the release.
 - [#1312](https://github.com/topiary/topiary/pull/1312) Added `bin/changelog.nu` to automatically add entry to `CHANGELOG.md`
 - [#1315](https://github.com/topiary/topiary/pull/1315) Add rootcause-backtrace to cli
 - [#1314](https://github.com/topiary/topiary/pull/1314) Allow skipping of formatting stages
+- [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string.
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ This name should be decided amongst the team before the release.
 - [#1299](https://github.com/topiary/topiary/pull/1299) Add `QuerySource` config fetching to topiary-config.
 - [#1312](https://github.com/topiary/topiary/pull/1312) Added `bin/changelog.nu` to automatically add entry to `CHANGELOG.md`
 - [#1315](https://github.com/topiary/topiary/pull/1315) Add rootcause-backtrace to cli
-- [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string.
+- [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string. And use `@multi_line_string` to add multi line string formatting to the Nickel formatter.
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ This name should be decided amongst the team before the release.
 - [#1312](https://github.com/topiary/topiary/pull/1312) Added `bin/changelog.nu` to automatically add entry to `CHANGELOG.md`
 - [#1315](https://github.com/topiary/topiary/pull/1315) Add rootcause-backtrace to cli
 - [#1314](https://github.com/topiary/topiary/pull/1314) Allow skipping of formatting stages
-- [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string.
+- [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string. And use `@multi_line_string` to add multi line string formatting to the Nickel formatter.
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ This name should be decided amongst the team before the release.
 - [#1299](https://github.com/topiary/topiary/pull/1299) Add `QuerySource` config fetching to topiary-config.
 - [#1312](https://github.com/topiary/topiary/pull/1312) Added `bin/changelog.nu` to automatically add entry to `CHANGELOG.md`
 - [#1315](https://github.com/topiary/topiary/pull/1315) Add rootcause-backtrace to cli
+- [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string.
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/docs/book/src/reference/capture-names/indentation.md
+++ b/docs/book/src/reference/capture-names/indentation.md
@@ -53,6 +53,38 @@ respectively, after) them.
 ] @append_indent_end
 ```
 
+## `@multi_line_string`
+
+To be used on multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of the multi line string. Consider the following Nickel example.
+```Nickel
+m%"a
+b"%
+```
+
+`@multi_line_string` could format this as follows.
+```Nickel
+m%"
+  a
+  b
+"%
+```
+
+Nickel considers these 2 strings above as equal because Nickel ignores indentation common to all lines of the multi line string. Otherwise, `@multi_line_string` would not be admissible in a Nickel formatter.
+
+As illustrated in the example below, `@multi_line_string` requires both a `@multi_line_string.start` and a `@multi_line_string.end` directive in the same query matching the start and end delimiters of the string, for example `m%"` and `"%` in Nickel.
+
+As illustrated in the example below, you can add an optional `#multi_line_string.last_insignificant!` predicate. It indicates that a line break can be introduced before the end delimiter if, in the input, the end delimiter is on the same line as the string's last nonwhitespace line, as illustrated by `b"%` in the examples above. Nickel considers this not to change the string's value. Otherwise, `#multi_line_string.last_insignificant!` would not be admissible in a Nickel formatter. For example, Nix does consider this to change the string's value.
+
+### Example
+
+```scheme
+(str_chunks_multi
+  start: (multstr_start) @multi_line_string.start
+  end: (multstr_end) @multi_line_string.end
+  (#multi_line_string.last_insignificant!)
+) @multi_line_string
+```
+
 ## `@multi_line_indent_all`
 
 To be used on comments, or other leaf nodes, to indicate that we should

--- a/docs/book/src/reference/capture-names/indentation.md
+++ b/docs/book/src/reference/capture-names/indentation.md
@@ -73,7 +73,7 @@ Nickel considers these 2 strings above as equal because Nickel ignores indentati
 
 As illustrated in the example below, `@multi_line_string` requires both a `@multi_line_string.start` and a `@multi_line_string.end` directive in the same query matching the start and end delimiters of the string, for example `m%"` and `"%` in Nickel.
 
-As illustrated in the example below, you can add an optional `#multi_line_string.last_insignificant!` predicate. It indicates that a line break can be introduced before the end delimiter if, in the input, the end delimiter is on the same line as the string's last nonwhitespace line, as illustrated by `b"%` in the examples above. Nickel considers this not to change the string's value. Otherwise, `#multi_line_string.last_insignificant!` would not be admissible in a Nickel formatter. For example, Nix does consider this to change the string's value.
+As illustrated in the example below, you can add an optional `#multi_line_string.last_insignificant!` predicate. It indicates that a line break can be introduced before the end delimiter if, in the input, the end delimiter is on the same line as the string's last non-whitespace line, as illustrated by `b"%` in the examples above. Nickel considers this not to change the string's value. Otherwise, `#multi_line_string.last_insignificant!` would not be admissible in a Nickel formatter. For example, Nix does consider this to change the string's value.
 
 ### Example
 

--- a/docs/book/src/reference/capture-names/indentation.md
+++ b/docs/book/src/reference/capture-names/indentation.md
@@ -53,6 +53,61 @@ respectively, after) them.
 ] @append_indent_end
 ```
 
+## `@multi_line_string`
+
+To be used on multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of the multi line string. Consider the following Nickel example.
+```Nickel
+m%"a
+b"%
+```
+
+`@multi_line_string` could format this as follows.
+```Nickel
+m%"
+  a
+  b
+"%
+```
+
+Nickel considers these 2 strings above as equal because Nickel ignores indentation common to all lines of the multi line string. Otherwise, `@multi_line_string` would not be admissible in a Nickel formatter.
+
+Here is an example query for Nickel.
+```scheme
+(str_chunks_multi
+  start: (multstr_start) @multi_line_string.start
+  end: (multstr_end) @multi_line_string.end
+  (#multi_line_string.last_insignificant!)
+) @multi_line_string
+```
+
+As illustrated by this example, `@multi_line_string` requires both a `@multi_line_string.start` and a `@multi_line_string.end` directive in the same query matching the start and end delimiters of the string, for example `m%"` and `"%` in Nickel.
+
+As furthermore illustrated by this example above, you can add an optional `#multi_line_string.last_insignificant!` predicate. It indicates that a line break can be introduced before the end delimiter if, in the input, the end delimiter is on the same line as the string's last non-whitespace line, as illustrated by `b"%` in the examples above. Nickel considers this not to change the string's value. Otherwise, `#multi_line_string.last_insignificant!` would not be admissible in a Nickel formatter. For example, Nix does consider this to change the string's value.
+
+Here is an example query for Nix.
+```scheme
+(indented_string_expression
+  "''" @multi_line_string.start
+  "''" @multi_line_string.end
+  (#multi_line_string.carriage_return_significant!)
+  (#multi_line_string.tab_significant!)
+) @multi_line_string
+```
+
+As illustrated by this example, you can add an optional `#multi_line_string.carriage_return_significant!` predicate. It indicates that the formatted language made the questionable design decision that carriage returns always become part of the string's value. even if they occur at the very line end in a CRLF line ending.
+
+As furthermore illustrated by this example above, you can add an optional `#multi_line_string.tab_significant!` predicate. It indicates that the formatted language made the questionable design decision that tabs always become part of the string's value. even if they occur in indentation common to all lines of the multi line string.
+
+### Example
+
+```scheme
+(str_chunks_multi
+  start: (multstr_start) @multi_line_string.start
+  end: (multstr_end) @multi_line_string.end
+  (#multi_line_string.last_insignificant!)
+) @multi_line_string
+```
+
 ## `@multi_line_indent_all`
 
 To be used on comments, or other leaf nodes, to indicate that we should

--- a/topiary-cli/tests/sample-tester.rs
+++ b/topiary-cli/tests/sample-tester.rs
@@ -44,7 +44,6 @@ macro_rules! lang_test {
 mod test_fmt {
     use super::*;
 
-    #[allow(unused)]
     fn fmt_input(lang: &str) {
         let file = format!("{lang}.{}", get_file_extension(lang));
         let input = PathBuf::from(format!("tests/samples/input/{file}"));
@@ -145,7 +144,6 @@ mod test_fmt {
 mod test_check {
     use super::*;
 
-    #[allow(unused)]
     fn check_input(lang: &str) {
         let file = format!("{lang}.{}", get_file_extension(lang));
         let input = PathBuf::from(format!("tests/samples/input/{file}"));
@@ -199,7 +197,6 @@ mod test_check {
 mod test_coverage {
     use super::*;
 
-    #[allow(unused)]
     fn coverage_input(lang: &str) {
         let file = format!("{lang}.{}", get_file_extension(lang));
         let input = PathBuf::from(format!("tests/samples/input/{file}"));

--- a/topiary-cli/tests/samples/expected/nickel.ncl
+++ b/topiary-cli/tests/samples/expected/nickel.ncl
@@ -6,9 +6,10 @@
         std.string.split
           " "
           m%"
-          line one with trailing space 
-          line two
-        "%
+            line one with trailing space 
+             line two
+             
+          "%
         |> std.array.at 6
     },
     # Issue 680
@@ -230,17 +231,17 @@
   array = {
     NonEmpty
       | doc m%"
-          Enforces that an array is not empty.
+        Enforces that an array is not empty.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          ([] | std.array.NonEmpty) =>
-            error
-          ([ 1 ] | std.array.NonEmpty) =>
-            [ 1 ]
-          ```
-        "%
+        ```nickel
+        ([] | std.array.NonEmpty) =>
+          error
+        ([ 1 ] | std.array.NonEmpty) =>
+          [ 1 ]
+        ```
+      "%
       =
         %contract/custom% (fun _label value =>
           if %typeof% value == 'Array then
@@ -256,124 +257,124 @@
       : forall a. Array a -> a
       | NonEmpty -> Dyn
       | doc m%"
-          Returns the first element of an array.
+        Returns the first element of an array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.first [ "this is the head", "this is not" ] =>
-            "this is the head"
-          ```
-        "%
+        ```nickel
+        std.array.first [ "this is the head", "this is not" ] =>
+          "this is the head"
+        ```
+      "%
       = fun array => %array/at% array 0,
 
     last
       : forall a. Array a -> a
       | NonEmpty -> Dyn
       | doc m%"
-          Returns the last element of an array.
+        Returns the last element of an array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.last [ "this is the head", "this is not" ] =>
-            "this is not"
-          ```
-        "%
+        ```nickel
+        std.array.last [ "this is the head", "this is not" ] =>
+          "this is not"
+        ```
+      "%
       = fun array => %array/at% array (%array/length% array - 1),
 
     drop_first
       : forall a. Array a -> Array a
       | NonEmpty -> Dyn
       | doc m%"
-          Returns the given array without its first element.
+        Returns the given array without its first element.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.drop_first [ 1, 2, 3 ] =>
-            [ 2, 3 ]
-          ```
-        "%
+        ```nickel
+        std.array.drop_first [ 1, 2, 3 ] =>
+          [ 2, 3 ]
+        ```
+      "%
       = fun array => %array/slice% 1 (%array/length% array) array,
 
     drop_last
       : forall a. Array a -> Array a
       | NonEmpty -> Dyn
       | doc m%"
-          Returns the given array without its last element.
+        Returns the given array without its last element.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.drop_last [ 1, 2, 3 ] =>
-            [ 1, 2 ]
-          ```
-        "%
+        ```nickel
+        std.array.drop_last [ 1, 2, 3 ] =>
+          [ 1, 2 ]
+        ```
+      "%
       = fun array => %array/slice% 0 (%array/length% array - 1) array,
 
     length
       : forall a. Array a -> Number
       | doc m%"
-          Returns the length of an array.
+        Returns the length of an array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.length [ "Hello,", " World!" ] =>
-            2
-          ```
-        "%
+        ```nickel
+        std.array.length [ "Hello,", " World!" ] =>
+          2
+        ```
+      "%
       = fun l => %array/length% l,
 
     map
       : forall a b. (a -> b) -> Array a -> Array b
       | doc m%"
-          Applies a function to every element in the given array. That is,
-          `map f [ x1, x2, ..., xn ]` is `[ f x1, f x2, ..., f xn ]`.
+        Applies a function to every element in the given array. That is,
+        `map f [ x1, x2, ..., xn ]` is `[ f x1, f x2, ..., f xn ]`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.map (fun x => x + 1) [ 1, 2, 3 ] =>
-            [ 2, 3, 4 ]
-          ```
-        "%
+        ```nickel
+        std.array.map (fun x => x + 1) [ 1, 2, 3 ] =>
+          [ 2, 3, 4 ]
+        ```
+      "%
       = fun f l => %array/map% l f,
 
     at
       : forall a. Number -> Array a -> a
       | std.contract.unstable.IndexedArrayFun 'Index
       | doc m%"
-          Retrieves the n-th element from an array, with indices starting at 0.
+        Retrieves the n-th element from an array, with indices starting at 0.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.at 3 [ "zero", "one", "two", "three", "four" ] =>
-            "three"
-          ```
-        "%
+        ```nickel
+        std.array.at 3 [ "zero", "one", "two", "three", "four" ] =>
+          "three"
+        ```
+      "%
       = fun n l => %array/at% l n,
 
     at_or
       : forall a. Number -> a -> Array a -> a
       | std.number.Nat -> Dyn
       | doc m%"
-          Retrieves the n-th element from an array, with indices starting at 0
-          or the provided default value if the index is greater than the length
-          of the array.
+        Retrieves the n-th element from an array, with indices starting at 0
+        or the provided default value if the index is greater than the length
+        of the array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.at_or 3 "default" [ "zero", "one", "two", "three" ] =>
-            "three"
+        ```nickel
+        std.array.at_or 3 "default" [ "zero", "one", "two", "three" ] =>
+          "three"
 
-          std.array.at_or 3 "default" [ "zero", "one" ] =>
-            "default"
-          ```
-        "%
+        std.array.at_or 3 "default" [ "zero", "one" ] =>
+          "default"
+        ```
+      "%
       = fun n default_value array =>
         if n < %array/length% array then
           %array/at% array n
@@ -383,82 +384,82 @@
     concat
       : forall a. Array a -> Array a -> Array a
       | doc m%"
-          Appends the second array to the first one.
+        Appends the second array to the first one.
 
-          # Examples
+        # Examples
 
-          ```nickel
-            std.array.concat [ 1, 2, 3 ] [ 4, 5, 6 ] =>
-              [ 1, 2, 3, 4, 5, 6 ]
-          ```
-        "%
+        ```nickel
+          std.array.concat [ 1, 2, 3 ] [ 4, 5, 6 ] =>
+            [ 1, 2, 3, 4, 5, 6 ]
+        ```
+      "%
       = fun l1 l2 => l1 @ l2,
 
     fold_left
       : forall a b. (a -> b -> a) -> a -> Array b -> a
       | doc m%"
-          Folds a function over an array. In a functional language like Nickel,
-          folds serve a similar purpose to loops or iterators. `fold_left`
-          iterates over an array, by repeatedly applying a function to each
-          element, threading an additional arbitrary state (the accumulator, of
-          type `a` in the signature) through the chain of applications.
+        Folds a function over an array. In a functional language like Nickel,
+        folds serve a similar purpose to loops or iterators. `fold_left`
+        iterates over an array, by repeatedly applying a function to each
+        element, threading an additional arbitrary state (the accumulator, of
+        type `a` in the signature) through the chain of applications.
 
-          `fold_left f init [x1, x2, ..., xn]` results in `f (... (f (f init x1) x2) ...) xn`.
+        `fold_left f init [x1, x2, ..., xn]` results in `f (... (f (f init x1) x2) ...) xn`.
 
-          This function is strict in the intermediate accumulator.
+        This function is strict in the intermediate accumulator.
 
-          # Left vs right
+        # Left vs right
 
-          Folds come in two variants, left and right. How to decide which one to
-          use?
+        Folds come in two variants, left and right. How to decide which one to
+        use?
 
-          - If the folded function isn't associative (such as subtraction), then
-            each variant will give a different result. The choice is dictacted by
-            which one you need. For example:
-
-            ```nickel
-            std.array.fold_right (-) 0 [1, 2, 3, 4]
-             => -2
-            std.array.fold_left (-) 0 [1, 2, 3, 4]
-             => -10
-            ```
-          - If the folded function is associative, both `fold_right` and
-            `fold_left` return the same result. In that case, **`fold_left` is
-            generally preferred**, because it forces the evaluation of the
-            intermediate results resulting in less memory consumption and overall
-            better performance (outside of pathological cases).
-            `fold_left` also iterates from the start of the array, which
-            corresponds to the usual behavior of loops and iterators in most
-            programming languages. There is one case where `fold_right` might be
-            preferred, see the next point.
-          - If the folded function is associative but _(left) short-circuiting_,
-            meaning that it can sometimes determine the result without using the
-            right argument, then `fold_right` provides early return. An example is
-            the boolean AND operator `&&`: when evaluating `left && right`, if
-            `left` is `false`, the whole expression will evaluate to `false`
-            without even evaluating `right`. Consider the following expression:
-
-            ```nickel
-            std.array.replicate 1000 true
-            # gives [false, .. true 1000 times]
-            |> std.array.prepend false
-            |> std.array.fold_right (&&) [false]
-            ```
-
-            Here, `fold_right` will stop at the first element, and the operation
-            runs in constant time, given the definition of `fold_right` and the
-            lazy evaluation of Nickel. If we had used `fold_left` instead, which
-            is closer to a standard iterator, we would have iterated over all of
-            the 1000 elements of the array.
-
-          # Examples
+        - If the folded function isn't associative (such as subtraction), then
+          each variant will give a different result. The choice is dictacted by
+          which one you need. For example:
 
           ```nickel
-          fold_left (fun acc e => acc + e) 0 [ 1, 2, 3 ] =>
-            (((0 + 1) + 2) 3) =>
-            6
+          std.array.fold_right (-) 0 [1, 2, 3, 4]
+            => -2
+          std.array.fold_left (-) 0 [1, 2, 3, 4]
+            => -10
           ```
-        "%
+        - If the folded function is associative, both `fold_right` and
+          `fold_left` return the same result. In that case, **`fold_left` is
+          generally preferred**, because it forces the evaluation of the
+          intermediate results resulting in less memory consumption and overall
+          better performance (outside of pathological cases).
+          `fold_left` also iterates from the start of the array, which
+          corresponds to the usual behavior of loops and iterators in most
+          programming languages. There is one case where `fold_right` might be
+          preferred, see the next point.
+        - If the folded function is associative but _(left) short-circuiting_,
+          meaning that it can sometimes determine the result without using the
+          right argument, then `fold_right` provides early return. An example is
+          the boolean AND operator `&&`: when evaluating `left && right`, if
+          `left` is `false`, the whole expression will evaluate to `false`
+          without even evaluating `right`. Consider the following expression:
+
+          ```nickel
+          std.array.replicate 1000 true
+          # gives [false, .. true 1000 times]
+          |> std.array.prepend false
+          |> std.array.fold_right (&&) [false]
+          ```
+
+          Here, `fold_right` will stop at the first element, and the operation
+          runs in constant time, given the definition of `fold_right` and the
+          lazy evaluation of Nickel. If we had used `fold_left` instead, which
+          is closer to a standard iterator, we would have iterated over all of
+          the 1000 elements of the array.
+
+        # Examples
+
+        ```nickel
+        fold_left (fun acc e => acc + e) 0 [ 1, 2, 3 ] =>
+          (((0 + 1) + 2) 3) =>
+          6
+        ```
+      "%
       = fun f acc array =>
         let length = %array/length% array in
         if length == 0 then
@@ -480,35 +481,35 @@
     try_fold_left
       : forall a b c. (a -> c -> [| 'Ok a, 'Error b |]) -> a -> Array c -> [| 'Ok a, 'Error b |]
       | doc m%"
-          Folds a function over an array from left to right, possibly stopping early.
+        Folds a function over an array from left to right, possibly stopping early.
 
-          This differs from `fold_left` in that the function being folded returns either
-          `'Error y` (meaning that the folding should terminate, immediately returning
-          `'Error y`) or `'Ok acc` (meaning that the folding should continue as usual,
-          with the new accumulator `acc`). This early return can be used as an optimization,
-          to avoid evaluating the whole array.
+        This differs from `fold_left` in that the function being folded returns either
+        `'Error y` (meaning that the folding should terminate, immediately returning
+        `'Error y`) or `'Ok acc` (meaning that the folding should continue as usual,
+        with the new accumulator `acc`). This early return can be used as an optimization,
+        to avoid evaluating the whole array.
 
-          # Examples
+        # Examples
 
-          This defines a function that returns the first element satisfying a predicate.
+        This defines a function that returns the first element satisfying a predicate.
 
-          ```nickel
-          let find_first: forall a. (a -> Bool) -> Array a -> [| 'Some a, 'None |]
-            = fun pred xs =>
-              # Our fold function, which just ignores the accumulator and immediately
-              # returns an element if it satisfies the predicate. Note that `'Error`
-              # (which is the short-circuiting branch) means that we found something.
-              let f = fun _acc x => if pred x then 'Error x else 'Ok null in
-              try_fold_left f null xs |> match {
-                'Ok _ => 'None,
-                'Error x => 'Some x,
-              }
-          in
-          let even = fun x => x % 2 == 0 in
-          find_first even [1, 3, 4, 5, 2] =>
-            'Some 4
-          ```
-        "%
+        ```nickel
+        let find_first: forall a. (a -> Bool) -> Array a -> [| 'Some a, 'None |]
+          = fun pred xs =>
+            # Our fold function, which just ignores the accumulator and immediately
+            # returns an element if it satisfies the predicate. Note that `'Error`
+            # (which is the short-circuiting branch) means that we found something.
+            let f = fun _acc x => if pred x then 'Error x else 'Ok null in
+            try_fold_left f null xs |> match {
+              'Ok _ => 'None,
+              'Error x => 'Some x,
+            }
+        in
+        let even = fun x => x % 2 == 0 in
+        find_first even [1, 3, 4, 5, 2] =>
+          'Some 4
+        ```
+      "%
       = fun f acc array =>
         let length = %array/length% array in
         if length == 0 then
@@ -532,27 +533,27 @@
     fold_right
       : forall a b. (a -> b -> b) -> b -> Array a -> b
       | doc m%"
-          Folds a function over an array. Folds serve a similar purpose to loops or
-          iterators in a functional language like Nickel. `fold_right` iterates
-          over an array by repeatedly applying a function to each element and
-          threading an additional arbitrary state (the accumulator of type `a` in
-          the signature) through the chain of applications.
+        Folds a function over an array. Folds serve a similar purpose to loops or
+        iterators in a functional language like Nickel. `fold_right` iterates
+        over an array by repeatedly applying a function to each element and
+        threading an additional arbitrary state (the accumulator of type `a` in
+        the signature) through the chain of applications.
 
-          `fold_right f init [x1, x2, ..., xn]` results in `f x1 (f x2 (... (f xn init) ...))`.
+        `fold_right f init [x1, x2, ..., xn]` results in `f x1 (f x2 (... (f xn init) ...))`.
 
-          # Left vs right
+        # Left vs right
 
-          Folds come in two variants, left and right. How to decide which one to
-          use? Please refer to the documentation of `fold_left`.
+        Folds come in two variants, left and right. How to decide which one to
+        use? Please refer to the documentation of `fold_left`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.fold_right (fun e acc => acc @ [e]) [] [ 1, 2, 3 ] =>
-            ((([] @ [3]) @ [2]) @ [1]) =>
-            [ 3, 2, 1 ]
-          ```
-        "%
+        ```nickel
+        std.array.fold_right (fun e acc => acc @ [e]) [] [ 1, 2, 3 ] =>
+          ((([] @ [3]) @ [2]) @ [1]) =>
+          [ 3, 2, 1 ]
+        ```
+      "%
       = fun f fst l =>
         let length = %array/length% l in
         let rec go = fun n =>
@@ -566,105 +567,105 @@
     prepend
       : forall a. a -> Array a -> Array a
       | doc m%"
-          Builds an array given the first element and the rest of the array.
+        Builds an array given the first element and the rest of the array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.prepend 1 [ 2, 3 ] =>
-            [ 1, 2, 3 ]
-          ```
-        "%
+        ```nickel
+        std.array.prepend 1 [ 2, 3 ] =>
+          [ 1, 2, 3 ]
+        ```
+      "%
       = fun x l => [x] @ l,
 
     append
       : forall a. a -> Array a -> Array a
       | doc m%"
-          Builds an array given the last element and the rest of the array.
+        Builds an array given the last element and the rest of the array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.append 3 [ 1, 2 ] =>
-            [ 1, 2, 3 ]
-          ```
-        "%
+        ```nickel
+        std.array.append 3 [ 1, 2 ] =>
+          [ 1, 2, 3 ]
+        ```
+      "%
       = fun x l => l @ [x],
 
     reverse
       : forall a. Array a -> Array a
       | doc m%"
-          Reverses an array.
+        Reverses an array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.reverse [ 1, 2, 3 ] =>
-            [ 3, 2, 1 ]
-          ```
-        "%
+        ```nickel
+        std.array.reverse [ 1, 2, 3 ] =>
+          [ 3, 2, 1 ]
+        ```
+      "%
       = fun l => fold_left (fun acc e => [e] @ acc) [] l,
 
     filter
       : forall a. (a -> Bool) -> Array a -> Array a
       | doc m%"
-          `filter f xs` returns an array containing all elements from `xs` that satisfy `f`.
+        `filter f xs` returns an array containing all elements from `xs` that satisfy `f`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.filter (fun x => x <= 3) [ 4, 3, 2, 5, 1 ] =>
-            [ 3, 2, 1 ]
-          ```
-        "%
+        ```nickel
+        std.array.filter (fun x => x <= 3) [ 4, 3, 2, 5, 1 ] =>
+          [ 3, 2, 1 ]
+        ```
+      "%
       = fun pred l => fold_left (fun acc x => if pred x then acc @ [x] else acc) [] l,
 
     flatten
       : forall a. Array (Array a) -> Array a
       | doc m%"
-          Concatenates all elements of an array of arrays.
+        Concatenates all elements of an array of arrays.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.flatten [[1, 2], [3, 4]] =>
-            [1, 2, 3, 4]
-          ```
-        "%
+        ```nickel
+        std.array.flatten [[1, 2], [3, 4]] =>
+          [1, 2, 3, 4]
+        ```
+      "%
       = fun l => fold_right (fun l acc => l @ acc) [] l,
 
     all
       : forall a. (a -> Bool) -> Array a -> Bool
       | doc m%"
-          Returns `true` if all elements in the given array satisfy the predicate,
-          `false` otherwise.
+        Returns `true` if all elements in the given array satisfy the predicate,
+        `false` otherwise.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.all (fun x => x < 3) [ 1, 2 ] =>
-            true
-          std.array.all (fun x => x < 3) [ 1, 2, 3 ] =>
-            false
-          ```
-        "%
+        ```nickel
+        std.array.all (fun x => x < 3) [ 1, 2 ] =>
+          true
+        std.array.all (fun x => x < 3) [ 1, 2, 3 ] =>
+          false
+        ```
+      "%
       = fun pred l => fold_right (fun x acc => if pred x then acc else false) true l,
 
     any
       : forall a. (a -> Bool) -> Array a -> Bool
       | doc m%"
-          Returns `true` if at least one element in the given array satisfies
-          the predicate, `false` otherwise.
+        Returns `true` if at least one element in the given array satisfies
+        the predicate, `false` otherwise.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.any (fun x => x < 3) [ 1, 2, 3, 4 ] =>
-            true
-          std.array.any (fun x => x < 3) [ 5, 6, 7, 8 ] =>
-            false
-          ```
-        "%
+        ```nickel
+        std.array.any (fun x => x < 3) [ 1, 2, 3, 4 ] =>
+          true
+        std.array.any (fun x => x < 3) [ 5, 6, 7, 8 ] =>
+          false
+        ```
+      "%
       = fun pred l => fold_right (fun x acc => if pred x then true else acc) false l,
 
     # **Warning**: unless you know what you're doing, please don't change the
@@ -682,31 +683,31 @@
     elem
       : Dyn -> Array Dyn -> Bool
       | doc m%"
-          Returns `true` if the given value appears in the array, `false` otherwise.
+        Returns `true` if the given value appears in the array, `false` otherwise.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.elem 3 [ 1, 2, 3, 4, 5 ] =>
-            true
-          ```
-        "%
+        ```nickel
+        std.array.elem 3 [ 1, 2, 3, 4, 5 ] =>
+          true
+        ```
+      "%
       = fun elt => any (fun x => x == elt),
 
     partition
       : forall a. (a -> Bool) -> Array a -> { right : Array a, wrong : Array a }
       | doc m%"
-          Partitions an array into two new arrays. `right` will contain all
-          elements that satisfy the predicate, while `wrong` will contain those
-          that do not.
+        Partitions an array into two new arrays. `right` will contain all
+        elements that satisfy the predicate, while `wrong` will contain those
+        that do not.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.partition (fun x => x < 5) [ 2, 4, 5, 3, 7, 8, 6 ] =>
-            { right = [ 2, 4, 3 ], wrong = [ 5, 7, 8, 6 ] }
-          ```
-        "%
+        ```nickel
+        std.array.partition (fun x => x < 5) [ 2, 4, 5, 3, 7, 8, 6 ] =>
+          { right = [ 2, 4, 3 ], wrong = [ 5, 7, 8, 6 ] }
+        ```
+      "%
       = fun pred l =>
         let aux = fun acc x =>
           if (pred x) then
@@ -720,34 +721,34 @@
       : forall a. (Number -> a) -> Number -> Array a
       | Dyn -> std.number.Nat -> Dyn
       | doc m%"
-          `generate f n` returns an array of length `n` by applying `f` to the
-          integers from `0` to `n-1`. That is, `generate f n` is
-          `[ f 0, f 1, ..., f (n - 1)]`
+        `generate f n` returns an array of length `n` by applying `f` to the
+        integers from `0` to `n-1`. That is, `generate f n` is
+        `[ f 0, f 1, ..., f (n - 1)]`
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.generate (fun x => x * x) 4 =>
-            [ 0, 1, 4, 9 ]
-          ```
-        "%
+        ```nickel
+        std.array.generate (fun x => x * x) 4 =>
+          [ 0, 1, 4, 9 ]
+        ```
+      "%
       = fun f n => %array/generate% n f,
 
     compare
       : forall a. (a -> a -> [| 'Lesser, 'Equal, 'Greater |]) -> Array a -> Array a -> [| 'Lesser, 'Equal, 'Greater |]
       | doc m%"
-          `compare order a b` lexicographically compares `a` and `b`, using `order` to
-          compare the individual elements.
+        `compare order a b` lexicographically compares `a` and `b`, using `order` to
+        compare the individual elements.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.compare std.number.compare [3, 1, 4] [6, 2, 8] =>
-            'Lesser
-          std.array.compare std.string.compare ["hello", "world"] ["hello"] =>
-            'Greater
-          ```
-        "%
+        ```nickel
+        std.array.compare std.number.compare [3, 1, 4] [6, 2, 8] =>
+          'Lesser
+        std.array.compare std.string.compare ["hello", "world"] ["hello"] =>
+          'Greater
+        ```
+      "%
       =
         let refine = fun left right =>
           left
@@ -764,22 +765,22 @@
     sort
       : forall a. (a -> a -> [| 'Lesser, 'Equal, 'Greater |]) -> Array a -> Array a
       | doc m%"
-          Sorts an array based on the provided comparison operator.
+        Sorts an array based on the provided comparison operator.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.sort (fun x y =>
-            if x < y then
-              'Lesser
-            else if (x == y) then
-              'Equal
-            else
-              'Greater)
-            [ 4, 5, 1, 2 ]
-          => [ 1, 2, 4, 5 ]
-          ```
-        "%
+        ```nickel
+        std.array.sort (fun x y =>
+          if x < y then
+            'Lesser
+          else if (x == y) then
+            'Equal
+          else
+            'Greater)
+          [ 4, 5, 1, 2 ]
+        => [ 1, 2, 4, 5 ]
+        ```
+      "%
       #TODO: maybe inline partition to avoid contract checks?
       = fun cmp array =>
         let length = %array/length% array in
@@ -794,34 +795,34 @@
     flat_map
       : forall a b. (a -> Array b) -> Array a -> Array b
       | doc m%"
-          First `map` the given function over the array and then `flatten` the
-          result.
+        First `map` the given function over the array and then `flatten` the
+        result.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.flat_map (fun x => [x, x]) [1, 2, 3]
-            => [1, 1, 2, 2, 3, 3]
-          ```
-        "%
+        ```nickel
+        std.array.flat_map (fun x => [x, x]) [1, 2, 3]
+          => [1, 1, 2, 2, 3, 3]
+        ```
+      "%
       = fun f xs => map f xs |> flatten,
 
     intersperse
       : forall a. a -> Array a -> Array a
       | doc m%"
-          Intersperses a value between the elements of an array.
+        Intersperses a value between the elements of an array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.intersperse ", " [ "Hello", "wonderful", "world!" ]
-            => [ "Hello", ", ", "wonderful", ", ", "world!" ]
-          std.array.intersperse ", " [ "Hello" ]
-            => [ "Hello" ]
-          std.array.intersperse ", " []
-            => []
-          ```
-        "%
+        ```nickel
+        std.array.intersperse ", " [ "Hello", "wonderful", "world!" ]
+          => [ "Hello", ", ", "wonderful", ", ", "world!" ]
+        std.array.intersperse ", " [ "Hello" ]
+          => [ "Hello" ]
+        std.array.intersperse ", " []
+          => []
+        ```
+      "%
       = fun v array =>
         let length = %array/length% array in
         if length <= 1 then
@@ -835,51 +836,51 @@
       : forall a. Number -> Number -> Array a -> Array a
       | std.contract.unstable.ArraySliceFun
       | doc m%"
-          `slice start end array` returns the slice of `array` between `start` (included) and
-          `end` (excluded).
+        `slice start end array` returns the slice of `array` between `start` (included) and
+        `end` (excluded).
 
-          # Preconditions
+        # Preconditions
 
-          In `slice start end value`, `start` and `end` must be positive
-          integers such that `0 <= start <= end <= std.array.length value`.
+        In `slice start end value`, `start` and `end` must be positive
+        integers such that `0 <= start <= end <= std.array.length value`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.slice 1 3 [ 0, 1, 2, 3, 4, 5]
-            => [ 1, 2 ]
-          std.array.slice 0 3 [ "Hello", "world", "!" ]
-            => [ "Hello", "world", "!" ]
-          std.array.slice 2 3 [ "Hello", "world", "!" ]
-            => [ "!" ]
-           ```
-        "%
+        ```nickel
+        std.array.slice 1 3 [ 0, 1, 2, 3, 4, 5]
+          => [ 1, 2 ]
+        std.array.slice 0 3 [ "Hello", "world", "!" ]
+          => [ "Hello", "world", "!" ]
+        std.array.slice 2 3 [ "Hello", "world", "!" ]
+          => [ "!" ]
+         ```
+      "%
       = fun start end value => %array/slice% start end value,
 
     split_at
       : forall a. Number -> Array a -> { left : Array a, right : Array a }
       | std.contract.unstable.IndexedArrayFun 'Split
       | doc m%"
-          Splits an array in two at a given index and puts all the elements
-          to the left of the element at the given index (excluded) in the
-          `left` field, and the rest of the array in the `right` field.
+        Splits an array in two at a given index and puts all the elements
+        to the left of the element at the given index (excluded) in the
+        `left` field, and the rest of the array in the `right` field.
 
-          # Preconditions
+        # Preconditions
 
-          In `split_at index value`, `index` must be a positive integer such
-          that `0 <= index <= std.array.length value`.
+        In `split_at index value`, `index` must be a positive integer such
+        that `0 <= index <= std.array.length value`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.split_at 2 [ 0, 1, 2, 3, 4, 5]
-            => { left = [ 0, 1 ], right = [ 2, 3, 4, 5 ] }
-          std.array.split_at 0 [ "Hello", "world", "!" ]
-            => { left = [  ], right = [ "Hello", "world", "!" ] }
-          std.array.split_at 3 [ "Hello", "world", "!" ]
-            => { left = [ "Hello", "world", "!" ], right = [  ] }
-          ```
-        "%
+        ```nickel
+        std.array.split_at 2 [ 0, 1, 2, 3, 4, 5]
+          => { left = [ 0, 1 ], right = [ 2, 3, 4, 5 ] }
+        std.array.split_at 0 [ "Hello", "world", "!" ]
+          => { left = [  ], right = [ "Hello", "world", "!" ] }
+        std.array.split_at 3 [ "Hello", "world", "!" ]
+          => { left = [ "Hello", "world", "!" ], right = [  ] }
+        ```
+      "%
       = fun index value =>
         {
           left = %array/slice% 0 index value,
@@ -890,43 +891,43 @@
       : forall a. Number -> a -> Array a
       | std.number.Nat -> Dyn
       | doc m%"
-          `replicate n x` creates an array containing `x` exactly `n` times.
+        `replicate n x` creates an array containing `x` exactly `n` times.
 
-          # Preconditions
+        # Preconditions
 
-          `n` must be an integer greater or equal to `0`.
+        `n` must be an integer greater or equal to `0`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.replicate 0 false
-            => [ ]
-          std.array.replicate 5 "x"
-            => [ "x", "x", "x", "x", "x" ]
-          ```
-        "%
+        ```nickel
+        std.array.replicate 0 false
+          => [ ]
+        std.array.replicate 5 "x"
+          => [ "x", "x", "x", "x", "x" ]
+        ```
+      "%
       = fun n x => %array/generate% n (fun _i => x),
 
     range_step
       : Number -> Number -> Number -> Array Number
       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
       | doc m%"
-          `range_step start end step` generates the array of numbers
-          `[start, start + step, start + 2*step, ..]` up to the first element
-          (excluded) larger than or equal to `end`
+        `range_step start end step` generates the array of numbers
+        `[start, start + step, start + 2*step, ..]` up to the first element
+        (excluded) larger than or equal to `end`
 
-          # Preconditions
+        # Preconditions
 
-          In `range_step start end step`, `start` and `end` must satisfy `start
-          <= end`. `step` must be strictly greater than `0`.
+        In `range_step start end step`, `start` and `end` must satisfy `start
+        <= end`. `step` must be strictly greater than `0`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.range_step (-1.5) 2 0.5
-           => [ -1.5, -1, -0.5, 0, 0.5, 1, 1.5 ]
-          ```
-        "%
+        ```nickel
+        std.array.range_step (-1.5) 2 0.5
+         => [ -1.5, -1, -0.5, 0, 0.5, 1, 1.5 ]
+        ```
+      "%
       = fun start end step =>
         %array/generate%
           ((end - start) / step |> std.number.floor)
@@ -936,60 +937,60 @@
       : Number -> Number -> Array Number
       | std.contract.unstable.RangeFun Dyn
       | doc m%"
-          `range start end` generates the array of numbers
-          `[start, start + 1, start + 2, ..]` up to the first element
-          (excluded) larger than or equal to `end`.
+        `range start end` generates the array of numbers
+        `[start, start + 1, start + 2, ..]` up to the first element
+        (excluded) larger than or equal to `end`.
 
-          `range start end` is equivalent to `range_step start end 1`.
+        `range start end` is equivalent to `range_step start end 1`.
 
-          # Preconditions
+        # Preconditions
 
-          In `range_step start end`, `start` and `end` must satisfy
-          `start <= end`.
+        In `range_step start end`, `start` and `end` must satisfy
+        `start <= end`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.range 0 5
-           => [ 0, 1, 2, 3, 4 ]
-          ```
-        "%
+        ```nickel
+        std.array.range 0 5
+         => [ 0, 1, 2, 3, 4 ]
+        ```
+      "%
       = fun start end => range_step start end 1,
 
     reduce_left
       : forall a. (a -> a -> a) -> Array a -> a
       | Dyn -> NonEmpty -> Dyn
       | doc m%"
-          Reduces the elements to a single one, by repeatedly applying a
-          reducing operation.
+        Reduces the elements to a single one, by repeatedly applying a
+        reducing operation.
 
-          `reduce_left` associates to the left, that is
-          `reduce_left op [x1, x2, ..., xn]` results in `op (... (op (op x1 x2) x3) ...) xn`.
+        `reduce_left` associates to the left, that is
+        `reduce_left op [x1, x2, ..., xn]` results in `op (... (op (op x1 x2) x3) ...) xn`.
 
-          `reduce_left` is the same as `fold_left`, but uses the first element as
-          the initial accumulator.
+        `reduce_left` is the same as `fold_left`, but uses the first element as
+        the initial accumulator.
 
-          # Preconditions
+        # Preconditions
 
-          The provided array must be non-empty.
+        The provided array must be non-empty.
 
-          # Left vs right
+        # Left vs right
 
-          The rationale to decide between `fold_left` and `fold_right` applies to
-          `reduce_left` and `reduce_right` as well. See the documentation of
-          `fold_left`.
+        The rationale to decide between `fold_left` and `fold_right` applies to
+        `reduce_left` and `reduce_right` as well. See the documentation of
+        `fold_left`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.reduce_left (@) [ [1, 2], [3], [4,5] ]
-            => (([1, 2] @ [3]) @ [4,5])
-            => [ 1, 2, 4, 5 ]
-          std.array.reduce_left (-) [ 1, 2, 3, 4]
-            => ((1 - 2) - 3) - 4
-            => -8
-          ```
-        "%
+        ```nickel
+        std.array.reduce_left (@) [ [1, 2], [3], [4,5] ]
+          => (([1, 2] @ [3]) @ [4,5])
+          => [ 1, 2, 4, 5 ]
+        std.array.reduce_left (-) [ 1, 2, 3, 4]
+          => ((1 - 2) - 3) - 4
+          => -8
+        ```
+      "%
       = fun f array =>
         let first = %array/at% array 0 in
         let rest = %array/slice% 1 (%array/length% array) array in
@@ -999,37 +1000,37 @@
       : forall a. (a -> a -> a) -> Array a -> a
       | Dyn -> NonEmpty -> Dyn
       | doc m%"
-          Reduces the elements to a single one, by repeatedly applying a reducing
-          operation.
+        Reduces the elements to a single one, by repeatedly applying a reducing
+        operation.
 
-          `reduce_right` associates to the right, that is
-          `reduce_right op [x1, x2, ..., xn]` results in
-          `op x1 (op x2 (... (op xn-1 xn) ...))`.
+        `reduce_right` associates to the right, that is
+        `reduce_right op [x1, x2, ..., xn]` results in
+        `op x1 (op x2 (... (op xn-1 xn) ...))`.
 
-          `reduce_right` is the same as `fold_right`, but uses the last element as
-          the initial element.
+        `reduce_right` is the same as `fold_right`, but uses the last element as
+        the initial element.
 
-          # Preconditions
+        # Preconditions
 
-          The provided array must be non-empty.
+        The provided array must be non-empty.
 
-          # Left vs right
+        # Left vs right
 
-          The rationale to decide between `fold_left` and `fold_right` applies to
-          `reduce_left` and `reduce_right` as well. See the documentation of
-          `fold_left`.
+        The rationale to decide between `fold_left` and `fold_right` applies to
+        `reduce_left` and `reduce_right` as well. See the documentation of
+        `fold_left`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.reduce_right (@) [ [1, 2], [3], [4,5] ]
-            => [1, 2] @ ([3] @ [4,5])
-            => [ 1, 2, 4, 5 ]
-          std.array.reduce_right (-) [ 1, 2, 3, 4]
-            => 1 - (2 - (3 - 4))
-            => -2
-          ```
-        "%
+        ```nickel
+        std.array.reduce_right (@) [ [1, 2], [3], [4,5] ]
+          => [1, 2] @ ([3] @ [4,5])
+          => [ 1, 2, 4, 5 ]
+        std.array.reduce_right (-) [ 1, 2, 3, 4]
+          => 1 - (2 - (3 - 4))
+          => -2
+        ```
+      "%
       = fun f array =>
         let last_index = %array/length% array - 1 in
         let last = %array/at% array last_index in
@@ -1039,21 +1040,21 @@
     zip_with
       : forall a b c. (a -> b -> c) -> Array a -> Array b -> Array c
       | doc m%"
-          `zip_with f xs ys` combines the arrays `xs` and `ys` using the
-          operation `f`. The resulting array's length will be the smaller of the
-          lengths of `xs` and `ys`.
+        `zip_with f xs ys` combines the arrays `xs` and `ys` using the
+        operation `f`. The resulting array's length will be the smaller of the
+        lengths of `xs` and `ys`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.zip_with (+) [1, 2, 3] [4, 5, 6]
-            => [5, 7, 9]
-          std.array.zip_with (*) [1, 2] [4, 5, 6]
-            => [4, 10]
-          std.array.zip_with (-) [1, 2, 3] [4, 5]
-            => [-3, -3]
-          ```
-        "%
+        ```nickel
+        std.array.zip_with (+) [1, 2, 3] [4, 5, 6]
+          => [5, 7, 9]
+        std.array.zip_with (*) [1, 2] [4, 5, 6]
+          => [4, 10]
+        std.array.zip_with (-) [1, 2, 3] [4, 5]
+          => [-3, -3]
+        ```
+      "%
       = fun f xs ys =>
         std.array.generate
           (fun i => f (std.array.at i xs) (std.array.at i ys))
@@ -1062,17 +1063,17 @@
     map_with_index
       : forall a b. (Number -> a -> b) -> Array a -> Array b
       | doc m%"
-          Applies a function to every element in the given array while passing
-          its (0-based) index. That is,
-          `map_with_index f [ x1, x2, ... ]` is `[ f 0 x1, f 1 x2, ... ]`.
+        Applies a function to every element in the given array while passing
+        its (0-based) index. That is,
+        `map_with_index f [ x1, x2, ... ]` is `[ f 0 x1, f 1 x2, ... ]`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.map_with_index (fun i x => i + x + 1) [ 1, 2, 3 ] =>
-            [ 2, 4, 6 ]
-          ```
-        "%
+        ```nickel
+        std.array.map_with_index (fun i x => i + x + 1) [ 1, 2, 3 ] =>
+          [ 2, 4, 6 ]
+        ```
+      "%
       = fun f xs =>
         xs
         |> std.array.length
@@ -1191,51 +1192,51 @@
 
     blame
       | doc m%"
-          Raises blame for a given label.
+        Raises blame for a given label.
 
-          Type: `forall a. Label -> a`
-          (for technical reasons, this function isn't actually statically typed)
+        Type: `forall a. Label -> a`
+        (for technical reasons, this function isn't actually statically typed)
 
-          Blame is the mechanism to signal contract violation in Nickel. It
-          ends the program execution and prints a detailed report thanks to the
-          information tracked inside the label.
+        Blame is the mechanism to signal contract violation in Nickel. It
+        ends the program execution and prints a detailed report thanks to the
+        information tracked inside the label.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          IsZero = fun label value =>
-            if value == 0 then
-              value
-            else
-              std.contract.blame label
-          ```
-        "%
+        ```nickel
+        IsZero = fun label value =>
+          if value == 0 then
+            value
+          else
+            std.contract.blame label
+        ```
+      "%
       = fun label => %blame% label,
 
     blame_with_message
       | doc m%"
-          Raises blame with respect to a given label with a custom error message.
+        Raises blame with respect to a given label with a custom error message.
 
-          Type: `forall a. String -> Label -> a`
-          (for technical reasons, this function isn't actually statically typed)
+        Type: `forall a. String -> Label -> a`
+        (for technical reasons, this function isn't actually statically typed)
 
-          Same as `blame`, but takes an additional error message that will be
-          displayed as part of the blame error. `blame_with_message message label`
-          is equivalent to `blame (label.with_message message label)`
+        Same as `blame`, but takes an additional error message that will be
+        displayed as part of the blame error. `blame_with_message message label`
+        is equivalent to `blame (label.with_message message label)`
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let IsZero = fun label value =>
-            if value == 0 then
-              value
-            else
-              std.contract.blame_with_message "Not zero" label
-          in
+        ```nickel
+        let IsZero = fun label value =>
+          if value == 0 then
+            value
+          else
+            std.contract.blame_with_message "Not zero" label
+        in
 
-          0 | IsZero
-          ```
-        "%
+        0 | IsZero
+        ```
+      "%
       = fun message label => %blame% (%label/with_message% message label),
 
     custom
@@ -1249,85 +1250,85 @@
         |]
       ) -> Dyn
       | doc m%"
-          Build a generic custom contract. Whenever possible, more restricted
-          constructors such as `std.contract.from_predicate` or
-          `std.contract.from_validator` should be used. However, the most
-          general `std.contract.custom` might be required to write delayed
-          contracts or contracts taking other contracts as parameters.
+        Build a generic custom contract. Whenever possible, more restricted
+        constructors such as `std.contract.from_predicate` or
+        `std.contract.from_validator` should be used. However, the most
+        general `std.contract.custom` might be required to write delayed
+        contracts or contracts taking other contracts as parameters.
 
-          # Custom contracts
+        # Custom contracts
 
-          The argument of `std.contract.custom` is a function that takes a label
-          and the value to be checked, and returns `'Ok value` to return
-          the original value with potential delayed checks inside, or `'Error
-          {..}` to signal an immediate contract violation.
+        The argument of `std.contract.custom` is a function that takes a label
+        and the value to be checked, and returns `'Ok value` to return
+        the original value with potential delayed checks inside, or `'Error
+        {..}` to signal an immediate contract violation.
 
-          The label should only be used for delayed checks. The preferred method
-          to indicate a contract violation is to return `'Error {..}`.
+        The label should only be used for delayed checks. The preferred method
+        to indicate a contract violation is to return `'Error {..}`.
 
-          For more details on custom contracts and delayed contracts, please
-          refer to the corresponding section of the user manual.
+        For more details on custom contracts and delayed contracts, please
+        refer to the corresponding section of the user manual.
 
-          # Typing
+        # Typing
 
-          Because Nickel doesn't currently have proper types for labels and
-          contracts, they are replaced with `Dyn` in the type signature. You can
-          think of the actual type of the delayed part as `(Label -> Dyn ->
-          [| ... |])`, and the return type of `custom` as `Contract`.
+        Because Nickel doesn't currently have proper types for labels and
+        contracts, they are replaced with `Dyn` in the type signature. You can
+        think of the actual type of the delayed part as `(Label -> Dyn ->
+        [| ... |])`, and the return type of `custom` as `Contract`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let Nullable = fun Contract =>
-            std.contract.custom (fun label value =>
-              if value == null then
-                'Ok value
-              else
-                std.contract.check Contract label value
-            )
-          in
+        ```nickel
+        let Nullable = fun Contract =>
+          std.contract.custom (fun label value =>
+            if value == null then
+              'Ok value
+            else
+              std.contract.check Contract label value
+          )
+        in
 
-          null | Nullable Number
-            => null
-          ```
-        "%
+        null | Nullable Number
+          => null
+        ```
+      "%
       = fun contract => %contract/custom% contract,
 
     from_predicate
       | (Dyn -> Bool) -> Dyn
       | doc m%"
-          Build a contract from a boolean predicate.
+        Build a contract from a boolean predicate.
 
-          # Contract application
+        # Contract application
 
-          Before Nickel 1.8, `from_predicate` used to wrap the predicate as a
-          naked function of a label and value. You could thus theoretically
-          apply it as a normal function, as in
-          `(std.contract.from_predicate my_pred) label value`. While possible,
-          this wasn't recommended nor really officially supported: all contracts
-          should be applied using a contract annotation or `std.contract.apply`
-          and its variants, as explained in the documentation of
-          `std.contract.apply`.
+        Before Nickel 1.8, `from_predicate` used to wrap the predicate as a
+        naked function of a label and value. You could thus theoretically
+        apply it as a normal function, as in
+        `(std.contract.from_predicate my_pred) label value`. While possible,
+        this wasn't recommended nor really officially supported: all contracts
+        should be applied using a contract annotation or `std.contract.apply`
+        and its variants, as explained in the documentation of
+        `std.contract.apply`.
 
-          From Nickel 1.8 and onwards, `from_predicate` generates a bespoke
-          contract value that can only be used in an annotation, be passed to
-          `std.contract.apply` or other operations on contracts, but can't be
-          used as normal function anymore.
+        From Nickel 1.8 and onwards, `from_predicate` generates a bespoke
+        contract value that can only be used in an annotation, be passed to
+        `std.contract.apply` or other operations on contracts, but can't be
+        used as normal function anymore.
 
-          # Typing
+        # Typing
 
-          Because Nickel doesn't currently have proper types for contracts, the
-          return type of `from_predicate` is simply `Dyn` in the type signature.
-          You should think of `from_predicate` as some returning a value of some
-          hypothetical type `Contract`.
+        Because Nickel doesn't currently have proper types for contracts, the
+        return type of `from_predicate` is simply `Dyn` in the type signature.
+        You should think of `from_predicate` as some returning a value of some
+        hypothetical type `Contract`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let IsZero = std.contract.from_predicate (fun x => x == 0) in
-          0 | IsZero
-          ```
-        "%
+        ```nickel
+        let IsZero = std.contract.from_predicate (fun x => x == 0) in
+        0 | IsZero
+        ```
+      "%
       = fun pred =>
         %contract/custom% (fun _label value =>
           if pred value then
@@ -1351,43 +1352,43 @@
         |]
       ) -> Dyn
       | doc m%%"
-          Build a contract from a validator.
+        Build a contract from a validator.
 
-          # Validator
+        # Validator
 
-          A validator is a function returning either `'Ok` or `'Error {message,
-          notes}` with an optional error message and notes to display. Both
-          validators and predicates are immediate contracts: they must decide
-          right away if the value passes or fails (as opposed to delayed
-          contracts). But as opposed to predicates, validators have the
-          additional ability to customize the error reporting.
+        A validator is a function returning either `'Ok` or `'Error {message,
+        notes}` with an optional error message and notes to display. Both
+        validators and predicates are immediate contracts: they must decide
+        right away if the value passes or fails (as opposed to delayed
+        contracts). But as opposed to predicates, validators have the
+        additional ability to customize the error reporting.
 
-          # Typing
+        # Typing
 
-          Because Nickel doesn't currently have proper types for contracts, the
-          return type of `from_validator` is simply `Dyn` in the type signature.
-          You should think of `from_validator` as returning a value of some
-          hypothetical type `Contract`.
+        Because Nickel doesn't currently have proper types for contracts, the
+        return type of `from_validator` is simply `Dyn` in the type signature.
+        You should think of `from_validator` as returning a value of some
+        hypothetical type `Contract`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let IsZero = std.contract.from_validator (match {
-            0 => 'Ok,
-            n if std.is_number n =>
-              'Error {
-                message = "expected 0, got %{std.to_string n}",
-                notes = ["The value is a number, but it isn't 0"],
-              },
-            v =>
-              let vtype = v |> std.typeof |> std.to_string in
-              'Error { message = "expected a number, got a %{vtype}" }
-          })
-          in
+        ```nickel
+        let IsZero = std.contract.from_validator (match {
+          0 => 'Ok,
+          n if std.is_number n =>
+            'Error {
+              message = "expected 0, got %{std.to_string n}",
+              notes = ["The value is a number, but it isn't 0"],
+            },
+          v =>
+            let vtype = v |> std.typeof |> std.to_string in
+            'Error { message = "expected a number, got a %{vtype}" }
+        })
+        in
 
-          0 | IsZero
-          ```
-        "%%
+        0 | IsZero
+        ```
+      "%%
       # A validator turns out to be a valid custom contract as well (which just
       # never returns a value with delayed checks)
       = fun validator =>
@@ -1403,37 +1404,37 @@
     Sequence
       | Array Dyn -> Dyn
       | doc m%"
-          Apply multiple contracts from left to right.
+        Apply multiple contracts from left to right.
 
-          Type: `Array Contract -> Contract`
-          (for technical reasons, this function isn't actually statically typed)
+        Type: `Array Contract -> Contract`
+        (for technical reasons, this function isn't actually statically typed)
 
-          # Examples
+        # Examples
 
-          ```nickel
-          x | std.contract.Sequence [ Foo, Bar ]
-          ```
+        ```nickel
+        x | std.contract.Sequence [ Foo, Bar ]
+        ```
 
-          is equivalent to
+        is equivalent to
 
-          ```nickel
-          (x | Foo) | Bar
-          ```
+        ```nickel
+        (x | Foo) | Bar
+        ```
 
-          This is useful in positions where one cannot apply multiple contracts,
-          such as an argument to another contract:
+        This is useful in positions where one cannot apply multiple contracts,
+        such as an argument to another contract:
 
-          ```nickel
-          x | Array (std.contract.Sequence [ Foo, Bar ])
-          ```
+        ```nickel
+        x | Array (std.contract.Sequence [ Foo, Bar ])
+        ```
 
-          Or stored in a variable:
+        Or stored in a variable:
 
-          ```nickel
-          let C = std.contract.Sequence [ Foo, Bar ] in
-          x | C
-          ```
-        "%
+        ```nickel
+        let C = std.contract.Sequence [ Foo, Bar ] in
+        x | C
+        ```
+      "%
       = fun contracts =>
         %contract/custom% (fun label value =>
           std.array.try_fold_left
@@ -1444,261 +1445,261 @@
 
     label
       | doc m%"
-          The label submodule provides functions that manipulate the label
-          associated with a contract application.
+        The label submodule provides functions that manipulate the label
+        associated with a contract application.
 
-          A label is a special opaque value automatically passed by the Nickel
-          interpreter to contracts when performing a contract check.
+        A label is a special opaque value automatically passed by the Nickel
+        interpreter to contracts when performing a contract check.
 
-          A label stores a stack of custom error diagnostics, that can be
-          manipulated by the functions in this module. Labels thus offer a way to
-          customize the error message that will be shown if a contract is broken.
+        A label stores a stack of custom error diagnostics, that can be
+        manipulated by the functions in this module. Labels thus offer a way to
+        customize the error message that will be shown if a contract is broken.
 
-          Note that the label should only be used for delayed checks. Immediate
-          error reporting is better done in custom contracts by returning an
-          error value.
+        Note that the label should only be used for delayed checks. Immediate
+        error reporting is better done in custom contracts by returning an
+        error value.
 
-          The setters (`with_XXX` functions) always operate on the current error
-          diagnostic, which is the last diagnostic on the stack. If the stack is
-          empty, a fresh diagnostic is silently created when using a setter.
+        The setters (`with_XXX` functions) always operate on the current error
+        diagnostic, which is the last diagnostic on the stack. If the stack is
+        empty, a fresh diagnostic is silently created when using a setter.
 
-          The previous diagnostics on the stack are considered archived, and
-          can't be modified anymore. All diagnostics will be shown during error
-          reporting, with the most recent being used as the main one.
+        The previous diagnostics on the stack are considered archived, and
+        can't be modified anymore. All diagnostics will be shown during error
+        reporting, with the most recent being used as the main one.
 
-          `std.contract.apply` and `std.contract.check` are the
-          operations that push a new fresh diagnostic on the stack, saving the
-          previously current error diagnostic. `apply` and friends are typically
-          used to apply subcontracts inside a parent contract. Stacking the
-          current diagnostic potentially customized by the parent contract saves
-          the information inside, and provides a fresh diagnostic for the child
-          contract to use.
-        "%
+        `std.contract.apply` and `std.contract.check` are the
+        operations that push a new fresh diagnostic on the stack, saving the
+        previously current error diagnostic. `apply` and friends are typically
+        used to apply subcontracts inside a parent contract. Stacking the
+        current diagnostic potentially customized by the parent contract saves
+        the information inside, and provides a fresh diagnostic for the child
+        contract to use.
+      "%
       = {
         with_message
           | doc m%"
-              Attaches a custom error message to the current error diagnostic of a
-              label.
+            Attaches a custom error message to the current error diagnostic of a
+            label.
 
-              Type: `String -> Label -> Label`
-              (for technical reasons, this function isn't actually statically typed)
+            Type: `String -> Label -> Label`
+            (for technical reasons, this function isn't actually statically typed)
 
-              If a custom error message was previously set, there are two
-              possibilities:
-                - the label has gone through a `std.contract.apply` call in-between.
-                  In this case, the previous diagnostic has been stacked, and
-                  using `with_message` won't erase anything but rather modify
-                  the fresh current diagnostic.
-                - no `std.contract.apply` has taken place since the last message
-                  was set. In this case, the current diagnostic's error message
-                  is replaced.
+            If a custom error message was previously set, there are two
+            possibilities:
+              - the label has gone through a `std.contract.apply` call in-between.
+                In this case, the previous diagnostic has been stacked, and
+                using `with_message` won't erase anything but rather modify
+                the fresh current diagnostic.
+              - no `std.contract.apply` has taken place since the last message
+                was set. In this case, the current diagnostic's error message
+                is replaced.
 
-              # Examples
+            # Examples
 
-              This example implements a contract which ensures that the value is
-              a record with a field `foo` that is an even number.
+            This example implements a contract which ensures that the value is
+            a record with a field `foo` that is an even number.
 
-              ```nickel
-              let FooIsEven = std.contract.custom (fun label =>
-                match {
-                  record @ { foo, .. } =>
-                    'Ok (
-                      std.record.map (fun key value =>
-                        if key == "foo"
-                        && !(std.is_number value && value % 2 == 0) then
-                          label
-                          |> std.contract.label.with_message "field foo must be an even number"
-                          |> std.contract.blame
-                        else
-                          value
-                      )
-                      record
-                    ),
-                  _ => 'Error {},
-                }
-              )
-              in
+            ```nickel
+            let FooIsEven = std.contract.custom (fun label =>
+              match {
+                record @ { foo, .. } =>
+                  'Ok (
+                    std.record.map (fun key value =>
+                      if key == "foo"
+                      && !(std.is_number value && value % 2 == 0) then
+                        label
+                        |> std.contract.label.with_message "field foo must be an even number"
+                        |> std.contract.blame
+                      else
+                        value
+                    )
+                    record
+                  ),
+                _ => 'Error {},
+              }
+            )
+            in
 
-              { foo = 4, hello = "world" } | FooIsEven
-                => { foo = 4, hello = "world" }
-              ```
-            "%
+            { foo = 4, hello = "world" } | FooIsEven
+              => { foo = 4, hello = "world" }
+            ```
+          "%
           = fun message label => %label/with_message% message label,
 
         with_notes
           | doc m%"
-              Attaches custom error notes to the current error diagnostic of a
-              label.
+            Attaches custom error notes to the current error diagnostic of a
+            label.
 
-              Type: `Array String -> Label -> Label`
-              (for technical reasons, this function isn't actually statically typed)
+            Type: `Array String -> Label -> Label`
+            (for technical reasons, this function isn't actually statically typed)
 
-              If custom error notes were previously set, there are two
-              possibilities:
-                - the label has gone through a `std.contract.apply` call in-between.
-                  In this case, the previous diagnostic has been stacked, and
-                  using `with_notes` won't erase anything but rather modify the
-                  fresh current diagnostic.
-                - no `std.contract.apply` has taken place since the last message was
-                  set. In this case, the current diagnostic's error notes will
-                  be replaced.
+            If custom error notes were previously set, there are two
+            possibilities:
+              - the label has gone through a `std.contract.apply` call in-between.
+                In this case, the previous diagnostic has been stacked, and
+                using `with_notes` won't erase anything but rather modify the
+                fresh current diagnostic.
+              - no `std.contract.apply` has taken place since the last message was
+                set. In this case, the current diagnostic's error notes will
+                be replaced.
 
-              # Examples
+            # Examples
 
-              This example is illustrative. In practice, returning `'Error {..}`
-              should always be preferred over manipulating the label directly,
-              at least whenever possible.
+            This example is illustrative. In practice, returning `'Error {..}`
+            should always be preferred over manipulating the label directly,
+            at least whenever possible.
 
-              ```nickel
-              let AlwaysFailWithNotes = std.contract.custom (fun label _ =>
-                label
-                |> std.contract.label.with_notes [
-                  "This is note 1",
-                  "This is note 2",
-                ]
-                |> std.contract.blame
-              )
-              in
+            ```nickel
+            let AlwaysFailWithNotes = std.contract.custom (fun label _ =>
+              label
+              |> std.contract.label.with_notes [
+                "This is note 1",
+                "This is note 2",
+              ]
+              |> std.contract.blame
+            )
+            in
 
-              null | AlwaysFailWithNotes
-              ```
-            "%
+            null | AlwaysFailWithNotes
+            ```
+          "%
           # the %label/with_notes% operator expects an array of strings which is
           # fully evaluated, thus we force the notes first
           = fun notes label => %label/with_notes% (%force% notes) label,
 
         append_note
           | doc m%"
-              Appends a note to the error notes of the current diagnostic of a label.
+            Appends a note to the error notes of the current diagnostic of a label.
 
-              Type: `String -> Label -> Label`
-              (for technical reasons, this function isn't actually statically typed)
+            Type: `String -> Label -> Label`
+            (for technical reasons, this function isn't actually statically typed)
 
-              # Examples
+            # Examples
 
-              This example is illustrative. In practice, returning `'Error {..}`
-              should always be preferred over manipulating the label directly
-              whenever possible.
+            This example is illustrative. In practice, returning `'Error {..}`
+            should always be preferred over manipulating the label directly
+            whenever possible.
 
-              ```nickel
-              let AlwaysFailWithNotes = std.contract.custom (fun label _ =>
-                label
-                |> std.contract.label.append_note "This is note 1"
-                |> std.contract.label.append_note "This is note 2"
-                |> std.contract.blame
-              )
-              in
+            ```nickel
+            let AlwaysFailWithNotes = std.contract.custom (fun label _ =>
+              label
+              |> std.contract.label.append_note "This is note 1"
+              |> std.contract.label.append_note "This is note 2"
+              |> std.contract.blame
+            )
+            in
 
-              null | AlwaysFailWithNotes
-              ```
-            "%
+            null | AlwaysFailWithNotes
+            ```
+          "%
           = fun note label => %label/append_note% note label,
       },
 
     apply
       | doc m%"
-          Applies a contract to a label and a value. Either aborts the execution
-          with a broken contract error if the contract fails, or proceeds with
-          the evaluation of the value.
+        Applies a contract to a label and a value. Either aborts the execution
+        with a broken contract error if the contract fails, or proceeds with
+        the evaluation of the value.
 
-          A contract annotation such as `value | Contract` is eventually
-          translated (automatically) to a call to `std.contract.apply Contract label
-          value` where `label` is provided by the Nickel interpreter.
+        A contract annotation such as `value | Contract` is eventually
+        translated (automatically) to a call to `std.contract.apply Contract label
+        value` where `label` is provided by the Nickel interpreter.
 
-          Note that depending on the situation, you might need the variant
-          `std.contract.check` instead. Please refer to the documentation of
-          `std.contract.check` for more information.
+        Note that depending on the situation, you might need the variant
+        `std.contract.check` instead. Please refer to the documentation of
+        `std.contract.check` for more information.
 
-          # Type
+        # Type
 
-          For technical reasons, `apply` isn't statically typed nor protected by
-          a contract. The hypothetical type of `apply` is `Contract -> Label ->
-          Dyn -> Dyn` (note `Contract` and `Label` currently don't exist).
+        For technical reasons, `apply` isn't statically typed nor protected by
+        a contract. The hypothetical type of `apply` is `Contract -> Label ->
+        Dyn -> Dyn` (note `Contract` and `Label` currently don't exist).
 
-          # Arguments
+        # Arguments
 
-          `apply` takes three arguments. The arguments are in order:
+        `apply` takes three arguments. The arguments are in order:
 
-          - a contract which is currently either a custom contract (produced by
-            the stdlib constructors `std.contract.custom`,
-            `std.contract.from_validator` or `std.contract.from_predicate`), a
-            record, a static type or a naked function (see legacy contracts
-            below).
-          - a label (see `std.contract.label`)
-          - the value to be checked
+        - a contract which is currently either a custom contract (produced by
+          the stdlib constructors `std.contract.custom`,
+          `std.contract.from_validator` or `std.contract.from_predicate`), a
+          record, a static type or a naked function (see legacy contracts
+          below).
+        - a label (see `std.contract.label`)
+        - the value to be checked
 
-          # Return value
+        # Return value
 
-          `apply` returns the original value upon success, with potential
-          delayed checks inserted inside. Some contracts even return a modified
-          value, such as record contract which can set default values.
+        `apply` returns the original value upon success, with potential
+        delayed checks inserted inside. Some contracts even return a modified
+        value, such as record contract which can set default values.
 
-          # Legacy contracts
+        # Legacy contracts
 
-          For backward-compatibility reasons, the argument can also be a naked
-          function `Label -> Dyn -> Dyn`, but this is discouraged and will be
-          deprecated in the future. For such a contract, please wrap it using
-          `std.contract.custom` instead (the return type must be adapted).
+        For backward-compatibility reasons, the argument can also be a naked
+        function `Label -> Dyn -> Dyn`, but this is discouraged and will be
+        deprecated in the future. For such a contract, please wrap it using
+        `std.contract.custom` instead (the return type must be adapted).
 
-          # Examples
+        # Examples
 
-          This example is a custom re-implementation of the builtin contract
-          `[| 'Foo Number |]`. This makes for a short illustration of `apply`,
-          but you should of course just use the builtin contract in real-world
-          applications.
+        This example is a custom re-implementation of the builtin contract
+        `[| 'Foo Number |]`. This makes for a short illustration of `apply`,
+        but you should of course just use the builtin contract in real-world
+        applications.
 
-          ```nickel
-          let FooOfNumber = fun Contract =>
-            std.contract.custom
-              (fun label =>
-                match {
-                  'Foo arg => 'Foo (std.contract.apply Contract label value),
-                  _ => 'Error {},
-                }
-              )
-          in
+        ```nickel
+        let FooOfNumber = fun Contract =>
+          std.contract.custom
+            (fun label =>
+              match {
+                'Foo arg => 'Foo (std.contract.apply Contract label value),
+                _ => 'Error {},
+              }
+            )
+        in
 
-          { foo = 1 } | Nullable {foo | Number}
-          ```
+        { foo = 1 } | Nullable {foo | Number}
+        ```
 
-          # Diagnostics stack
+        # Diagnostics stack
 
-          Using `apply` will stack the current custom error reporting data, and
-          create a fresh working diagnostic. `apply` thus acts as a split point
-          between a contract and its subcontracts, providing the subcontracts
-          with a fresh diagnostic to use, while remembering the previous
-          diagnostics set by parent contracts.
+        Using `apply` will stack the current custom error reporting data, and
+        create a fresh working diagnostic. `apply` thus acts as a split point
+        between a contract and its subcontracts, providing the subcontracts
+        with a fresh diagnostic to use, while remembering the previous
+        diagnostics set by parent contracts.
 
-          ## Illustration
+        ## Illustration
 
-          ```nickel
-          let ChildContract = std.contract.from_validator (fun _ =>
-            'Error {
-              message = "child's message",
-              notes = ["child's note"]
-            }
-          )
-          in
+        ```nickel
+        let ChildContract = std.contract.from_validator (fun _ =>
+          'Error {
+            message = "child's message",
+            notes = ["child's note"]
+          }
+        )
+        in
 
-          let ParentContract = std.contract.from_validator (fun _ =>
-            'Error {
-              message = "parent's message",
-              notes = ["parent's note"]
-            }
-          )
-          in
+        let ParentContract = std.contract.from_validator (fun _ =>
+          'Error {
+            message = "parent's message",
+            notes = ["parent's note"]
+          }
+        )
+        in
 
-          null | ParentContract
-          ```
+        null | ParentContract
+        ```
 
-          This example will print two diagnostics: the main one, using the
-          message and note of the child contract, and a secondary diagnostic,
-          using the parent contract message and note.
+        This example will print two diagnostics: the main one, using the
+        message and note of the child contract, and a secondary diagnostic,
+        using the parent contract message and note.
 
-          This behavior is also observed when manipulating the label directly
-          and using `std.contract.blame` instead of returning an error value.
-          ```
-        "%
+        This behavior is also observed when manipulating the label directly
+        and using `std.contract.blame` instead of returning an error value.
+        ```
+      "%
       = fun contract label value =>
         %contract/apply% contract (%label/push_diag% label) value,
 
@@ -1711,95 +1712,95 @@
         }
       |]
       | doc m%"
-          Variant of `std.contract.apply` which returns `'Error {..}` upon
-          immediate failure of the contract instead of aborting the execution
-          with a blame error, or wraps the return value as `'Ok value`
-          otherwise. Delayed errors may still cause uncatchable blame errors.
+        Variant of `std.contract.apply` which returns `'Error {..}` upon
+        immediate failure of the contract instead of aborting the execution
+        with a blame error, or wraps the return value as `'Ok value`
+        otherwise. Delayed errors may still cause uncatchable blame errors.
 
-          `check` is intended to be used when calling another contract from a
-          custom contract, since the return type of `check` is precisely the
-          same as the return type of a custom contract, and because it preserves
-          immediate errors.
+        `check` is intended to be used when calling another contract from a
+        custom contract, since the return type of `check` is precisely the
+        same as the return type of a custom contract, and because it preserves
+        immediate errors.
 
-          Another use-case is to check if the immediate part of a contract is
-          failing or not without aborting the execution with an uncatchable
-          error.
+        Another use-case is to check if the immediate part of a contract is
+        failing or not without aborting the execution with an uncatchable
+        error.
 
-          `check` has the same behavior as `std.contract.apply` with respect to
-          the diagnostic stack. See `std.contract.apply` for more details.
+        `check` has the same behavior as `std.contract.apply` with respect to
+        the diagnostic stack. See `std.contract.apply` for more details.
 
-          Looking at the action of `check` on a custom contract might help: if
-          `Contract` is a custom contract defined as `std.contract.custom
-          contract_impl` where `contract_impl` is a function `fun label value =>
-          ...`, then `std.contract.check Contract label value` is just the
-          normal function application `contract_impl label value` (this isn't
-          entirely true because of the diagnostic stack and how checked values
-          are tracked for error reporting, but it's mostly true). Of course,
-          `check` works on other types of contracts, such as static types or
-          record contracts.
+        Looking at the action of `check` on a custom contract might help: if
+        `Contract` is a custom contract defined as `std.contract.custom
+        contract_impl` where `contract_impl` is a function `fun label value =>
+        ...`, then `std.contract.check Contract label value` is just the
+        normal function application `contract_impl label value` (this isn't
+        entirely true because of the diagnostic stack and how checked values
+        are tracked for error reporting, but it's mostly true). Of course,
+        `check` works on other types of contracts, such as static types or
+        record contracts.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let Nullable = fun Contract =>
-            std.contract.custom
-              (fun label value =>
-                if value == null then
-                  'Ok value
-                else
-                  std.contract.check Contract label value
-              )
-          in
+        ```nickel
+        let Nullable = fun Contract =>
+          std.contract.custom
+            (fun label value =>
+              if value == null then
+                'Ok value
+              else
+                std.contract.check Contract label value
+            )
+        in
 
-          { foo = 1 } | Nullable {foo | Number}
-          ```
-        "%
+        { foo = 1 } | Nullable {foo | Number}
+        ```
+      "%
       = fun contract label value =>
         %contract/check% contract (%label/push_diag% label) value,
 
     any_of
       | Array Dyn -> Dyn
       | doc m%"
-          Builds a contract that checks if the value satisfies at least one of
-          the given contracts. More precisely, `any_of` applies each contract in
-          order and returns the result of the first one that doesn't fail
-          immediately (that is, the first one which returns the value `'Ok _`).
+        Builds a contract that checks if the value satisfies at least one of
+        the given contracts. More precisely, `any_of` applies each contract in
+        order and returns the result of the first one that doesn't fail
+        immediately (that is, the first one which returns the value `'Ok _`).
 
-          **Important** `any_of` is only an approximation of what you could
-          expect from an `or` operation on contracts. Because `any_of` must
-          preserve the laziness of contracts, it means that it has to
-          pick the right branch by relying only on the immediate part of each
-          contract, and not on the delayed part.
+        **Important** `any_of` is only an approximation of what you could
+        expect from an `or` operation on contracts. Because `any_of` must
+        preserve the laziness of contracts, it means that it has to
+        pick the right branch by relying only on the immediate part of each
+        contract, and not on the delayed part.
 
-          Fortunately, `any_of` is an overstrict approximation, in that it might
-          reject more values than what you expect, but it'll never let invalid
-          values slip through.
+        Fortunately, `any_of` is an overstrict approximation, in that it might
+        reject more values than what you expect, but it'll never let invalid
+        values slip through.
 
-          Typically, `std.contract.any_of [{ foo | String }, { foo | Number }]`
-          will behave exactly as `{ foo | Number }`, because the immediate part
-          of the built-in record contracts can't discriminate between the two
-          possibilities. In particular, perhaps surprisingly, the value `{foo =
-          1+1}` is rejected. Please refer to the boolean combinators section of
-          the contract chapter of the manual for a more detailed
-          explanation of the limitations of `any_of` and other boolean
-          combinators, as well as how to work around them.
+        Typically, `std.contract.any_of [{ foo | String }, { foo | Number }]`
+        will behave exactly as `{ foo | Number }`, because the immediate part
+        of the built-in record contracts can't discriminate between the two
+        possibilities. In particular, perhaps surprisingly, the value `{foo =
+        1+1}` is rejected. Please refer to the boolean combinators section of
+        the contract chapter of the manual for a more detailed
+        explanation of the limitations of `any_of` and other boolean
+        combinators, as well as how to work around them.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let Date = std.contract.any_of [
-            String,
-            {
-              day | Number,
-              month | Number,
-              year | Number
-            }
-          ]
-          in
+        ```nickel
+        let Date = std.contract.any_of [
+          String,
+          {
+            day | Number,
+            month | Number,
+            year | Number
+          }
+        ]
+        in
 
-          { day = 1, month = 1, year = 1970 } | Date
-          ```
-        "%
+        { day = 1, month = 1, year = 1970 } | Date
+        ```
+      "%
       = fun contracts =>
         %contract/custom% (fun label value =>
           std.array.try_fold_left
@@ -1831,44 +1832,44 @@
     all_of
       : Array Dyn -> Dyn
       | doc m%"
-          Builds a contract that checks if the value satisfies all of the given
-          contracts. `all_of` is just an alias for `std.contract.Sequence`, to
-          maintain consistency with `std.contract.any_of` and other JSON
-          Schema-style combinators.
+        Builds a contract that checks if the value satisfies all of the given
+        contracts. `all_of` is just an alias for `std.contract.Sequence`, to
+        maintain consistency with `std.contract.any_of` and other JSON
+        Schema-style combinators.
 
-          As opposed to other boolean combinators such as `not` or `any_of`,
-          `all_of` work as you expect most of the time, including on contracts
-          with a delayed part. The only contracts for which `all_of` is
-          overstrict are function contracts. In general, you shouldn't use
-          function contracts with contract combinators.
-          ```
-        "%
+        As opposed to other boolean combinators such as `not` or `any_of`,
+        `all_of` work as you expect most of the time, including on contracts
+        with a delayed part. The only contracts for which `all_of` is
+        overstrict are function contracts. In general, you shouldn't use
+        function contracts with contract combinators.
+        ```
+      "%
       = std.contract.Sequence,
 
     not
       | Dyn -> Dyn
       | doc m%"
-          Builds a contract that checks if the value doesn't satisfy the given
-          contract. More specifically, `not Contract` will accept `value` if the
-          application of `Contract` to `value` fails immediately, returning
-          `'Error {..}`.
+        Builds a contract that checks if the value doesn't satisfy the given
+        contract. More specifically, `not Contract` will accept `value` if the
+        application of `Contract` to `value` fails immediately, returning
+        `'Error {..}`.
 
-          **Important**: as for other boolean combinators, `not` is only an
-          overstrict approximation of what you could expect. For example,
-          `std.contract.not (Array Number)` will reject `["a"]`, because the
-          check that elements are numbers is delayed. See the boolean
-          combinators section of the contract chapter of the manual for a more
-          detailed explanation of the limitations of `not` and other boolean
-          combinators, as well as how to work around them.
+        **Important**: as for other boolean combinators, `not` is only an
+        overstrict approximation of what you could expect. For example,
+        `std.contract.not (Array Number)` will reject `["a"]`, because the
+        check that elements are numbers is delayed. See the boolean
+        combinators section of the contract chapter of the manual for a more
+        detailed explanation of the limitations of `not` and other boolean
+        combinators, as well as how to work around them.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let NotNumber = std.contract.not Number in
-          "a" | NotNumber
-            => "a"
-          ```
-        "%
+        ```nickel
+        let NotNumber = std.contract.not Number in
+        "a" | NotNumber
+          => "a"
+        ```
+      "%
       = fun Contract =>
         %contract/custom% (fun label value =>
           value
@@ -1881,33 +1882,33 @@
 
     unstable
       | doc m%"
-          The unstable module gathers contracts that are used right now in the
-          standard library to check additional pre-condition, but aren't yet
-          stabilized.
+        The unstable module gathers contracts that are used right now in the
+        standard library to check additional pre-condition, but aren't yet
+        stabilized.
 
-          Unstable contracts are useful as a temporary solution for argument
-          validation, but they shouldn't be used outside of the standard
-          library. They aren't part of the backward compatibility policy, and
-          are subject to change at any point in time.
-        "%
+        Unstable contracts are useful as a temporary solution for argument
+        validation, but they shouldn't be used outside of the standard
+        library. They aren't part of the backward compatibility policy, and
+        are subject to change at any point in time.
+      "%
       = {
         DependentFun
           | doc m%"
-              **Warning**: this is an unstable item. It might be renamed,
-              modified or deleted in any subsequent minor Nickel version.
+            **Warning**: this is an unstable item. It might be renamed,
+            modified or deleted in any subsequent minor Nickel version.
 
-              A dependent function contract, where the argument is also passed
-              to the contract of the returned value.
+            A dependent function contract, where the argument is also passed
+            to the contract of the returned value.
 
-              That is, `some_function | DependentFun Foo Bar` performs the
-              same checks as
+            That is, `some_function | DependentFun Foo Bar` performs the
+            same checks as
 
-              ```nickel
-              fun arg =>
-                let arg_checked = (arg | Foo) in
-                (some_function arg_checked | (Bar arg_checked))
-              ```
-            "%
+            ```nickel
+            fun arg =>
+              let arg_checked = (arg | Foo) in
+              (some_function arg_checked | (Bar arg_checked))
+            ```
+          "%
           = fun Domain Codomain =>
             %contract/custom% (fun label function =>
               'Ok (fun arg =>
@@ -1920,15 +1921,15 @@
 
         RangeStep
           | doc m%"
-              **Warning**: this is an unstable item. It might be renamed,
-              modified or deleted in any subsequent minor Nickel version.
+            **Warning**: this is an unstable item. It might be renamed,
+            modified or deleted in any subsequent minor Nickel version.
 
-              A contract for a range step, which must be a positive number.
+            A contract for a range step, which must be a positive number.
 
-              This contract blames only if the value is a number but is not
-              positive: the fact that the value is a number is assumed to be
-              checked by an associated static type annotation.
-            "%
+            This contract blames only if the value is a number but is not
+            positive: the fact that the value is a number is assumed to be
+            checked by an associated static type annotation.
+          "%
           =
             %contract/custom% (fun _label value =>
               if %typeof% value == 'Number && value < 0 then
@@ -1942,19 +1943,19 @@
 
         RangeFun
           | doc m%"
-              **Warning**: this is an unstable item. It might be renamed,
-              modified or deleted in any subsequent minor Nickel version.
+            **Warning**: this is an unstable item. It might be renamed,
+            modified or deleted in any subsequent minor Nickel version.
 
-              A function contract which checks that the two first argument are a
-              valid range, that is two numbers `start` and `end` such that
-              `start <= end`.
+            A function contract which checks that the two first argument are a
+            valid range, that is two numbers `start` and `end` such that
+            `start <= end`.
 
-              This contract blames only if the arguments are of the right type
-              but don't satisfy the tested condition. The type of arguments is
-              assumed to be checked by an associated static type annotation. For
-              example, if the first argument is a string, this contract silently
-              passes.
-            "%
+            This contract blames only if the arguments are of the right type
+            but don't satisfy the tested condition. The type of arguments is
+            assumed to be checked by an associated static type annotation. For
+            example, if the first argument is a string, this contract silently
+            passes.
+          "%
           = fun Codomain =>
             let RangeSecond = fun start =>
               %contract/custom% (fun _label value =>
@@ -1988,20 +1989,20 @@
         IndexedArrayFun
           | [| 'Index, 'Split |] -> Dyn
           | doc m%"
-              **Warning**: this is an unstable item. It might be renamed,
-              modified or deleted in any subsequent minor Nickel version.
+            **Warning**: this is an unstable item. It might be renamed,
+            modified or deleted in any subsequent minor Nickel version.
 
-              A function contract which checks that the two first argument are,
-              in order, a number and an array such that the number is a valid
-              index for that array, that is a natural number such that
-              `0 <= index <= length array`.
+            A function contract which checks that the two first argument are,
+            in order, a number and an array such that the number is a valid
+            index for that array, that is a natural number such that
+            `0 <= index <= length array`.
 
-              This contract blames only if the arguments are of the right type
-              but don't satisfy the tested condition. The type of arguments is
-              assumed to be checked by an associated static type annotation. For
-              example, if the first argument is a string, this contract silently
-              passes.
-            "%
+            This contract blames only if the arguments are of the right type
+            but don't satisfy the tested condition. The type of arguments is
+            assumed to be checked by an associated static type annotation. For
+            example, if the first argument is a string, this contract silently
+            passes.
+          "%
           =
             # capture the `contract.label` module to avoid name collisions with
             # local contract argument `label`
@@ -2061,20 +2062,20 @@
 
         ArraySliceFun
           | doc m%"
-              **Warning**: this is an unstable item. It might be renamed,
-              modified or deleted in any subsequent minor Nickel version.
+            **Warning**: this is an unstable item. It might be renamed,
+            modified or deleted in any subsequent minor Nickel version.
 
-              A function contract which checks that the three first arguments
-              are, in order, two numbers and an array such that the two numbers
-              are a valid slice of that array, that is they are natural numbers
-              such that: `0 <= n1 <= n2 <= length array`
+            A function contract which checks that the three first arguments
+            are, in order, two numbers and an array such that the two numbers
+            are a valid slice of that array, that is they are natural numbers
+            such that: `0 <= n1 <= n2 <= length array`
 
-              This contract blames only if the arguments are of the right type
-              but don't satisfy the tested condition. The type of arguments is
-              assumed to be checked by an associated static type annotation. For
-              example, if the first argument is a string, this contract silently
-              passes.
-            "%
+            This contract blames only if the arguments are of the right type
+            but don't satisfy the tested condition. The type of arguments is
+            assumed to be checked by an associated static type annotation. For
+            example, if the first argument is a string, this contract silently
+            passes.
+          "%
           =
             # capture the `contract.label` module to avoid name collisions with
             # local contract argument `label`
@@ -2148,30 +2149,30 @@
 
         HasField
           | doc m%%"
-              **Warning**: this is an unstable item. It might be renamed,
-              modified or deleted in any subsequent minor Nickel version.
+            **Warning**: this is an unstable item. It might be renamed,
+            modified or deleted in any subsequent minor Nickel version.
 
-              A function contract for 2-ary functions which checks that second
-              argument is a record that contains the first argument as a field.
-              This contract is parametrized by the return type of the function.
+            A function contract for 2-ary functions which checks that second
+            argument is a record that contains the first argument as a field.
+            This contract is parametrized by the return type of the function.
 
-              This contract blames only if the arguments are of the right type
-              but don't satisfy the tested condition (the first is a string and
-              the second is a record). The type of arguments is assumed to be
-              checked by an associated static type annotation. For example, if
-              the first argument is a number, this contract silently passes.
+            This contract blames only if the arguments are of the right type
+            but don't satisfy the tested condition (the first is a string and
+            the second is a record). The type of arguments is assumed to be
+            checked by an associated static type annotation. For example, if
+            the first argument is a number, this contract silently passes.
 
-              ## Example
+            ## Example
 
-              ```nickel
-              let f | HasField Dyn = fun field record => record."%{field}" in
-              (f "foo" { foo = 1, bar = 2 })
-              + (f "baz" { foo = 1, bar = 2 })
-              ```
+            ```nickel
+            let f | HasField Dyn = fun field record => record."%{field}" in
+            (f "foo" { foo = 1, bar = 2 })
+            + (f "baz" { foo = 1, bar = 2 })
+            ```
 
-              In this example, the first call to `f` won't blame, but the second
-              will, as `baz` isn't a field of the record argument.
-            "%%
+            In this example, the first call to `f` won't blame, but the second
+            will, as `baz` isn't a field of the record argument.
+          "%%
           = fun Codomain =>
             let HasFieldSecond = fun field =>
               %contract/custom% (fun _label value =>
@@ -2226,7 +2227,7 @@
           'Bar 5
         ("tag" | std.enum.Enum) =>
           error
-        "%
+      "%
       =
         %contract/custom% (fun _label value =>
           if std.is_enum value then
@@ -2344,7 +2345,7 @@
         std.enum.to_tag_and_arg 'http
           => { tag = "http" }
         ```
-        "%
+      "%
       = fun enum_value =>
         let tag_string = %to_string% (%enum/get_tag% enum_value) in
         if %enum/is_variant% enum_value then
@@ -2372,7 +2373,7 @@
         std.enum.from_tag_and_arg { tag = "http" }
           => 'http
         ```
-        "%
+      "%
       = fun enum_data =>
         if %record/has_field% "arg" enum_data then
           %enum/make_variant% enum_data.tag enum_data.arg
@@ -2382,18 +2383,18 @@
     map
       | (Dyn -> Dyn) -> Enum -> Enum
       | doc m%"
-          Maps a function over an enum variant's argument. If the enum doesn't
-          have an argument, it is left unchanged.
+        Maps a function over an enum variant's argument. If the enum doesn't
+        have an argument, it is left unchanged.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.enum.map ((+) 1) ('Foo 42)
-            => 'Foo 43
-          std.enum.map f 'Bar
-            => 'Bar
-          ```
-        "%
+        ```nickel
+        std.enum.map ((+) 1) ('Foo 42)
+          => 'Foo 43
+        std.enum.map f 'Bar
+          => 'Bar
+        ```
+      "%
       = fun f enum_value =>
         if %enum/is_variant% enum_value then
           let tag = (%to_string% (%enum/get_tag% enum_value)) in
@@ -2788,7 +2789,7 @@
         std.number.log 10 std.number.e =>
           2.302585
         ```
-        "%
+      "%
       = fun x b => %number/log% x b,
 
     cos
@@ -2846,7 +2847,7 @@
         std.number.arccos 1 =>
           0
         ```
-        "%
+      "%
       = fun x => %number/arccos% x,
 
     arcsin
@@ -2862,7 +2863,7 @@
         std.number.arcsin 1 =>
           1.5707963
         ```
-        "%
+      "%
       = fun x => %number/arcsin% x,
 
     arctan
@@ -2876,22 +2877,22 @@
         std.number.arctan 1 =>
           0.78539816
         ```
-        "%
+      "%
       = fun x => %number/arctan% x,
 
     arctan2
       : Number -> Number -> Number
       | doc m%"
-      `arctan2 y x returns the four quadrant arctangent of y over x.
+        `arctan2 y x returns the four quadrant arctangent of y over x.
 
-      # Examples
+        # Examples
 
-      ```nickel
-      std.number.arctan2 1 0 =>
-        1.5707963
-      std.number.arctan2 (-0.5) (-0.5) =>
-        -0.7853981633974483
-      ```
+        ```nickel
+        std.number.arctan2 1 0 =>
+          1.5707963
+        std.number.arctan2 (-0.5) (-0.5) =>
+          -0.7853981633974483
+        ```
       "%
       = fun y x => %number/arctan2% y x,
 
@@ -2912,14 +2913,14 @@
     pi
       : Number
       | doc m%"
-      The π mathematical constant.
+        The π mathematical constant.
       "%
       = 3.14159265358979323846,
 
     e
       : Number
       | doc m%"
-      Euler's number, the e mathematical constant.
+        Euler's number, the e mathematical constant.
       "%
       = 2.7182818284590452354,
   },
@@ -3108,168 +3109,168 @@
     insert
       : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%%"
-          Inserts a new field into a record. `insert` doesn't mutate the original
-          record but returns a new one instead.
+        Inserts a new field into a record. `insert` doesn't mutate the original
+        record but returns a new one instead.
 
-          # Preconditions
+        # Preconditions
 
-          The field must not exist in the initial record, otherwise `insert`
-          will fail. If the field might already exist, use `std.record.update`
-          instead.
+        The field must not exist in the initial record, otherwise `insert`
+        will fail. If the field might already exist, use `std.record.update`
+        instead.
 
-          # Empty optional fields
+        # Empty optional fields
 
-          By default, `insert` ignores optional fields without definition. The
-          precondition above doesn't apply to empty optional fields, and
-          `insert` will silently erase an existing empty optional field.
+        By default, `insert` ignores optional fields without definition. The
+        precondition above doesn't apply to empty optional fields, and
+        `insert` will silently erase an existing empty optional field.
 
-          Use `std.record.insert_with_opts` for a version which doesn't ignore
-          empty optional fields.
+        Use `std.record.insert_with_opts` for a version which doesn't ignore
+        empty optional fields.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.record.insert "foo" 5 { bar = "bar" }
-            => { foo = 5, bar = "bar }
-          {}
-          |> std.record.insert "file.txt" "data/text"
-          |> std.record.insert "length" (10*1000)
-            => {"file.txt" = "data/text", "length" = 10000}
-          std.record.insert "already_there_opt" 0 {already_there_opt | optional}
-            => {already_there_optional = 0}
-          std.record.insert "already_there" 0 {already_there = 1}
-            => error
-          ```
-        "%%
+        ```nickel
+        std.record.insert "foo" 5 { bar = "bar" }
+          => { foo = 5, bar = "bar }
+        {}
+        |> std.record.insert "file.txt" "data/text"
+        |> std.record.insert "length" (10*1000)
+          => {"file.txt" = "data/text", "length" = 10000}
+        std.record.insert "already_there_opt" 0 {already_there_opt | optional}
+          => {already_there_optional = 0}
+        std.record.insert "already_there" 0 {already_there = 1}
+          => error
+        ```
+      "%%
       = fun field content r => %record/insert% field r content,
 
     insert_with_opts
       : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%%"
-          Inserts a new field into a record. `insert_with_opts` doesn't mutate the
-          original record but returns a new one instead.
+        Inserts a new field into a record. `insert_with_opts` doesn't mutate the
+        original record but returns a new one instead.
 
-          Same as `std.record.insert`, but doesn't ignore empty optional fields.
+        Same as `std.record.insert`, but doesn't ignore empty optional fields.
 
-          # Preconditions
+        # Preconditions
 
-          The field must not exist in the initial record, otherwise `insert`
-          will fail. If the field might already exist, use `std.record.update`
-          instead.
+        The field must not exist in the initial record, otherwise `insert`
+        will fail. If the field might already exist, use `std.record.update`
+        instead.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.record.insert_with_opts "foo" 5 { bar = "bar" }
-            => { foo = 5, bar = "bar }
-          {}
-          |> std.record.insert_with_opts "file.txt" "data/text"
-          |> std.record.insert_with_opts "length" (10*1000)
-            => {"file.txt" = "data/text", "length" = 10000}
-          std.record.insert_with_opts "already_there_optional" 0 {already_there | optional}
-            => error
-          std.record.insert_with_opts "already_there" 0 {already_there = 1}
-            => error
-          ```
-        "%%
+        ```nickel
+        std.record.insert_with_opts "foo" 5 { bar = "bar" }
+          => { foo = 5, bar = "bar }
+        {}
+        |> std.record.insert_with_opts "file.txt" "data/text"
+        |> std.record.insert_with_opts "length" (10*1000)
+          => {"file.txt" = "data/text", "length" = 10000}
+        std.record.insert_with_opts "already_there_optional" 0 {already_there | optional}
+          => error
+        std.record.insert_with_opts "already_there" 0 {already_there = 1}
+          => error
+        ```
+      "%%
       = fun field content r => %record/insert_with_opts% field r content,
 
     remove
       : forall a. String -> { _ : a } -> { _ : a }
       | doc m%"
-          Removes a field from a record. `remove` doesn't mutate the original
-          record but returns a new one instead.
+        Removes a field from a record. `remove` doesn't mutate the original
+        record but returns a new one instead.
 
-          # Preconditions
+        # Preconditions
 
-          The field to remove must be present in the record, or `remove` will
-          fail.
+        The field to remove must be present in the record, or `remove` will
+        fail.
 
-          # Empty optional fields
+        # Empty optional fields
 
-          By default, `remove` ignores optional fields. The precondition above
-          doesn't apply to an empty optional field and `remove` will fail with a
-          missing field error when trying to remove an empty optional field.
+        By default, `remove` ignores optional fields. The precondition above
+        doesn't apply to an empty optional field and `remove` will fail with a
+        missing field error when trying to remove an empty optional field.
 
-          Use `std.record.remove_with_opts` for a version which doesn't ignore
-          empty optional fields.
+        Use `std.record.remove_with_opts` for a version which doesn't ignore
+        empty optional fields.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.record.remove "foo" { foo = "foo", bar = "bar" }
-            => { bar = "bar" }
-          std.record.remove "foo_opt" {foo_opt | optional}
-            => error
-          std.record.remove "foo" { bar = "bar" }
-            => error
-          ```
-        "%
+        ```nickel
+        std.record.remove "foo" { foo = "foo", bar = "bar" }
+          => { bar = "bar" }
+        std.record.remove "foo_opt" {foo_opt | optional}
+          => error
+        std.record.remove "foo" { bar = "bar" }
+          => error
+        ```
+      "%
       = fun field r => %record/remove% field r,
 
     remove_with_opts
       : forall a. String -> { _ : a } -> { _ : a }
       | doc m%"
-          Removes a field from a record. `remove` doesn't mutate the original
-          record but returns a new one instead.
+        Removes a field from a record. `remove` doesn't mutate the original
+        record but returns a new one instead.
 
-          Same as `std.record.remove`, but doesn't ignore empty optional fields.
+        Same as `std.record.remove`, but doesn't ignore empty optional fields.
 
-          # Preconditions
+        # Preconditions
 
-          The field to remove must be present in the record, or `remove` will
-          fail.
+        The field to remove must be present in the record, or `remove` will
+        fail.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.record.remove_with_opts "foo" { foo = "foo", bar = "bar" }
-            => { bar = "bar" }
-          std.record.remove_with_opts "foo_opt" {foo_opt | optional}
-            => {}
-          std.record.remove_with_opts "foo" { bar = "bar" }
-            => error
-          ```
-        "%
+        ```nickel
+        std.record.remove_with_opts "foo" { foo = "foo", bar = "bar" }
+          => { bar = "bar" }
+        std.record.remove_with_opts "foo_opt" {foo_opt | optional}
+          => {}
+        std.record.remove_with_opts "foo" { bar = "bar" }
+          => error
+        ```
+      "%
       = fun field r => %record/remove_with_opts% field r,
 
     update
       : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%"
-          Updates a field of a record with a new value. `update` doesn't mutate the
-          original record but returns a new one instead. If the field to update is absent
-          from the given record, `update` adds it.
+        Updates a field of a record with a new value. `update` doesn't mutate the
+        original record but returns a new one instead. If the field to update is absent
+        from the given record, `update` adds it.
 
-          # Empty optional fields
+        # Empty optional fields
 
-          `update` works the same way for empty optional fields and other fields.
-          `update` guarantees that it can always replace a field with a new
-          value, no matter the nature of the field.
+        `update` works the same way for empty optional fields and other fields.
+        `update` guarantees that it can always replace a field with a new
+        value, no matter the nature of the field.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.record.update "foo" 5 { foo = "foo", bar = "bar" } =>
-            { foo = 5, bar = "bar" }
-          std.record.update "foo" 5 { bar = "bar" } =>
-            { foo = 5, bar = "bar" }
-          std.record.update "foo_opt" 5 {foo_opt | optional} =>
-            {foo_opt = 5}
-          ```
+        ```nickel
+        std.record.update "foo" 5 { foo = "foo", bar = "bar" } =>
+          { foo = 5, bar = "bar" }
+        std.record.update "foo" 5 { bar = "bar" } =>
+          { foo = 5, bar = "bar" }
+        std.record.update "foo_opt" 5 {foo_opt | optional} =>
+          {foo_opt = 5}
+        ```
 
-          # Overriding
+        # Overriding
 
-          As opposed to overriding a value with the merge operator `&`, `update`
-          will only change the specified field and won't automatically update the other
-          fields which depend on it:
+        As opposed to overriding a value with the merge operator `&`, `update`
+        will only change the specified field and won't automatically update the other
+        fields which depend on it:
 
-          ```nickel
-          { foo = bar + 1, bar | default = 0 } & { bar = 1 } =>
-            { foo = 2, bar = 1 }
-          std.record.update "bar" 1 {foo = bar + 1, bar | default = 0 } =>
-            { foo = 1, bar = 1 }
-          ```
-        "%
+        ```nickel
+        { foo = bar + 1, bar | default = 0 } & { bar = 1 } =>
+          { foo = 2, bar = 1 }
+        std.record.update "bar" 1 {foo = bar + 1, bar | default = 0 } =>
+          { foo = 1, bar = 1 }
+        ```
+      "%
       = fun field content r =>
         let r =
           if %record/has_field% field r then
@@ -3400,18 +3401,18 @@
         std.record.apply_on "age" std.number.compare { name = "Alice", age = 27 } { name = "Bob", age = 23 } =>
           'Greater
         ```
-        "%
+      "%
       = fun field f a b => f a."%{field}" b."%{field}",
 
     length
       : forall a. { _ : a } -> Number
       | doc m%"
-          Returns the number of fields in a record. This count doesn't include
-          fields both marked as optional and without a definition.
+        Returns the number of fields in a record. This count doesn't include
+        fields both marked as optional and without a definition.
 
-          Because of the need to filter empty optional fields, the cost of
-          `length` is linear in the size of the record.
-        "%
+        Because of the need to filter empty optional fields, the cost of
+        `length` is linear in the size of the record.
+      "%
       = fun record =>
         record
         |> fields
@@ -3749,21 +3750,21 @@
     replace_regex
       : String -> String -> String -> String
       | doc m%"
-        `replace_regex regex repl string` replaces every match of `regex` in `string` with `repl`.
+          `replace_regex regex repl string` replaces every match of `regex` in `string` with `repl`.
 
-        **Note**: this function will only replace matches which start & end
-        on the boundary of Unicode extended grapheme clusters. For example,
-        `replace_regex "❤️" "_" "👨‍❤️‍💋‍👨"` will return `"👨‍❤️‍💋‍👨"`, since the
-        heart codepoint occurs within the larger emoji grapheme cluster.
+          **Note**: this function will only replace matches which start & end
+          on the boundary of Unicode extended grapheme clusters. For example,
+          `replace_regex "❤️" "_" "👨‍❤️‍💋‍👨"` will return `"👨‍❤️‍💋‍👨"`, since the
+          heart codepoint occurs within the larger emoji grapheme cluster.
 
-        # Examples
+          # Examples
 
-        ```nickel
-        std.string.replace_regex "l+." "j" "Hello!"
-          => "Hej!"
-        std.string.replace_regex "\\d+" "\"a\" is not" "This 37 is a number."
-          "This \"a\" is not a number."
-      ```
+          ```nickel
+          std.string.replace_regex "l+." "j" "Hello!"
+            => "Hej!"
+          std.string.replace_regex "\\d+" "\"a\" is not" "This 37 is a number."
+            "This \"a\" is not a number."
+        ```
       "%
       = fun pattern replace s =>
         %string/replace_regex% s pattern replace,
@@ -4079,7 +4080,7 @@
         1 == 1 | std.test.Assert
          => true
         ```
-        "%
+      "%
       =
         %contract/custom% (fun _label value =>
           if value then
@@ -4103,7 +4104,7 @@
         [ (1 == 2), (1 == 1), (1 == 3) ] |> std.test.assert_all
          => error: contract broken by a value
         ```
-        "%
+      "%
       # We mostly rely on the contracts to do the work here. We just need to
       # make sure each element of the array is properly forced.
       = std.array.all (fun x => x),

--- a/topiary-cli/tests/samples/input/nickel.ncl
+++ b/topiary-cli/tests/samples/input/nickel.ncl
@@ -5,10 +5,10 @@
       a =
         std.string.split
           " "
-          m%"
-          line one with trailing space 
-          line two
-        "%
+m%"line one with trailing space 
+ line two
+ 
+ "%
         |> std.array.at 6
     },
     # Issue 680
@@ -221,17 +221,17 @@ doc "hello" | optional,
   array = {
     NonEmpty
       | doc m%"
-          Enforces that an array is not empty.
+        Enforces that an array is not empty.
 
-          # Examples
-
-          ```nickel
-          ([] | std.array.NonEmpty) =>
-            error
-          ([ 1 ] | std.array.NonEmpty) =>
-            [ 1 ]
-          ```
-        "%
+        # Examples
+        
+        ```nickel
+        ([] | std.array.NonEmpty) =>
+          error
+        ([ 1 ] | std.array.NonEmpty) =>
+          [ 1 ]
+        ```
+      "%
       =
         %contract/custom%
           (
@@ -249,14 +249,14 @@ doc "hello" | optional,
       : forall a. Array a -> a
       | NonEmpty -> Dyn
       | doc m%"
-          Returns the first element of an array.
-
-          # Examples
-
-          ```nickel
-          std.array.first [ "this is the head", "this is not" ] =>
-            "this is the head"
-          ```
+        Returns the first element of an array.
+ 
+        # Examples
+ 
+        ```nickel
+        std.array.first [ "this is the head", "this is not" ] =>
+          "this is the head"
+        ```
         "%
       = fun array => %array/at% array 0,
 
@@ -264,30 +264,29 @@ doc "hello" | optional,
       : forall a. Array a -> a
       | NonEmpty -> Dyn
       | doc m%"
-          Returns the last element of an array.
+        Returns the last element of an array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.last [ "this is the head", "this is not" ] =>
-            "this is not"
-          ```
-        "%
+        ```nickel
+        std.array.last [ "this is the head", "this is not" ] =>
+          "this is not"
+        ```
+    "%
       = fun array => %array/at% array (%array/length% array - 1),
 
     drop_first
       : forall a. Array a -> Array a
       | NonEmpty -> Dyn
       | doc m%"
-          Returns the given array without its first element.
+        Returns the given array without its first element.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.drop_first [ 1, 2, 3 ] =>
-            [ 2, 3 ]
-          ```
-        "%
+        ```nickel
+        std.array.drop_first [ 1, 2, 3 ] =>
+          [ 2, 3 ]
+        ```"%
       = fun array => %array/slice% 1 (%array/length% array) array,
 
     drop_last
@@ -302,21 +301,21 @@ doc "hello" | optional,
           std.array.drop_last [ 1, 2, 3 ] =>
             [ 1, 2 ]
           ```
-        "%
+      "%
       = fun array => %array/slice% 0 (%array/length% array - 1) array,
 
     length
       : forall a. Array a -> Number
       | doc m%"
-          Returns the length of an array.
+      Returns the length of an array.
 
-          # Examples
+      # Examples
 
-          ```nickel
-          std.array.length [ "Hello,", " World!" ] =>
-            2
-          ```
-        "%
+      ```nickel
+      std.array.length [ "Hello,", " World!" ] =>
+        2
+      ```
+      "%
       = fun l => %array/length% l,
 
     map
@@ -338,35 +337,35 @@ doc "hello" | optional,
       : forall a. Number -> Array a -> a
       | std.contract.unstable.IndexedArrayFun 'Index
       | doc m%"
-          Retrieves the n-th element from an array, with indices starting at 0.
+      Retrieves the n-th element from an array, with indices starting at 0.
 
-          # Examples
+      # Examples
 
-          ```nickel
-          std.array.at 3 [ "zero", "one", "two", "three", "four" ] =>
-            "three"
-          ```
-        "%
+      ```nickel
+      std.array.at 3 [ "zero", "one", "two", "three", "four" ] =>
+        "three"
+      ```
+    "%
       = fun n l => %array/at% l n,
 
     at_or
       : forall a. Number -> a -> Array a -> a
       | std.number.Nat -> Dyn
       | doc m%"
-          Retrieves the n-th element from an array, with indices starting at 0
-          or the provided default value if the index is greater than the length
-          of the array.
+        Retrieves the n-th element from an array, with indices starting at 0
+        or the provided default value if the index is greater than the length
+        of the array.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          std.array.at_or 3 "default" [ "zero", "one", "two", "three" ] =>
-            "three"
+        ```nickel
+        std.array.at_or 3 "default" [ "zero", "one", "two", "three" ] =>
+          "three"
 
-          std.array.at_or 3 "default" [ "zero", "one" ] =>
-            "default"
-          ```
-        "%
+        std.array.at_or 3 "default" [ "zero", "one" ] =>
+          "default"
+        ```
+      "%
       = fun n default_value array =>
         if n < %array/length% array then
           %array/at% array n
@@ -376,82 +375,82 @@ doc "hello" | optional,
     concat
       : forall a. Array a -> Array a -> Array a
       | doc m%"
-          Appends the second array to the first one.
+        Appends the second array to the first one.
 
-          # Examples
+        # Examples
 
-          ```nickel
-            std.array.concat [ 1, 2, 3 ] [ 4, 5, 6 ] =>
-              [ 1, 2, 3, 4, 5, 6 ]
-          ```
-        "%
+        ```nickel
+          std.array.concat [ 1, 2, 3 ] [ 4, 5, 6 ] =>
+            [ 1, 2, 3, 4, 5, 6 ]
+        ```
+      "%
       = fun l1 l2 => l1 @ l2,
 
     fold_left
       : forall a b. (a -> b -> a) -> a -> Array b -> a
       | doc m%"
-          Folds a function over an array. In a functional language like Nickel,
-          folds serve a similar purpose to loops or iterators. `fold_left`
-          iterates over an array, by repeatedly applying a function to each
-          element, threading an additional arbitrary state (the accumulator, of
-          type `a` in the signature) through the chain of applications.
+Folds a function over an array. In a functional language like Nickel,
+folds serve a similar purpose to loops or iterators. `fold_left`
+iterates over an array, by repeatedly applying a function to each
+element, threading an additional arbitrary state (the accumulator, of
+type `a` in the signature) through the chain of applications.
 
-          `fold_left f init [x1, x2, ..., xn]` results in `f (... (f (f init x1) x2) ...) xn`.
+`fold_left f init [x1, x2, ..., xn]` results in `f (... (f (f init x1) x2) ...) xn`.
 
-          This function is strict in the intermediate accumulator.
+This function is strict in the intermediate accumulator.
 
-          # Left vs right
+# Left vs right
 
-          Folds come in two variants, left and right. How to decide which one to
-          use?
+Folds come in two variants, left and right. How to decide which one to
+use?
 
-          - If the folded function isn't associative (such as subtraction), then
-            each variant will give a different result. The choice is dictacted by
-            which one you need. For example:
+- If the folded function isn't associative (such as subtraction), then
+  each variant will give a different result. The choice is dictacted by
+  which one you need. For example:
 
-            ```nickel
-            std.array.fold_right (-) 0 [1, 2, 3, 4]
-             => -2
-            std.array.fold_left (-) 0 [1, 2, 3, 4]
-             => -10
-            ```
-          - If the folded function is associative, both `fold_right` and
-            `fold_left` return the same result. In that case, **`fold_left` is
-            generally preferred**, because it forces the evaluation of the
-            intermediate results resulting in less memory consumption and overall
-            better performance (outside of pathological cases).
-            `fold_left` also iterates from the start of the array, which
-            corresponds to the usual behavior of loops and iterators in most
-            programming languages. There is one case where `fold_right` might be
-            preferred, see the next point.
-          - If the folded function is associative but _(left) short-circuiting_,
-            meaning that it can sometimes determine the result without using the
-            right argument, then `fold_right` provides early return. An example is
-            the boolean AND operator `&&`: when evaluating `left && right`, if
-            `left` is `false`, the whole expression will evaluate to `false`
-            without even evaluating `right`. Consider the following expression:
+  ```nickel
+  std.array.fold_right (-) 0 [1, 2, 3, 4]
+    => -2
+  std.array.fold_left (-) 0 [1, 2, 3, 4]
+    => -10
+  ```
+- If the folded function is associative, both `fold_right` and
+  `fold_left` return the same result. In that case, **`fold_left` is
+  generally preferred**, because it forces the evaluation of the
+  intermediate results resulting in less memory consumption and overall
+  better performance (outside of pathological cases).
+  `fold_left` also iterates from the start of the array, which
+  corresponds to the usual behavior of loops and iterators in most
+  programming languages. There is one case where `fold_right` might be
+  preferred, see the next point.
+- If the folded function is associative but _(left) short-circuiting_,
+  meaning that it can sometimes determine the result without using the
+  right argument, then `fold_right` provides early return. An example is
+  the boolean AND operator `&&`: when evaluating `left && right`, if
+  `left` is `false`, the whole expression will evaluate to `false`
+  without even evaluating `right`. Consider the following expression:
 
-            ```nickel
-            std.array.replicate 1000 true
-            # gives [false, .. true 1000 times]
-            |> std.array.prepend false
-            |> std.array.fold_right (&&) [false]
-            ```
+  ```nickel
+  std.array.replicate 1000 true
+  # gives [false, .. true 1000 times]
+  |> std.array.prepend false
+  |> std.array.fold_right (&&) [false]
+  ```
 
-            Here, `fold_right` will stop at the first element, and the operation
-            runs in constant time, given the definition of `fold_right` and the
-            lazy evaluation of Nickel. If we had used `fold_left` instead, which
-            is closer to a standard iterator, we would have iterated over all of
-            the 1000 elements of the array.
+  Here, `fold_right` will stop at the first element, and the operation
+  runs in constant time, given the definition of `fold_right` and the
+  lazy evaluation of Nickel. If we had used `fold_left` instead, which
+  is closer to a standard iterator, we would have iterated over all of
+  the 1000 elements of the array.
 
-          # Examples
+# Examples
 
-          ```nickel
-          fold_left (fun acc e => acc + e) 0 [ 1, 2, 3 ] =>
-            (((0 + 1) + 2) 3) =>
-            6
-          ```
-        "%
+```nickel
+fold_left (fun acc e => acc + e) 0 [ 1, 2, 3 ] =>
+  (((0 + 1) + 2) 3) =>
+  6
+```
+"%
       = fun f acc array =>
         let length = %array/length% array in
         if length == 0 then
@@ -1348,43 +1347,43 @@ doc "hello" | optional,
         |]
       ) -> Dyn
       | doc m%%"
-          Build a contract from a validator.
+        Build a contract from a validator.
 
-          # Validator
+        # Validator
 
-          A validator is a function returning either `'Ok` or `'Error {message,
-          notes}` with an optional error message and notes to display. Both
-          validators and predicates are immediate contracts: they must decide
-          right away if the value passes or fails (as opposed to delayed
-          contracts). But as opposed to predicates, validators have the
-          additional ability to customize the error reporting.
+        A validator is a function returning either `'Ok` or `'Error {message,
+        notes}` with an optional error message and notes to display. Both
+        validators and predicates are immediate contracts: they must decide
+        right away if the value passes or fails (as opposed to delayed
+        contracts). But as opposed to predicates, validators have the
+        additional ability to customize the error reporting.
 
-          # Typing
+        # Typing
 
-          Because Nickel doesn't currently have proper types for contracts, the
-          return type of `from_validator` is simply `Dyn` in the type signature.
-          You should think of `from_validator` as returning a value of some
-          hypothetical type `Contract`.
+        Because Nickel doesn't currently have proper types for contracts, the
+        return type of `from_validator` is simply `Dyn` in the type signature.
+        You should think of `from_validator` as returning a value of some
+        hypothetical type `Contract`.
 
-          # Examples
+        # Examples
 
-          ```nickel
-          let IsZero = std.contract.from_validator (match {
-            0 => 'Ok,
-            n if std.is_number n =>
-              'Error {
-                message = "expected 0, got %{std.to_string n}",
-                notes = ["The value is a number, but it isn't 0"],
-              },
-            v =>
-              let vtype = v |> std.typeof |> std.to_string in
-              'Error { message = "expected a number, got a %{vtype}" }
-          })
-          in
+        ```nickel
+        let IsZero = std.contract.from_validator (match {
+          0 => 'Ok,
+          n if std.is_number n =>
+            'Error {
+              message = "expected 0, got %{std.to_string n}",
+              notes = ["The value is a number, but it isn't 0"],
+            },
+          v =>
+            let vtype = v |> std.typeof |> std.to_string in
+            'Error { message = "expected a number, got a %{vtype}" }
+        })
+        in
 
-          0 | IsZero
-          ```
-        "%%
+        0 | IsZero
+        ```
+      "%%
       # A validator turns out to be a valid custom contract as well (which just
       # never returns a value with delayed checks)
       = fun validator =>
@@ -2173,29 +2172,29 @@ doc "hello" | optional,
 
         HasField
           | doc m%%"
-              **Warning**: this is an unstable item. It might be renamed,
-              modified or deleted in any subsequent minor Nickel version.
+            **Warning**: this is an unstable item. It might be renamed,
+            modified or deleted in any subsequent minor Nickel version.
 
-              A function contract for 2-ary functions which checks that second
-              argument is a record that contains the first argument as a field.
-              This contract is parametrized by the return type of the function.
+            A function contract for 2-ary functions which checks that second
+            argument is a record that contains the first argument as a field.
+            This contract is parametrized by the return type of the function.
 
-              This contract blames only if the arguments are of the right type
-              but don't satisfy the tested condition (the first is a string and
-              the second is a record). The type of arguments is assumed to be
-              checked by an associated static type annotation. For example, if
-              the first argument is a number, this contract silently passes.
+            This contract blames only if the arguments are of the right type
+            but don't satisfy the tested condition (the first is a string and
+            the second is a record). The type of arguments is assumed to be
+            checked by an associated static type annotation. For example, if
+            the first argument is a number, this contract silently passes.
 
-              ## Example
+            ## Example
 
-              ```nickel
-              let f | HasField Dyn = fun field record => record."%{field}" in
-              (f "foo" { foo = 1, bar = 2 })
-              + (f "baz" { foo = 1, bar = 2 })
-              ```
+            ```nickel
+            let f | HasField Dyn = fun field record => record."%{field}" in
+            (f "foo" { foo = 1, bar = 2 })
+            + (f "baz" { foo = 1, bar = 2 })
+            ```
 
-              In this example, the first call to `f` won't blame, but the second
-              will, as `baz` isn't a field of the record argument.
+            In this example, the first call to `f` won't blame, but the second
+            will, as `baz` isn't a field of the record argument.
             "%%
           = fun Codomain =>
             let HasFieldSecond = fun field =>
@@ -2300,7 +2299,7 @@ doc "hello" | optional,
 
         serialized | Schema
         ```
-      "%%
+    "%%
       =
         %contract/custom%
           (
@@ -2480,8 +2479,7 @@ doc "hello" | optional,
         ```nickel
         std.function.flip (fun x y => "%{x} %{y}") "world!" "Hello,"
           => "Hello, world!"
-        ```
-      "%%
+        ```"%%
       = fun f x y => f y x,
 
     const
@@ -2532,16 +2530,16 @@ doc "hello" | optional,
     pipe
       : forall a. a -> Array (a -> a) -> a
       | doc m%%"
-        Applies an array of functions to a value, in order.
+          Applies an array of functions to a value, in order.
 
-        # Examples
+          # Examples
 
-        ```nickel
-        std.function.pipe 2 [ (+) 2, (+) 3 ]
-          => 7
-        std.function.pipe 'World [ std.string.from, fun s => "Hello, %{s}!" ]
-          => "Hello, World!"
-        ```
+          ```nickel
+          std.function.pipe 2 [ (+) 2, (+) 3 ]
+            => 7
+          std.function.pipe 'World [ std.string.from, fun s => "Hello, %{s}!" ]
+            => "Hello, World!"
+          ```
       "%%
       = fun x fs => std.array.fold_left (|>) x fs,
   },
@@ -3092,51 +3090,51 @@ doc "hello" | optional,
       : forall a. String -> { _ : a } -> a
       | std.contract.unstable.HasField Dyn
       | doc m%%"
-        Returns the field of a record with the given name.
+      Returns the field of a record with the given name.
 
-        `std.record.get field record` is just `record."%{field}"`. The latter
-        form is more idiomatic and should be generally preferred.
+      `std.record.get field record` is just `record."%{field}"`. The latter
+      form is more idiomatic and should be generally preferred.
 
-        However, `std.record.get` can come in handy when a proper function is
-        expected, typically in a sequence of operations chained with the reverse
-        application operator `|>`.
+      However, `std.record.get` can come in handy when a proper function is
+      expected, typically in a sequence of operations chained with the reverse
+      application operator `|>`.
 
-        Trying to extract a field which doesn't exist will result in a contract
-        error.
+      Trying to extract a field which doesn't exist will result in a contract
+      error.
 
-        # Examples
+      # Examples
 
-        ```nickel
-        std.record.get "one" { one = 1, two = 2 } =>
-          1
-        { one = 1, two = 2, string = "three"}
-        |> std.record.to_array
-        |> std.array.filter (fun { field, value } => std.is_number value)
-        |> std.record.from_array
-        |> std.record.get "two"
-          => 2
-        ```
+      ```nickel
+      std.record.get "one" { one = 1, two = 2 } =>
+        1
+      { one = 1, two = 2, string = "three"}
+      |> std.record.to_array
+      |> std.array.filter (fun { field, value } => std.is_number value)
+      |> std.record.from_array
+      |> std.record.get "two"
+        => 2
+      ```
       "%%
       = fun field r => r."%{field}",
 
     get_or
       : forall a. String -> a -> { _ : a } -> a
       | doc m%%"
-        Returns the field of a record with the given name, or the default value
-        if either there is no such field or if this field doesn't have a
-        definition.
+          Returns the field of a record with the given name, or the default value
+          if either there is no such field or if this field doesn't have a
+          definition.
 
-        # Examples
+          # Examples
 
-        ```nickel
-        std.record.get_or "tree" 3 { one = 1, two = 2 }
-          => 3
-        std.record.get_or "one" 11 { one = 1, two = 2 }
-          => 1
-        std.record.get_or "value" "default" { tag = 'Hello, value }
-          => "default"
-        ```
-      "%%
+          ```nickel
+          std.record.get_or "tree" 3 { one = 1, two = 2 }
+            => 3
+          std.record.get_or "one" 11 { one = 1, two = 2 }
+            => 1
+          std.record.get_or "value" "default" { tag = 'Hello, value }
+            => "default"
+          ```
+        "%%
       = fun field default_value record =>
         if %record/has_field% field record
         && %record/field_is_defined% field record then
@@ -3147,70 +3145,70 @@ doc "hello" | optional,
     insert
       : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%%"
-          Inserts a new field into a record. `insert` doesn't mutate the original
-          record but returns a new one instead.
+      Inserts a new field into a record. `insert` doesn't mutate the original
+      record but returns a new one instead.
 
-          # Preconditions
+      # Preconditions
 
-          The field must not exist in the initial record, otherwise `insert`
-          will fail. If the field might already exist, use `std.record.update`
-          instead.
+      The field must not exist in the initial record, otherwise `insert`
+      will fail. If the field might already exist, use `std.record.update`
+      instead.
 
-          # Empty optional fields
+      # Empty optional fields
 
-          By default, `insert` ignores optional fields without definition. The
-          precondition above doesn't apply to empty optional fields, and
-          `insert` will silently erase an existing empty optional field.
+      By default, `insert` ignores optional fields without definition. The
+      precondition above doesn't apply to empty optional fields, and
+      `insert` will silently erase an existing empty optional field.
 
-          Use `std.record.insert_with_opts` for a version which doesn't ignore
-          empty optional fields.
+      Use `std.record.insert_with_opts` for a version which doesn't ignore
+      empty optional fields.
 
-          # Examples
+      # Examples
 
-          ```nickel
-          std.record.insert "foo" 5 { bar = "bar" }
-            => { foo = 5, bar = "bar }
-          {}
-          |> std.record.insert "file.txt" "data/text"
-          |> std.record.insert "length" (10*1000)
-            => {"file.txt" = "data/text", "length" = 10000}
-          std.record.insert "already_there_opt" 0 {already_there_opt | optional}
-            => {already_there_optional = 0}
-          std.record.insert "already_there" 0 {already_there = 1}
-            => error
-          ```
-        "%%
+      ```nickel
+      std.record.insert "foo" 5 { bar = "bar" }
+        => { foo = 5, bar = "bar }
+      {}
+      |> std.record.insert "file.txt" "data/text"
+      |> std.record.insert "length" (10*1000)
+        => {"file.txt" = "data/text", "length" = 10000}
+      std.record.insert "already_there_opt" 0 {already_there_opt | optional}
+        => {already_there_optional = 0}
+      std.record.insert "already_there" 0 {already_there = 1}
+        => error
+      ```
+    "%%
       = fun field content r => %record/insert% field r content,
 
     insert_with_opts
       : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%%"
-          Inserts a new field into a record. `insert_with_opts` doesn't mutate the
-          original record but returns a new one instead.
+Inserts a new field into a record. `insert_with_opts` doesn't mutate the
+original record but returns a new one instead.
 
-          Same as `std.record.insert`, but doesn't ignore empty optional fields.
+Same as `std.record.insert`, but doesn't ignore empty optional fields.
 
-          # Preconditions
+# Preconditions
 
-          The field must not exist in the initial record, otherwise `insert`
-          will fail. If the field might already exist, use `std.record.update`
-          instead.
+The field must not exist in the initial record, otherwise `insert`
+will fail. If the field might already exist, use `std.record.update`
+instead.
 
-          # Examples
+# Examples
 
-          ```nickel
-          std.record.insert_with_opts "foo" 5 { bar = "bar" }
-            => { foo = 5, bar = "bar }
-          {}
-          |> std.record.insert_with_opts "file.txt" "data/text"
-          |> std.record.insert_with_opts "length" (10*1000)
-            => {"file.txt" = "data/text", "length" = 10000}
-          std.record.insert_with_opts "already_there_optional" 0 {already_there | optional}
-            => error
-          std.record.insert_with_opts "already_there" 0 {already_there = 1}
-            => error
-          ```
-        "%%
+```nickel
+std.record.insert_with_opts "foo" 5 { bar = "bar" }
+  => { foo = 5, bar = "bar }
+{}
+|> std.record.insert_with_opts "file.txt" "data/text"
+|> std.record.insert_with_opts "length" (10*1000)
+  => {"file.txt" = "data/text", "length" = 10000}
+std.record.insert_with_opts "already_there_optional" 0 {already_there | optional}
+  => error
+std.record.insert_with_opts "already_there" 0 {already_there = 1}
+  => error
+```
+"%%
       = fun field content r => %record/insert_with_opts% field r content,
 
     remove

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -9,8 +9,8 @@ use rootcause::prelude::ResultExt;
 use topiary_tree_sitter_facade::Node;
 
 use crate::{
-    Atom, Capitalisation, FormatterError, FormatterResult, ScopeCondition, ScopeInformation,
-    tree_sitter::NodeExt,
+    Atom, Capitalisation, EnforceIndentation, FormatterError, FormatterResult, MultiLineIndent,
+    ScopeCondition, ScopeInformation, tree_sitter::NodeExt,
 };
 
 /// A struct that holds sets of node IDs that have line breaks before or after them.
@@ -30,7 +30,7 @@ struct NodesWithLinebreaks {
 /// repeating the leaf-id search loop.
 struct LeafFlagsMut<'a> {
     single_line_no_indent: &'a mut bool,
-    multi_line_indent_all: &'a mut bool,
+    multi_line_indent_all: &'a mut MultiLineIndent,
     keep_whitespace: &'a mut bool,
 }
 
@@ -233,6 +233,16 @@ impl AtomCollection {
             predicates.scope_id.as_deref().ok_or_else(|| {
                 FormatterError::Query(format!("@{name} requires a #scope_id! predicate"))
             })
+        };
+        let requires_multi_line_string_delimiters = || {
+            predicates
+                .multi_line_string_delimiters
+                .as_ref()
+                .ok_or_else(|| {
+                    FormatterError::Query(format!(
+                        "@{name} requires both a @multi_line_string.start and a @multi_line_string.end directive in the same query"
+                    ))
+                })
         };
 
         // For the {prepend/append}_scope_{begin/end} captures we need this information,
@@ -480,10 +490,22 @@ impl AtomCollection {
                 });
                 self.append(Atom::Hardline, node, predicates);
             }
+            "multi_line_string" => {
+                let (start, end) = requires_multi_line_string_delimiters()?;
+                self.mutate_leaf_flags(node.id(), |flags| {
+                    *flags.multi_line_indent_all =
+                        MultiLineIndent::EnforceIndentation(EnforceIndentation {
+                            last_line_break_significant: !predicates
+                                .multi_line_string_last_insignificant,
+                            start: start.clone(),
+                            end: end.clone(),
+                        });
+                });
+            }
             // Mark a leaf to have all its lines be indented
             "multi_line_indent_all" => {
                 self.mutate_leaf_flags(node.id(), |flags| {
-                    *flags.multi_line_indent_all = true;
+                    *flags.multi_line_indent_all = MultiLineIndent::MaintainOffset;
                 });
             }
             // Mark a leaf to disable trimming
@@ -609,7 +631,7 @@ impl AtomCollection {
                 id,
                 original_position: node.start_position().into(),
                 single_line_no_indent: false,
-                multi_line_indent_all: false,
+                multi_line_indent_all: MultiLineIndent::None,
                 keep_whitespace: false,
                 capitalisation: Capitalisation::Pass,
             });
@@ -1159,6 +1181,10 @@ pub struct QueryPredicates {
     pub multi_line_scope_only: Option<String>,
     /// A query name, for debugging/logging purposes
     pub query_name: Option<String>,
+    /// multi line string delimiters
+    pub multi_line_string_delimiters: Option<(String, String)>,
+    /// The flag that indicates that topiary must not add any line breaks to the end of multi line strings
+    pub multi_line_string_last_insignificant: bool,
 }
 
 /// Collapses spaces before antispace atoms in a vector of atoms.

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -234,15 +234,19 @@ impl AtomCollection {
                 FormatterError::Query(format!("@{name} requires a #scope_id! predicate"))
             })
         };
-        let requires_multi_line_string_delimiters = || {
-            predicates
-                .multi_line_string_delimiters
-                .as_ref()
-                .ok_or_else(|| {
+        let requires_multi_line_string_delimiters = || -> FormatterResult<(&String, &String)> {
+            Ok((
+                predicates.multi_line_string_start.as_ref().ok_or_else(|| {
                     FormatterError::Query(format!(
-                        "@{name} requires both a @multi_line_string.start and a @multi_line_string.end directive in the same query"
+                        "@{name} requires a @multi_line_string.start capture in the same query"
                     ))
-                })
+                })?,
+                predicates.multi_line_string_end.as_ref().ok_or_else(|| {
+                    FormatterError::Query(format!(
+                        "@{name} requires a @multi_line_string.end capture in the same query"
+                    ))
+                })?,
+            ))
         };
 
         // For the {prepend/append}_scope_{begin/end} captures we need this information,
@@ -1181,8 +1185,10 @@ pub struct QueryPredicates {
     pub multi_line_scope_only: Option<String>,
     /// A query name, for debugging/logging purposes
     pub query_name: Option<String>,
-    /// multi line string delimiters
-    pub multi_line_string_delimiters: Option<(String, String)>,
+    /// multi line string start delimiter
+    pub multi_line_string_start: Option<String>,
+    /// multi line string end delimiter
+    pub multi_line_string_end: Option<String>,
     /// The flag that indicates that topiary must not add any line breaks to the end of multi line strings
     pub multi_line_string_last_insignificant: bool,
 }

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -30,7 +30,7 @@ struct NodesWithLinebreaks {
 /// repeating the leaf-id search loop.
 struct LeafFlagsMut<'a> {
     single_line_no_indent: &'a mut bool,
-    multi_line_indent_all: &'a mut MultiLineIndent,
+    multi_line_indent: &'a mut MultiLineIndent,
     keep_whitespace: &'a mut bool,
 }
 
@@ -160,7 +160,7 @@ impl AtomCollection {
             if let Atom::Leaf {
                 id,
                 single_line_no_indent,
-                multi_line_indent_all,
+                multi_line_indent,
                 keep_whitespace,
                 ..
             } = atom
@@ -168,7 +168,7 @@ impl AtomCollection {
             {
                 f(LeafFlagsMut {
                     single_line_no_indent,
-                    multi_line_indent_all,
+                    multi_line_indent,
                     keep_whitespace,
                 });
             }
@@ -493,7 +493,7 @@ impl AtomCollection {
             "multi_line_string" => {
                 let (start, end) = requires_multi_line_string_delimiters()?;
                 self.mutate_leaf_flags(node.id(), |flags| {
-                    *flags.multi_line_indent_all =
+                    *flags.multi_line_indent =
                         MultiLineIndent::EnforceIndentation(EnforceIndentation {
                             last_line_break_significant: !predicates
                                 .multi_line_string_last_insignificant,
@@ -505,7 +505,7 @@ impl AtomCollection {
             // Mark a leaf to have all its lines be indented
             "multi_line_indent_all" => {
                 self.mutate_leaf_flags(node.id(), |flags| {
-                    *flags.multi_line_indent_all = MultiLineIndent::MaintainOffset;
+                    *flags.multi_line_indent = MultiLineIndent::MaintainOffset;
                 });
             }
             // Mark a leaf to disable trimming
@@ -631,7 +631,7 @@ impl AtomCollection {
                 id,
                 original_position: node.start_position().into(),
                 single_line_no_indent: false,
-                multi_line_indent_all: MultiLineIndent::None,
+                multi_line_indent: MultiLineIndent::None,
                 keep_whitespace: false,
                 capitalisation: Capitalisation::Pass,
             });

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -9,8 +9,8 @@ use rootcause::prelude::ResultExt;
 use topiary_tree_sitter_facade::Node;
 
 use crate::{
-    Atom, Capitalisation, EnforceIndentation, FormatterError, FormatterResult, MultiLineIndent,
-    ScopeCondition, ScopeInformation, tree_sitter::NodeExt,
+    Atom, Capitalisation, FormatterError, FormatterResult, MultiLineIndent, ScopeCondition,
+    ScopeInformation, multi_line_indent, tree_sitter::NodeExt,
 };
 
 /// A struct that holds sets of node IDs that have line breaks before or after them.
@@ -497,13 +497,14 @@ impl AtomCollection {
             "multi_line_string" => {
                 let (start, end) = requires_multi_line_string_delimiters()?;
                 self.mutate_leaf_flags(node.id(), |flags| {
-                    *flags.multi_line_indent =
-                        MultiLineIndent::EnforceIndentation(EnforceIndentation {
+                    *flags.multi_line_indent = MultiLineIndent::EnforceIndentation(
+                        multi_line_indent::EnforceIndentation {
                             last_line_break_significant: !predicates
                                 .multi_line_string_last_insignificant,
                             start: start.clone(),
                             end: end.clone(),
-                        });
+                        },
+                    );
                 });
             }
             // Mark a leaf to have all its lines be indented

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -9,8 +9,8 @@ use rootcause::prelude::ResultExt;
 use topiary_tree_sitter_facade::Node;
 
 use crate::{
-    Atom, Capitalisation, FormatterError, FormatterResult, ScopeCondition, ScopeInformation,
-    tree_sitter::NodeExt,
+    Atom, Capitalisation, FormatterError, FormatterResult, MultiLineIndent, ScopeCondition,
+    ScopeInformation, multi_line_indent, tree_sitter::NodeExt,
 };
 
 /// A struct that holds sets of node IDs that have line breaks before or after them.
@@ -29,8 +29,9 @@ struct NodesWithLinebreaks {
 /// exposed together so leaf-flag directives can flip a single flag without
 /// repeating the leaf-id search loop.
 struct LeafFlagsMut<'a> {
+    content: &'a mut String,
     single_line_no_indent: &'a mut bool,
-    multi_line_indent_all: &'a mut bool,
+    multi_line_indent: &'a mut MultiLineIndent,
     keep_whitespace: &'a mut bool,
 }
 
@@ -155,24 +156,31 @@ impl AtomCollection {
     /// `self.atoms` whose tree-sitter `id` equals `node_id`. Used by the
     /// leaf-flag directives (`@single_line_no_indent`,
     /// `@multi_line_indent_all`, `@keep_whitespace`).
-    fn mutate_leaf_flags(&mut self, node_id: usize, mut f: impl FnMut(LeafFlagsMut<'_>)) {
+    fn mutate_leaf_flags(
+        &mut self,
+        node_id: usize,
+        mut f: impl FnMut(LeafFlagsMut<'_>) -> FormatterResult<()>,
+    ) -> FormatterResult<()> {
         for atom in &mut self.atoms {
             if let Atom::Leaf {
+                content,
                 id,
                 single_line_no_indent,
-                multi_line_indent_all,
+                multi_line_indent,
                 keep_whitespace,
                 ..
             } = atom
                 && *id == node_id
             {
                 f(LeafFlagsMut {
+                    content,
                     single_line_no_indent,
-                    multi_line_indent_all,
+                    multi_line_indent,
                     keep_whitespace,
-                });
+                })?;
             }
         }
+        Ok(())
     }
     // wrap inside a conditional atom if #single/multi_line_scope_only! is set
     fn wrap(&mut self, atom: Atom, predicates: &QueryPredicates) -> Atom {
@@ -233,6 +241,20 @@ impl AtomCollection {
             predicates.scope_id.as_deref().ok_or_else(|| {
                 FormatterError::Query(format!("@{name} requires a #scope_id! predicate"))
             })
+        };
+        let requires_multi_line_string_delimiters = || -> FormatterResult<(&String, &String)> {
+            Ok((
+                predicates.multi_line_string_start.as_ref().ok_or_else(|| {
+                    FormatterError::Query(format!(
+                        "@{name} requires a @multi_line_string.start capture in the same query"
+                    ))
+                })?,
+                predicates.multi_line_string_end.as_ref().ok_or_else(|| {
+                    FormatterError::Query(format!(
+                        "@{name} requires a @multi_line_string.end capture in the same query"
+                    ))
+                })?,
+            ))
         };
 
         // For the {prepend/append}_scope_{begin/end} captures we need this information,
@@ -477,20 +499,68 @@ impl AtomCollection {
             "single_line_no_indent" => {
                 self.mutate_leaf_flags(node.id(), |flags| {
                     *flags.single_line_no_indent = true;
-                });
+                    Ok(())
+                })?;
                 self.append(Atom::Hardline, node, predicates);
+            }
+            "multi_line_string" => {
+                let (start, end) = requires_multi_line_string_delimiters()?;
+                self.mutate_leaf_flags(node.id(), |flags| {
+                    *flags.content = flags
+                        .content
+                        .strip_prefix(start)
+                        .ok_or_else(|| {
+                            FormatterError::Query(format!(
+                                "the multi line string starting with {:?} in {} should start with {start:?} as marked by the query{}.",
+                                flags.content.chars().take(16).collect::<String>(),
+                                node.display_one_based(),
+                                if let Some(query_name) = predicates.query_name.as_ref() {format!(" {query_name}")} else {"".to_owned()},
+                            ))
+                        })?
+                        .strip_suffix(end)
+                        .ok_or_else(|| {
+                            FormatterError::Query(format!(
+                                "the multi line string ending with {:?} in {} should end with {end:?} as marked by the query{}.",
+                                flags.content
+                                    .chars()
+                                    .rev()
+                                    .take(16)
+                                    .collect::<String>()
+                                    .chars()
+                                    .rev()
+                                    .collect::<String>(),
+                                node.display_one_based(),
+                                if let Some(n) = &predicates.query_name {format!(" {n}")} else {"".to_owned()},
+                            ))
+                        })?
+                        .to_owned();
+                    *flags.multi_line_indent = MultiLineIndent::EnforceIndentation(
+                        multi_line_indent::EnforceIndentation {
+                            start: start.clone(),
+                            end: end.clone(),
+                            last_line_break_significant: !predicates
+                                .multi_line_string_last_insignificant,
+                            carriage_return_significant: predicates
+                                .multi_line_string_cr_significant,
+                            tab_significant: predicates.multi_line_string_tab_significant,
+                        },
+                    );
+                Ok(())
+                })?;
             }
             // Mark a leaf to have all its lines be indented
             "multi_line_indent_all" => {
                 self.mutate_leaf_flags(node.id(), |flags| {
-                    *flags.multi_line_indent_all = true;
-                });
+                    *flags.multi_line_indent = MultiLineIndent::MaintainOffset;
+                    Ok(())
+                })?;
             }
             // Mark a leaf to disable trimming
             "keep_whitespace" => {
                 self.mutate_leaf_flags(node.id(), |flags| {
                     *flags.keep_whitespace = true;
-                });
+                    Ok(())
+                })?;
             }
             // Return a query parsing error on unknown capture names
             unknown => {
@@ -609,7 +679,7 @@ impl AtomCollection {
                 id,
                 original_position: node.start_position().into(),
                 single_line_no_indent: false,
-                multi_line_indent_all: false,
+                multi_line_indent: MultiLineIndent::None,
                 keep_whitespace: false,
                 capitalisation: Capitalisation::Pass,
             });
@@ -1159,6 +1229,16 @@ pub struct QueryPredicates {
     pub multi_line_scope_only: Option<String>,
     /// A query name, for debugging/logging purposes
     pub query_name: Option<String>,
+    /// multi line string start delimiter
+    pub multi_line_string_start: Option<String>,
+    /// multi line string end delimiter
+    pub multi_line_string_end: Option<String>,
+    /// The flag that indicates that topiary must not add any line breaks to the end of multi line strings
+    pub multi_line_string_last_insignificant: bool,
+    /// The flag that indicates that carriage returns always become part of the string's value.
+    pub multi_line_string_cr_significant: bool,
+    /// The flag that indicates that tabs always become part of the string's value.
+    pub multi_line_string_tab_significant: bool,
 }
 
 /// Collapses spaces before antispace atoms in a vector of atoms.

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -92,7 +92,7 @@ pub enum Atom {
         // marks the leaf to be printed on a single line, with no indentation
         single_line_no_indent: bool,
         // if the leaf is multi-line, each line will be indented, not just the first
-        multi_line_indent_all: MultiLineIndent,
+        multi_line_indent: MultiLineIndent,
         // don't trim trailing newline characters if set to true
         keep_whitespace: bool,
         capitalisation: Capitalisation,

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -49,19 +49,23 @@ pub enum Capitalisation {
     Pass,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EnforceIndentation {
-    last_line_break_significant: bool,
-    start: String,
-    end: String,
+pub mod multi_line_indent {
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct EnforceIndentation {
+        pub(crate) last_line_break_significant: bool,
+        pub(crate) start: String,
+        pub(crate) end: String,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub enum MultiLineIndent {
+        None,
+        MaintainOffset,
+        EnforceIndentation(EnforceIndentation),
+    }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum MultiLineIndent {
-    None,
-    MaintainOffset,
-    EnforceIndentation(EnforceIndentation),
-}
+use multi_line_indent::MultiLineIndent;
 
 /// An atom represents a small piece of the output. We turn Tree-sitter nodes
 /// into atoms, and we add white-space atoms where appropriate. The final list

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -51,9 +51,9 @@ pub enum Capitalisation {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EnforceIndentation {
-    pub last_line_break_significant: bool,
-    pub start: String,
-    pub end: String,
+    last_line_break_significant: bool,
+    start: String,
+    end: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -41,10 +41,11 @@ pub struct ScopeInformation {
     scope_id: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum Capitalisation {
     UpperCase,
     LowerCase,
+    #[default]
     Pass,
 }
 

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -48,6 +48,27 @@ pub enum Capitalisation {
     #[default]
     Pass,
 }
+
+pub mod multi_line_indent {
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct EnforceIndentation {
+        pub(crate) start: String,
+        pub(crate) end: String,
+        pub(crate) last_line_break_significant: bool,
+        pub(crate) carriage_return_significant: bool,
+        pub(crate) tab_significant: bool,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub enum MultiLineIndent {
+        None,
+        MaintainOffset,
+        EnforceIndentation(EnforceIndentation),
+    }
+}
+
+use multi_line_indent::MultiLineIndent;
+
 /// An atom represents a small piece of the output. We turn Tree-sitter nodes
 /// into atoms, and we add white-space atoms where appropriate. The final list
 /// of atoms is rendered to the output.
@@ -77,7 +98,7 @@ pub enum Atom {
         // marks the leaf to be printed on a single line, with no indentation
         single_line_no_indent: bool,
         // if the leaf is multi-line, each line will be indented, not just the first
-        multi_line_indent_all: bool,
+        multi_line_indent: MultiLineIndent,
         // don't trim trailing newline characters if set to true
         keep_whitespace: bool,
         capitalisation: Capitalisation,

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -41,13 +41,27 @@ pub struct ScopeInformation {
     scope_id: String,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Capitalisation {
     UpperCase,
     LowerCase,
-    #[default]
     Pass,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EnforceIndentation {
+    pub last_line_break_significant: bool,
+    pub start: String,
+    pub end: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MultiLineIndent {
+    None,
+    MaintainOffset,
+    EnforceIndentation(EnforceIndentation),
+}
+
 /// An atom represents a small piece of the output. We turn Tree-sitter nodes
 /// into atoms, and we add white-space atoms where appropriate. The final list
 /// of atoms is rendered to the output.
@@ -77,7 +91,7 @@ pub enum Atom {
         // marks the leaf to be printed on a single line, with no indentation
         single_line_no_indent: bool,
         // if the leaf is multi-line, each line will be indented, not just the first
-        multi_line_indent_all: bool,
+        multi_line_indent_all: MultiLineIndent,
         // don't trim trailing newline characters if set to true
         keep_whitespace: bool,
         capitalisation: Capitalisation,

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -2,11 +2,13 @@
 //! module is responsible for rendering the slice of Atoms back into a displayable
 //! format.
 
-use std::fmt::Write;
+use std::{cmp::Ordering, fmt::Write};
 
 use rootcause::prelude::ResultExt;
 
-use crate::{Atom, Capitalisation, FormatterError, FormatterResult};
+use crate::{
+    Atom, Capitalisation, EnforceIndentation, FormatterError, FormatterResult, MultiLineIndent,
+};
 
 /// Renders a slice of [`Atom`]s into formatted source code.
 ///
@@ -69,22 +71,31 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                     content.trim_end_matches('\n')
                 };
 
-                let mut content = if *multi_line_indent_all {
-                    let cursor = current_column(&buffer) as i32;
+                let mut content = match multi_line_indent_all {
+                    MultiLineIndent::None => content.into(),
+                    MultiLineIndent::MaintainOffset => {
+                        let cursor = current_column(&buffer) as i32;
 
-                    // original_position is 1-based
-                    let original_column = original_position.column as i32 - 1;
+                        // original_position is 1-based
+                        let original_column = original_position.column as i32 - 1;
 
-                    let indenting = cursor - original_column;
+                        let indenting = cursor - original_column;
 
-                    // The following assumes spaces are used for indenting
-                    match indenting {
-                        0 => content.into(),
-                        n if n > 0 => add_spaces_after_newlines(content, indenting),
-                        _ => try_removing_spaces_after_newlines(content, -indenting),
+                        // The following assumes spaces are used for indenting
+                        match indenting {
+                            0 => content.into(),
+                            n if n > 0 => add_spaces_after_newlines(content, indenting),
+                            _ => try_removing_spaces_after_newlines(content, -indenting),
+                        }
                     }
-                } else {
-                    content.into()
+                    MultiLineIndent::EnforceIndentation(absolute_indentation) => {
+                        render_enforced_indentation(
+                            absolute_indentation,
+                            content,
+                            indent_level,
+                            indent,
+                        )?
+                    }
                 };
                 match capitalisation {
                     Capitalisation::UpperCase => {
@@ -156,4 +167,1620 @@ fn try_removing_spaces_after_newlines(s: &str, n: i32) -> String {
     }
 
     result
+}
+
+/// formats multi line source code constructs like multi line strings.
+///
+/// `absolute_indentation` contains configuration. at this stage we assume that it is a `ClosingColumnInsignificant` constructor.
+/// `content_original` is the multi line string including the delimiters.
+/// `indent_level` is the current indentation level of the line containing the start delimiter.
+/// `indent` is the white space prefix of a line at indentation level 1.
+/// the returned `String` differs only in white space from `content_original`.
+fn render_enforced_indentation(
+    absolute_indentation: &EnforceIndentation,
+    content_original: &str,
+    indent_level: usize,
+    indent: &str,
+) -> FormatterResult<String> {
+    let EnforceIndentation {
+        last_line_break_significant,
+        start,
+        end,
+    } = absolute_indentation;
+
+    let content: Vec<&str> = content_original
+        .strip_prefix(start)
+        .ok_or_else(|| {
+            FormatterError::Query(format!(
+                "the multi line leaf starting with {:?} should start with {start:?} as marked by the query",
+                &content_original[..content_original.len().min(16)]
+            ))
+        })?
+        .strip_suffix(end)
+        .ok_or_else(|| {
+            FormatterError::Query(format!(
+                "the multi line leaf ending with {:?} should end with {end:?} as marked by the query",
+                &content_original[content_original.len().saturating_sub(16)..]
+            ))
+        })?
+        .split("\n")
+        .map(|s| s.strip_suffix("\r").unwrap_or(s)) // to do. remove this?
+        .collect(); // because we need `DoubleEndedIterator::next_back`.
+
+    if content.len() == 1 {
+        return Ok(content_original.to_owned());
+    }
+
+    let mut content = content.iter().copied();
+    let mut buffer = String::new();
+    write!(buffer, "{start}").unwrap();
+
+    // skip potential empty first line
+    if content
+        .clone()
+        .next()
+        .expect("`split` should not produce empty iterators.")
+        .chars()
+        .all(char::is_whitespace)
+    {
+        content
+            .next()
+            .expect("`split` should not produce empty iterators.");
+    }
+
+    // skip potential empty last line
+    let last_line_is_whitespace = content
+        .clone()
+        .next_back()
+        .expect("`split` should not produce empty iterators and `content_collected.len() != 1`.")
+        .chars()
+        .all(char::is_whitespace);
+    if last_line_is_whitespace {
+        content.next_back().expect(
+            "`split` should not produce empty iterators and `content_collected.len() != 1`.",
+        );
+    }
+
+    if content.clone().next().is_none() {
+        return Ok(format!("{start}{end}"));
+    }
+
+    let whitespace_prefixes = content
+        .clone()
+        .filter(|s| !s.chars().all(char::is_whitespace))
+        .map(str::chars)
+        .map(|s| s.take_while(|c| c.is_whitespace()));
+    if let Some(common_whitespace_prefix) = common_prefix(whitespace_prefixes.clone()) {
+        // purely for warning generation
+        match common_whitespace_prefix.clone().count().cmp(
+            &whitespace_prefixes.map(Iterator::count).min().expect(
+                "whitespace_prefixes should not be empty if `common_prefix` returns `Some`.",
+            ),
+        ) {
+            Ordering::Less => println!(
+                // to do
+                "is this indentation? then you should not mix different kinds of whitespace characters."
+            ),
+            Ordering::Equal => (),
+            Ordering::Greater => panic!(
+                "the common whitespace prefix should be a substring of the shortest whitespace prefix."
+            ),
+        }
+
+        let common_whitespace_prefix_len_utf8: usize =
+            common_whitespace_prefix.map(char::len_utf8).sum();
+        let content =
+            content.map(|line| &line[line.len().min(common_whitespace_prefix_len_utf8)..]);
+
+        for line in content {
+            if line.is_empty() {
+                writeln!(buffer).unwrap();
+            } else {
+                write!(buffer, "\n{}{line}", indent.repeat(indent_level + 1)).unwrap();
+            }
+        }
+    } else {
+        // no lines other than whitespace lines
+        for _ in content {
+            writeln!(buffer).unwrap();
+        }
+    }
+    #[allow(clippy::nonminimal_bool)]
+    if last_line_is_whitespace || (!last_line_is_whitespace && !last_line_break_significant) {
+        write!(buffer, "\n{}", indent.repeat(indent_level)).unwrap();
+    }
+    write!(buffer, "{end}").unwrap();
+    Ok(buffer)
+}
+
+/// returns an iterator over the longest common prefix shared by all the
+/// inner iterables of `list_of_lists`, or `none` if `list_of_lists` is empty.
+///
+/// the prefix is computed element-wise: items at the same position in each
+/// inner iterable are compared, and the iteration stops as soon as any pair
+/// differs (or one of the inner iterables is exhausted).
+fn common_prefix<TSS>(
+    list_of_lists: TSS,
+) -> Option<impl Iterator<Item = <TSS::Item as IntoIterator>::Item> + Clone>
+where
+    TSS: IntoIterator,
+    TSS::Item: IntoIterator,
+    <TSS::Item as IntoIterator>::IntoIter: Clone,
+    <TSS::Item as IntoIterator>::Item: PartialEq,
+{
+    let mut iters = list_of_lists
+        .into_iter()
+        .map(IntoIterator::into_iter)
+        .collect::<Vec<_>>();
+    if iters.is_empty() {
+        return None;
+    }
+    Some(std::iter::from_fn(move || {
+        let mut items = iters.iter_mut().map(Iterator::next);
+        let first = items.next().expect("`iters` should not be empty.")?;
+        items
+            .all(|item| item.as_ref() == Some(&first))
+            .then_some(first)
+    }))
+}
+
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn test_common_prefix() {
+        assert_eq!(
+            common_prefix(["012a", "01b", "0123c"].map(str::chars))
+                .map(Iterator::collect::<String>)
+                .as_ref()
+                .map(String::as_str),
+            Some("01")
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation0() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''\t
+    a
+   b
+     c
+            ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                 a
+                b
+                  c
+            ''",
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation1() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''x
+    a
+   b
+     c
+            ''",
+                3,
+                "    "
+            )
+            .unwrap(),
+            "''
+                x
+                    a
+                   b
+                     c
+            ''"
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_1_line0() {
+        for line in ["''''", "'' ''", "'' a''"] {
+            assert_eq!(
+                render_enforced_indentation(
+                    &EnforceIndentation {
+                        last_line_break_significant: false,
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                    },
+                    line,
+                    3,
+                    "  ",
+                )
+                .unwrap(),
+                line,
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_1_line1() {
+        for line in ["''''", "'' ''", "'' a''"] {
+            assert_eq!(
+                render_enforced_indentation(
+                    &EnforceIndentation {
+                        last_line_break_significant: true,
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                    },
+                    line,
+                    3,
+                    "  ",
+                )
+                .unwrap(),
+                line,
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_2_lines0() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "'' 
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "'' 
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''"
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''"
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "'' 
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''"
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a
+            ''"
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_2_lines1() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "'' 
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "'' 
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''"
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a''"
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "'' 
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a''"
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a''"
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_3_lines0() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+    
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+    
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''            a
+        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                        a
+                    a
+                a
+            ''",
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_3_lines1() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+    
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    a
+''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    a
+    
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    a
+    ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+    
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+    
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''        a
+    
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''    
+        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''            a
+        a
+    a''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                        a
+                    a
+                a''",
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_significant_whitespace0() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+                    a
+                     
+                ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+                 
+            ''",
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_significant_whitespace1() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+                    a
+                     
+                ''",
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+                 
+            ''",
+        );
+    }
 }

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -218,7 +218,7 @@ fn render_enforced_indentation(
 
     let mut content = content.iter().copied();
     let mut buffer = String::new();
-    write!(buffer, "{start}").unwrap();
+    write!(buffer, "{start}").context_to()?;
 
     // skip potential empty first line
     if content
@@ -296,16 +296,16 @@ fn render_enforced_indentation(
 
     for line in content {
         if line.is_empty() {
-            writeln!(buffer).unwrap();
+            writeln!(buffer).context_to()?;
         } else {
-            write!(buffer, "\n{}{line}", indent.repeat(indent_level + 1)).unwrap();
+            write!(buffer, "\n{}{line}", indent.repeat(indent_level + 1)).context_to()?;
         }
     }
     #[allow(clippy::nonminimal_bool)]
     if last_line_is_whitespace || (!last_line_is_whitespace && !last_line_break_significant) {
-        write!(buffer, "\n{}", indent.repeat(indent_level)).unwrap();
+        write!(buffer, "\n{}", indent.repeat(indent_level)).context_to()?;
     }
-    write!(buffer, "{end}").unwrap();
+    write!(buffer, "{end}").context_to()?;
     Ok(buffer)
 }
 

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -248,47 +248,54 @@ fn render_enforced_indentation(
         return Ok(format!("{start}{end}"));
     }
 
-    let whitespace_prefixes = content
-        .clone()
-        .filter(|s| !s.chars().all(char::is_whitespace))
-        .map(str::chars)
-        .map(|s| s.take_while(|c| c.is_whitespace()));
-    if let Some(common_whitespace_prefix) = common_prefix(whitespace_prefixes.clone()) {
-        if log::log_enabled!(log::Level::Info) {
-            match common_whitespace_prefix.clone().count().cmp(
-                &whitespace_prefixes.map(Iterator::count).min().expect(
-                    "whitespace_prefixes should not be empty if `common_prefix` returns `Some`.",
-                ),
-            ) {
-                // do not change the log level without changing it in the if condition 6 lines above.
-                Ordering::Less => log::info!(
-                    "the multi line string starting at {} mixes different whitespace characters like spaces and tabs in its lines' whitespace prefixes. \
+    let mut common_whitespace_prefix_len: usize = 0;
+    let mut common_whitespace_prefix_len_utf8 = 0;
+    let mut content_collected: Vec<_> = content.clone().map(str::chars).collect();
+    loop {
+        let mut nexts = content_collected.iter_mut().filter_map(Iterator::next);
+        if let Some(first) = nexts.next()
+            && first.is_whitespace()
+            && nexts.all(|c| c == first)
+        {
+            common_whitespace_prefix_len += 1;
+            common_whitespace_prefix_len_utf8 += first.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    if log::log_enabled!(log::Level::Info) {
+        match content
+            .clone()
+            .filter(|s| !s.chars().all(char::is_whitespace))
+            .map(str::chars)
+            .map(|s| s.take_while(|c| c.is_whitespace()))
+            .map(Iterator::count)
+            .min()
+            .map(|min_whitespace_prefix_len| {
+                common_whitespace_prefix_len.cmp(&min_whitespace_prefix_len)
+            }) {
+            None => (), // no lines other than whitespace lines
+            // do not change the log level without changing it in the if condition 6 lines above.
+            Some(Ordering::Less) => log::info!(
+                "the multi line string starting at {} mixes different whitespace characters like spaces and tabs in its lines' whitespace prefixes. \
                     is this supposed to be indentation? then you should not mix different whitespace characters.",
-                    start_position
-                ),
-                Ordering::Equal => (),
-                Ordering::Greater => panic!(
-                    "the common whitespace prefix should be a substring of the shortest whitespace prefix."
-                ),
-            }
+                start_position
+            ),
+            Some(Ordering::Equal) => (),
+            Some(Ordering::Greater) => panic!(
+                "the common whitespace prefix should be a substring of the shortest whitespace prefix."
+            ),
         }
+    }
 
-        let common_whitespace_prefix_len_utf8: usize =
-            common_whitespace_prefix.map(char::len_utf8).sum();
-        let content =
-            content.map(|line| &line[line.len().min(common_whitespace_prefix_len_utf8)..]);
+    let content = content.map(|line| &line[line.len().min(common_whitespace_prefix_len_utf8)..]);
 
-        for line in content {
-            if line.is_empty() {
-                writeln!(buffer).unwrap();
-            } else {
-                write!(buffer, "\n{}{line}", indent.repeat(indent_level + 1)).unwrap();
-            }
-        }
-    } else {
-        // no lines other than whitespace lines
-        for _ in content {
+    for line in content {
+        if line.is_empty() {
             writeln!(buffer).unwrap();
+        } else {
+            write!(buffer, "\n{}{line}", indent.repeat(indent_level + 1)).unwrap();
         }
     }
     #[allow(clippy::nonminimal_bool)]
@@ -299,51 +306,9 @@ fn render_enforced_indentation(
     Ok(buffer)
 }
 
-/// returns an iterator over the longest common prefix shared by all the
-/// inner iterables of `list_of_lists`, or `none` if `list_of_lists` is empty.
-///
-/// the prefix is computed element-wise: items at the same position in each
-/// inner iterable are compared, and the iteration stops as soon as any pair
-/// differs (or one of the inner iterables is exhausted).
-fn common_prefix<TSS>(
-    list_of_lists: TSS,
-) -> Option<impl Iterator<Item = <TSS::Item as IntoIterator>::Item> + Clone>
-where
-    TSS: IntoIterator,
-    TSS::Item: IntoIterator,
-    <TSS::Item as IntoIterator>::IntoIter: Clone,
-    <TSS::Item as IntoIterator>::Item: PartialEq,
-{
-    let mut iters = list_of_lists
-        .into_iter()
-        .map(IntoIterator::into_iter)
-        .collect::<Vec<_>>();
-    if iters.is_empty() {
-        return None;
-    }
-    Some(std::iter::from_fn(move || {
-        let mut items = iters.iter_mut().map(Iterator::next);
-        let first = items.next().expect("`iters` should not be empty.")?;
-        items
-            .all(|item| item.as_ref() == Some(&first))
-            .then_some(first)
-    }))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_common_prefix() {
-        assert_eq!(
-            common_prefix(["012a", "01b", "0123c"].map(str::chars))
-                .map(Iterator::collect::<String>)
-                .as_ref()
-                .map(String::as_str),
-            Some("01")
-        );
-    }
 
     fn start_position() -> Position {
         Position { row: 1, column: 1 }
@@ -2018,6 +1983,56 @@ mod tests {
             "''
                 a
                  
+            ''",
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_mixed_whitespace0() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+                     a
+                    \t
+                ''",
+                3,
+                "    ",
+                &start_position(),
+            )
+            .unwrap(),
+            "''
+                 a
+                \t
+            ''",
+        );
+    }
+
+    #[test]
+    fn test_render_enforced_indentation_mixed_whitespace1() {
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                "''
+                     a
+                    \t
+                ''",
+                3,
+                "    ",
+                &start_position(),
+            )
+            .unwrap(),
+            "''
+                 a
+                \t
             ''",
         );
     }

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -8,6 +8,7 @@ use rootcause::prelude::ResultExt;
 
 use crate::{
     Atom, Capitalisation, EnforceIndentation, FormatterError, FormatterResult, MultiLineIndent,
+    tree_sitter::Position,
 };
 
 /// Renders a slice of [`Atom`]s into formatted source code.
@@ -94,6 +95,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                             content,
                             indent_level,
                             indent,
+                            original_position,
                         )?
                     }
                 };
@@ -181,6 +183,7 @@ fn render_enforced_indentation(
     content_original: &str,
     indent_level: usize,
     indent: &str,
+    start_position: &Position,
 ) -> FormatterResult<String> {
     let EnforceIndentation {
         last_line_break_significant,
@@ -251,20 +254,23 @@ fn render_enforced_indentation(
         .map(str::chars)
         .map(|s| s.take_while(|c| c.is_whitespace()));
     if let Some(common_whitespace_prefix) = common_prefix(whitespace_prefixes.clone()) {
-        // purely for warning generation
-        match common_whitespace_prefix.clone().count().cmp(
-            &whitespace_prefixes.map(Iterator::count).min().expect(
-                "whitespace_prefixes should not be empty if `common_prefix` returns `Some`.",
-            ),
-        ) {
-            Ordering::Less => println!(
-                // to do
-                "is this indentation? then you should not mix different kinds of whitespace characters."
-            ),
-            Ordering::Equal => (),
-            Ordering::Greater => panic!(
-                "the common whitespace prefix should be a substring of the shortest whitespace prefix."
-            ),
+        if log::log_enabled!(log::Level::Info) {
+            match common_whitespace_prefix.clone().count().cmp(
+                &whitespace_prefixes.map(Iterator::count).min().expect(
+                    "whitespace_prefixes should not be empty if `common_prefix` returns `Some`.",
+                ),
+            ) {
+                // do not change the log level without changing it in the if condition 6 lines above.
+                Ordering::Less => log::info!(
+                    "the multi line string starting at {} mixes different whitespace characters like spaces and tabs in its lines' whitespace prefixes. \
+                    is this supposed to be indentation? then you should not mix different whitespace characters.",
+                    start_position
+                ),
+                Ordering::Equal => (),
+                Ordering::Greater => panic!(
+                    "the common whitespace prefix should be a substring of the shortest whitespace prefix."
+                ),
+            }
         }
 
         let common_whitespace_prefix_len_utf8: usize =
@@ -324,8 +330,8 @@ where
     }))
 }
 
+#[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
     use super::*;
 
     #[test]
@@ -337,6 +343,10 @@ mod tests {
                 .map(String::as_str),
             Some("01")
         );
+    }
+
+    fn start_position() -> Position {
+        Position { row: 1, column: 1 }
     }
 
     #[test]
@@ -356,6 +366,7 @@ mod tests {
 ''",
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -382,7 +393,8 @@ mod tests {
      c
 ''",
                 3,
-                "    "
+                "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -407,6 +419,7 @@ mod tests {
                     line,
                     3,
                     "  ",
+                    &start_position(),
                 )
                 .unwrap(),
                 line,
@@ -427,6 +440,7 @@ mod tests {
                     line,
                     3,
                     "  ",
+                    &start_position(),
                 )
                 .unwrap(),
                 line,
@@ -449,6 +463,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -466,6 +481,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -483,6 +499,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -502,6 +519,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -519,6 +537,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -536,6 +555,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -555,6 +575,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -574,6 +595,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -593,6 +615,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -617,6 +640,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -634,6 +658,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -651,6 +676,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -670,6 +696,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -687,6 +714,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''''",
@@ -704,6 +732,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -723,6 +752,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -741,6 +771,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -759,6 +790,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -783,6 +815,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -803,6 +836,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -823,6 +857,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -844,6 +879,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -864,6 +900,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -884,6 +921,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -905,6 +943,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -925,6 +964,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -945,6 +985,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -966,6 +1007,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -986,6 +1028,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1006,6 +1049,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1027,6 +1071,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1047,6 +1092,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1067,6 +1113,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1088,6 +1135,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1108,6 +1156,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1128,6 +1177,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1149,6 +1199,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1170,6 +1221,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1191,6 +1243,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1213,6 +1266,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1234,6 +1288,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1255,6 +1310,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1277,6 +1333,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1298,6 +1355,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1319,6 +1377,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1345,6 +1404,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1365,6 +1425,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1385,6 +1446,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1406,6 +1468,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1426,6 +1489,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1446,6 +1510,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1467,6 +1532,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1487,6 +1553,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1507,6 +1574,7 @@ mod tests {
                 .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1528,6 +1596,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1548,6 +1617,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1568,6 +1638,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1589,6 +1660,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1609,6 +1681,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1629,6 +1702,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1650,6 +1724,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1670,6 +1745,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1690,6 +1766,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1711,6 +1788,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1731,6 +1809,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1751,6 +1830,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1772,6 +1852,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1792,6 +1873,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1812,6 +1894,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1833,6 +1916,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1853,6 +1937,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1873,6 +1958,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1899,6 +1985,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''
@@ -1925,6 +2012,7 @@ mod tests {
                     .replace('.', " "),
                 3,
                 "    ",
+                &start_position(),
             )
             .unwrap(),
             "''

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -348,11 +348,12 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''\t
+                "\
+''\t
     a
    b
      c
-            ''",
+''",
                 3,
                 "    ",
             )
@@ -374,11 +375,12 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''x
+                "\
+''x
     a
    b
      c
-            ''",
+''",
                 3,
                 "    "
             )
@@ -441,8 +443,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-''",
+                &"\
+''
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -456,8 +460,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "'' 
-''",
+                &"\
+''.
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -471,8 +477,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
-''",
+                &"\
+''....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -488,8 +496,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    ''",
+                &"\
+''
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -503,8 +513,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "'' 
-    ''",
+                &"\
+''.
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -518,8 +530,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
-    ''",
+                &"\
+''....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -535,8 +549,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    a''",
+                &"\
+''
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -552,8 +568,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "'' 
-    a''",
+                &"\
+''.
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -569,8 +587,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
-    a''",
+                &"\
+''........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -591,8 +611,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-''",
+                &"\
+''
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -606,8 +628,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "'' 
-''",
+                &"\
+''.
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -621,8 +645,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
-''",
+                &"\
+''....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -638,8 +664,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    ''",
+                &"\
+''
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -653,8 +681,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "'' 
-    ''",
+                &"\
+''.
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -668,8 +698,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
-    ''",
+                &"\
+''....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -685,8 +717,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    a''",
+                &"\
+''
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -701,8 +735,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "'' 
-    a''",
+                &"\
+''.
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -717,8 +753,10 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
-    a''",
+                &"\
+''........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -738,9 +776,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
+                &"\
+''
 
-''",
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -756,9 +796,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
+                &"\
+''....
 
-''",
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -774,64 +816,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
+                &"\
+''....a
 
-''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-                a
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''
-    
-''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    
-    
-''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    a
-    
-''",
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -848,9 +837,72 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    a
-''",
+                &"\
+''
+....
+''"
+                .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....
+....
+''"
+                .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....a
+....
+''"
+                .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''
+....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -866,9 +918,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
-    a
-''",
+                &"\
+''....
+....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -884,9 +938,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
-    a
-''",
+                &"\
+''........a
+....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -903,9 +959,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
+                &"\
+''
 
-    ''",
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -921,9 +979,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
+                &"\
+''....
 
-    ''",
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -939,64 +999,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
+                &"\
+''....a
 
-    ''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-                a
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''
-    
-    ''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    
-    
-    ''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    a
-    
-    ''",
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1013,9 +1020,72 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    a
-    ''",
+                &"\
+''
+....
+....''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....
+....
+....''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....a
+....
+....''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''
+....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1031,9 +1101,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
-    a
-    ''",
+                &"\
+''....
+....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1049,9 +1121,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
-    a
-    ''",
+                &"\
+''........a
+....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1068,9 +1142,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
+                &"\
+''
 
-    a''",
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1087,9 +1163,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
+                &"\
+''....
 
-    a''",
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1106,67 +1184,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
+                &"\
+''........a
 
-    a''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-                    a
-
-                a
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''
-    
-    a''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-                a
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    
-    
-    a''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-                a
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: false,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''        a
-    
-    a''",
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1184,9 +1206,75 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-        a
-    a''",
+                &"\
+''
+....
+....a''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....
+....
+....a''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''........a
+....
+....a''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+
+                a
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: false,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''
+........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1203,9 +1291,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
-        a
-    a''",
+                &"\
+''....
+........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1222,9 +1312,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''            a
-        a
-    a''",
+                &"\
+''............a
+........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1246,9 +1338,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
+                &"\
+''
 
-''",
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1264,9 +1358,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
+                &"\
+''....
 
-''",
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1282,64 +1378,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
+                &"\
+''....a
 
-''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-                a
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: true,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''
-    
-''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: true,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    
-    
-''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-            ''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: true,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    a
-    
-''",
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1356,9 +1399,72 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    a
-''",
+                &"\
+''
+....
+''"
+                .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....
+....
+''"
+                .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....a
+....
+''"
+                .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                a
+
+            ''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''
+....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1374,9 +1480,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
-    a
-''",
+                &"\
+''....
+....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1392,9 +1500,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
-    a
-''",
+                &"\
+''........a
+....a
+''"
+                .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1411,9 +1521,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
+                &"\
+''
 
-    ''",
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1429,9 +1541,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
+                &"\
+''....
 
-    ''",
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1447,9 +1561,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
+                &"\
+''....a
 
-    ''",
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1466,9 +1582,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    
-    ''",
+                &"\
+''
+....
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1484,9 +1602,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
-    
-    ''",
+                &"\
+''....
+....
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1502,9 +1622,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    a
-    
-    ''",
+                &"\
+''....a
+....
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1521,9 +1643,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-    a
-    ''",
+                &"\
+''
+....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1539,9 +1663,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
-    a
-    ''",
+                &"\
+''....
+....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1557,9 +1683,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
-    a
-    ''",
+                &"\
+''........a
+....a
+....''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1576,9 +1704,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
+                &"\
+''
 
-    a''",
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1594,9 +1724,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
+                &"\
+''....
 
-    a''",
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1612,64 +1744,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''        a
+                &"\
+''........a
 
-    a''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-                    a
-
-                a''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: true,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''
-    
-    a''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-                a''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: true,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''    
-    
-    a''",
-                3,
-                "    ",
-            )
-            .unwrap(),
-            "''
-
-                a''",
-        );
-        assert_eq!(
-            render_enforced_indentation(
-                &EnforceIndentation {
-                    last_line_break_significant: true,
-                    start: "''".to_owned(),
-                    end: "''".to_owned(),
-                },
-                "''        a
-    
-    a''",
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1686,9 +1765,72 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-        a
-    a''",
+                &"\
+''
+....
+....a''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''....
+....
+....a''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''........a
+....
+....a''"
+                    .replace('.', " "),
+                3,
+                "    ",
+            )
+            .unwrap(),
+            "''
+                    a
+
+                a''",
+        );
+        assert_eq!(
+            render_enforced_indentation(
+                &EnforceIndentation {
+                    last_line_break_significant: true,
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                },
+                &"\
+''
+........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1704,9 +1846,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''    
-        a
-    a''",
+                &"\
+''....
+........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1722,9 +1866,11 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''            a
-        a
-    a''",
+                &"\
+''............a
+........a
+....a''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1745,10 +1891,12 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-                    a
-                     
-                ''",
+                &"\
+''
+....................a
+.....................
+................''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )
@@ -1769,10 +1917,12 @@ mod tests {
                     start: "''".to_owned(),
                     end: "''".to_owned(),
                 },
-                "''
-                    a
-                     
-                ''",
+                &"\
+''
+....................a
+.....................
+................''"
+                    .replace('.', " "),
                 3,
                 "    ",
             )

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -89,9 +89,9 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                             1.. => add_spaces_after_newlines(content, indenting),
                         }
                     }
-                    MultiLineIndent::EnforceIndentation(absolute_indentation) => {
+                    MultiLineIndent::EnforceIndentation(enforce_indentation) => {
                         render_enforced_indentation(
-                            absolute_indentation,
+                            enforce_indentation,
                             content,
                             indent_level,
                             indent,
@@ -173,13 +173,13 @@ fn try_removing_spaces_after_newlines(s: &str, n: i32) -> String {
 
 /// formats multi line source code constructs like multi line strings.
 ///
-/// `absolute_indentation` contains configuration. at this stage we assume that it is a `ClosingColumnInsignificant` constructor.
+/// `enforce_indentation` contains configuration.
 /// `content_original` is the multi line string including the delimiters.
 /// `indent_level` is the current indentation level of the line containing the start delimiter.
 /// `indent` is the white space prefix of a line at indentation level 1.
 /// the returned `String` differs only in white space from `content_original`.
 fn render_enforced_indentation(
-    absolute_indentation: &EnforceIndentation,
+    enforce_indentation: &EnforceIndentation,
     content_original: &str,
     indent_level: usize,
     indent: &str,
@@ -189,7 +189,7 @@ fn render_enforced_indentation(
         last_line_break_significant,
         start,
         end,
-    } = absolute_indentation;
+    } = enforce_indentation;
 
     let content: Vec<&str> = content_original
         .strip_prefix(start)

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -204,7 +204,7 @@ fn render_enforced_indentation(
             ))
         })?
         .split("\n")
-        .map(|s| s.strip_suffix("\r").unwrap_or(s)) // to do. remove this?
+        .map(|s| s.strip_suffix("\r").unwrap_or(s))
         .collect(); // because we need `DoubleEndedIterator::next_back`.
 
     if content.len() == 1 {

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -84,9 +84,9 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
 
                         // The following assumes spaces are used for indenting
                         match indenting {
+                            ..0 => try_removing_spaces_after_newlines(content, -indenting),
                             0 => content.into(),
-                            n if n > 0 => add_spaces_after_newlines(content, indenting),
-                            _ => try_removing_spaces_after_newlines(content, -indenting),
+                            1.. => add_spaces_after_newlines(content, indenting),
                         }
                     }
                     MultiLineIndent::EnforceIndentation(absolute_indentation) => {

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -2,11 +2,14 @@
 //! module is responsible for rendering the slice of Atoms back into a displayable
 //! format.
 
-use std::fmt::Write;
+use std::{cmp::Ordering, fmt::Write};
 
 use rootcause::prelude::ResultExt;
 
-use crate::{Atom, Capitalisation, FormatterError, FormatterResult};
+use crate::{
+    Atom, Capitalisation, FormatterError, FormatterResult, MultiLineIndent, multi_line_indent,
+    tree_sitter::Position,
+};
 
 /// Renders a slice of [`Atom`]s into formatted source code.
 ///
@@ -53,7 +56,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                 content,
                 original_position,
                 single_line_no_indent,
-                multi_line_indent_all,
+                multi_line_indent,
                 keep_whitespace,
                 capitalisation,
                 ..
@@ -69,22 +72,32 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                     content.trim_end_matches('\n')
                 };
 
-                let mut content = if *multi_line_indent_all {
-                    let cursor = current_column(&buffer) as i32;
+                let mut content = match multi_line_indent {
+                    MultiLineIndent::None => content.into(),
+                    MultiLineIndent::MaintainOffset => {
+                        let cursor = current_column(&buffer) as i32;
 
-                    // original_position is 1-based
-                    let original_column = original_position.column as i32 - 1;
+                        // original_position is 1-based
+                        let original_column = original_position.column as i32 - 1;
 
-                    let indenting = cursor - original_column;
+                        let indenting = cursor - original_column;
 
-                    // The following assumes spaces are used for indenting
-                    match indenting {
-                        0 => content.into(),
-                        n if n > 0 => add_spaces_after_newlines(content, indenting),
-                        _ => try_removing_spaces_after_newlines(content, -indenting),
+                        // The following assumes spaces are used for indenting
+                        match indenting {
+                            ..0 => try_removing_spaces_after_newlines(content, -indenting),
+                            0 => content.into(),
+                            1.. => add_spaces_after_newlines(content, indenting),
+                        }
                     }
-                } else {
-                    content.into()
+                    MultiLineIndent::EnforceIndentation(enforce_indentation) => {
+                        render_multi_line_string(
+                            enforce_indentation,
+                            content,
+                            indent_level,
+                            indent,
+                            original_position,
+                        )
+                    }
                 };
                 match capitalisation {
                     Capitalisation::UpperCase => {
@@ -156,4 +169,1300 @@ fn try_removing_spaces_after_newlines(s: &str, n: i32) -> String {
     }
 
     result
+}
+
+/// formats multi line strings.
+///
+/// `enforce_indentation` contains configuration.
+/// `content_original` is the multi line string excluding the delimiters.
+/// `indent_level` is the current indentation level of the line containing the start delimiter.
+/// `indent` is the white space prefix of a line at indentation level 1.
+/// the returned `String` differs only in white space from `content_original`
+/// and the returned `String` does include delimiters again.
+fn render_multi_line_string(
+    enforce_indentation: &multi_line_indent::EnforceIndentation,
+    content_original: &str,
+    indent_level: usize,
+    indent: &str,
+    start_position: &Position,
+) -> String {
+    let multi_line_indent::EnforceIndentation {
+        start,
+        end,
+        last_line_break_significant,
+        carriage_return_significant,
+        tab_significant,
+    } = enforce_indentation;
+
+    let is_insignificant_whitespace = if *tab_significant {
+        |c| c == ' '
+    } else {
+        |c| c == ' ' || c == '\t'
+    };
+
+    // split lines, and normalize line endings
+    let content: Vec<&str> = if *carriage_return_significant {
+        content_original.split("\n").collect() // because we need `DoubleEndedIterator::next_back`.
+    } else {
+        content_original
+            .split("\n")
+            .map(|s| s.strip_suffix("\r").unwrap_or(s))
+            .collect()
+    };
+
+    // early exit with the original content for degenerate multi line string
+    if content.len() == 1 {
+        return format!("{start}{content_original}{end}");
+    }
+
+    let mut content = content.iter().copied();
+    let mut buffer = String::new();
+    write!(buffer, "{start}").expect("`fmt::Write`ing to a `String` should never fail.");
+
+    // early exit on carriage returns
+    if *carriage_return_significant
+        && content
+            .clone()
+            .next()
+            .expect("`split` should not produce empty iterators.")
+            .ends_with('\r')
+    {
+        // we cannot introduce `\r\n` line breaks because `\r`s are significant.
+        // we do not want to introduce `\n` line breaks because we do not want to introduce inconsistent line endings.
+        // so we have to short circuit the rest of the algorithm because it might add line breaks.
+        // we might implement some reduced formatting that does not add line breaks in the future if that is considered worth it.
+        log::warn!(
+            "not formatting the multi line string starting with {:?} at {} \
+                because carriage returns become part of the string's value according to the query \
+                and the line of the string's start delimiter ends with a carriage return.",
+            content_original.chars().take(16).collect::<String>(),
+            start_position,
+        );
+        return format!("{start}{content_original}{end}");
+    }
+
+    // skip potential empty first line
+    if content
+        .clone()
+        .next()
+        .expect("`split` should not produce empty iterators.")
+        .chars()
+        .all(is_insignificant_whitespace)
+    {
+        content
+            .next()
+            .expect("`split` should not produce empty iterators.");
+    }
+
+    // skip potential empty last line
+    let last_line_is_whitespace = content
+        .clone()
+        .next_back()
+        .expect("`split` should not produce empty iterators and `content_collected.len() != 1`.")
+        .chars()
+        .all(is_insignificant_whitespace);
+    if last_line_is_whitespace {
+        content.next_back().expect(
+            "`split` should not produce empty iterators and `content_collected.len() != 1`.",
+        );
+    }
+
+    // early exit with empty string for delimiters on successive lines and whitespace characters only
+    if content.clone().next().is_none() {
+        return format!("{start}{end}");
+    }
+
+    // length of the longest prefix-comparable whitespace prefix both in characters and utf 8 bytes
+    let mut prefixcomparable_whitespace_prefix_len: usize = 0;
+    let mut prefixcomparable_whitespace_prefix_len_utf8 = 0;
+    let mut content_collected: Vec<_> = content.clone().map(str::chars).collect();
+    loop {
+        let mut nexts = content_collected.iter_mut().filter_map(Iterator::next);
+        if let Some(first) = nexts.next()
+            && is_insignificant_whitespace(first)
+            && nexts.all(|c| c == first)
+        {
+            prefixcomparable_whitespace_prefix_len += 1;
+            prefixcomparable_whitespace_prefix_len_utf8 += first.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    // very simple non exhaustive check for mixing of spaces and tabs
+    if log::log_enabled!(log::Level::Info) {
+        match content
+            .clone()
+            .filter(|s| !s.chars().all(is_insignificant_whitespace))
+            .map(str::chars)
+            .map(|s| s.take_while(|c| is_insignificant_whitespace(*c)))
+            .map(Iterator::count)
+            .min()
+            .map(|min_whitespace_prefix_len| {
+                prefixcomparable_whitespace_prefix_len.cmp(&min_whitespace_prefix_len)
+            }) {
+            None => (), // no lines other than whitespace lines
+            // do not change the log level without changing it in the if condition 6 lines above.
+            Some(Ordering::Less) => log::info!(
+                "the multi line string starting with {:?} at {} mixes different whitespace characters like spaces and tabs in its lines' whitespace prefixes. \
+                    is this supposed to be indentation? then you should not mix different whitespace characters.",
+                content_original.chars().take(16).collect::<String>(),
+                start_position,
+            ),
+            Some(Ordering::Equal) => (),
+            Some(Ordering::Greater) => panic!(
+                "the common whitespace prefix should be a substring of the shortest whitespace prefix."
+            ),
+        }
+    }
+
+    // strip insignificant prefixes
+    let content =
+        content.map(|line| &line[line.len().min(prefixcomparable_whitespace_prefix_len_utf8)..]);
+
+    // render output
+    for line in content {
+        if line.is_empty() {
+            writeln!(buffer).expect("`fmt::Write`ing to a `String` should never fail.");
+        } else {
+            write!(buffer, "\n{}{line}", indent.repeat(indent_level + 1))
+                .expect("`fmt::Write`ing to a `String` should never fail.");
+        }
+    }
+
+    // potentially introduce line break before end delimiter
+    #[allow(clippy::nonminimal_bool)]
+    if last_line_is_whitespace || (!last_line_is_whitespace && !last_line_break_significant) {
+        write!(buffer, "\n{}", indent.repeat(indent_level))
+            .expect("`fmt::Write`ing to a `String` should never fail.");
+    }
+
+    write!(buffer, "{end}").expect("`fmt::Write`ing to a `String` should never fail.");
+
+    buffer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn start_position() -> Position {
+        Position { row: 1, column: 1 }
+    }
+
+    #[test]
+    fn test_render_multi_line_string0() {
+        assert_eq!(
+            render_multi_line_string(
+                &multi_line_indent::EnforceIndentation {
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                    last_line_break_significant: false,
+                    carriage_return_significant: false,
+                    tab_significant: false,
+                },
+                "\
+''\t
+    a
+   b
+     c
+''"
+                .strip_prefix("''")
+                .unwrap()
+                .strip_suffix("''")
+                .unwrap(),
+                3,
+                "    ",
+                &start_position(),
+            ),
+            "''
+                 a
+                b
+                  c
+            ''",
+        );
+    }
+
+    #[test]
+    fn test_render_multi_line_string1() {
+        assert_eq!(
+            render_multi_line_string(
+                &multi_line_indent::EnforceIndentation {
+                    start: "''".to_owned(),
+                    end: "''".to_owned(),
+                    last_line_break_significant: false,
+                    carriage_return_significant: false,
+                    tab_significant: false,
+                },
+                "\
+''x
+    a
+   b
+     c
+''"
+                .strip_prefix("''")
+                .unwrap()
+                .strip_suffix("''")
+                .unwrap(),
+                3,
+                "    ",
+                &start_position(),
+            ),
+            "''
+                x
+                    a
+                   b
+                     c
+            ''"
+        );
+    }
+
+    #[test]
+    fn test_render_multi_line_string_preserve_whitespace() {
+        for ((last_line_break_significant, carriage_return_significant), tab_significant) in
+            cartesian_product(
+                cartesian_product([false, true], [false, true]),
+                [false, true],
+            )
+        {
+            assert_eq!(
+                render_multi_line_string(
+                    &multi_line_indent::EnforceIndentation {
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                        last_line_break_significant,
+                        carriage_return_significant,
+                        tab_significant,
+                    },
+                    &"''
+........................a
+.........................
+....................''"
+                        .strip_prefix("''")
+                        .unwrap()
+                        .strip_suffix("''")
+                        .unwrap()
+                        .replace('.', " "),
+                    4,
+                    "    ",
+                    &start_position(),
+                ),
+                "''
+....................a
+.....................
+                ''"
+                .replace('.', " "),
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_mixed_whitespace() {
+        for ((last_line_break_significant, carriage_return_significant), tab_significant) in
+            cartesian_product(
+                cartesian_product([false, true], [false, true]),
+                [false, true],
+            )
+        {
+            assert_eq!(
+                render_multi_line_string(
+                    &multi_line_indent::EnforceIndentation {
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                        last_line_break_significant,
+                        carriage_return_significant,
+                        tab_significant,
+                    },
+                    &"''
+.........................a
+........................\t
+                    ''"
+                    .strip_prefix("''")
+                    .unwrap()
+                    .strip_suffix("''")
+                    .unwrap()
+                    .replace('.', " "),
+                    4,
+                    "    ",
+                    &start_position(),
+                ),
+                "''
+.....................a
+....................\t
+                ''"
+                .replace('.', " "),
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_significant_whitespace() {
+        for ((last_line_break_significant, carriage_return_significant), tab_significant) in
+            cartesian_product(
+                cartesian_product([false, true], [false, true]),
+                [false, true],
+            )
+        {
+            assert_eq!(
+                render_multi_line_string(
+                    &multi_line_indent::EnforceIndentation {
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                        last_line_break_significant,
+                        carriage_return_significant,
+                        tab_significant,
+                    },
+                    &"\
+''
+\ra
+\ra
+''"
+                    .strip_prefix("''")
+                    .unwrap()
+                    .strip_suffix("''")
+                    .unwrap(),
+                    4,
+                    "    ",
+                    &start_position(),
+                ),
+                "''
+                    \ra
+                    \ra
+                ''",
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_carriage_return() {
+        for (input, output) in [
+            (
+                "''
+                        a\r
+                ''",
+                "''
+                    a\r
+                ''",
+            ),
+            (
+                "''\r
+                        a
+                ''",
+                "''\r
+                        a
+                ''",
+            ),
+        ] {
+            for (last_line_break_significant, tab_significant) in
+                cartesian_product([false, true], [false, true])
+            {
+                assert_eq!(
+                    render_multi_line_string(
+                        &multi_line_indent::EnforceIndentation {
+                            start: "''".to_owned(),
+                            end: "''".to_owned(),
+                            last_line_break_significant,
+                            carriage_return_significant: true,
+                            tab_significant,
+                        },
+                        input
+                            .strip_prefix("''")
+                            .unwrap()
+                            .strip_suffix("''")
+                            .unwrap(),
+                        4,
+                        "    ",
+                        &start_position(),
+                    ),
+                    output,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_tab() {
+        for (last_line_break_significant, carriage_return_significant) in
+            cartesian_product([false, true], [false, true])
+        {
+            assert_eq!(
+                render_multi_line_string(
+                    &multi_line_indent::EnforceIndentation {
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                        last_line_break_significant,
+                        carriage_return_significant,
+                        tab_significant: false,
+                    },
+                    "\
+''
+\ta
+\ta
+''"
+                    .strip_prefix("''")
+                    .unwrap()
+                    .strip_suffix("''")
+                    .unwrap(),
+                    4,
+                    "    ",
+                    &start_position(),
+                ),
+                "''
+                    a
+                    a
+                ''",
+            );
+            assert_eq!(
+                render_multi_line_string(
+                    &multi_line_indent::EnforceIndentation {
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                        last_line_break_significant,
+                        carriage_return_significant,
+                        tab_significant: true,
+                    },
+                    "\
+''
+\ta
+\ta
+''"
+                    .strip_prefix("''")
+                    .unwrap()
+                    .strip_suffix("''")
+                    .unwrap(),
+                    4,
+                    "    ",
+                    &start_position(),
+                ),
+                "''
+                    \ta
+                    \ta
+                ''",
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_1_line() {
+        for (((last_line_break_significant, carriage_return_significant), tab_significant), line) in
+            cartesian_product(
+                cartesian_product(
+                    cartesian_product([false, true], [false, true]),
+                    [false, true],
+                ),
+                ["''''", "'' ''", "'' a''"],
+            )
+        {
+            assert_eq!(
+                render_multi_line_string(
+                    &multi_line_indent::EnforceIndentation {
+                        start: "''".to_owned(),
+                        end: "''".to_owned(),
+                        last_line_break_significant,
+                        carriage_return_significant,
+                        tab_significant,
+                    },
+                    line.strip_prefix("''").unwrap().strip_suffix("''").unwrap(),
+                    3,
+                    "  ",
+                    &start_position(),
+                ),
+                line,
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_2_lines0() {
+        for (input, output) in [
+            (
+                "\
+''
+''", "''''",
+            ),
+            (
+                "\
+''.
+''", "''''",
+            ),
+            (
+                "\
+''....a
+''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+....''",
+                "''''",
+            ),
+            (
+                "\
+''.
+....''",
+                "''''",
+            ),
+            (
+                "\
+''....a
+....''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+....a''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''.
+....a''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''........a
+....a''",
+                "''
+                        a
+                    a
+                ''",
+            ),
+        ] {
+            for (carriage_return_significant, tab_significant) in
+                cartesian_product([false, true], [false, true])
+            {
+                assert_eq!(
+                    render_multi_line_string(
+                        &multi_line_indent::EnforceIndentation {
+                            start: "''".to_owned(),
+                            end: "''".to_owned(),
+                            last_line_break_significant: false,
+                            carriage_return_significant,
+                            tab_significant,
+                        },
+                        &input
+                            .strip_prefix("''")
+                            .unwrap()
+                            .strip_suffix("''")
+                            .unwrap()
+                            .replace('.', " "),
+                        4,
+                        "    ",
+                        &start_position(),
+                    ),
+                    output,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_2_lines1() {
+        for (input, output) in [
+            (
+                "\
+''
+''", "''''",
+            ),
+            (
+                "\
+''.
+''", "''''",
+            ),
+            (
+                "\
+''....a
+''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+....''",
+                "''''",
+            ),
+            (
+                "\
+''.
+....''",
+                "''''",
+            ),
+            (
+                "\
+''....a
+....''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+....a''",
+                "''
+                    a''",
+            ),
+            (
+                "\
+''.
+....a''",
+                "''
+                    a''",
+            ),
+            (
+                "\
+''........a
+....a''",
+                "''
+                        a
+                    a''",
+            ),
+        ] {
+            for (carriage_return_significant, tab_significant) in
+                cartesian_product([false, true], [false, true])
+            {
+                assert_eq!(
+                    render_multi_line_string(
+                        &multi_line_indent::EnforceIndentation {
+                            start: "''".to_owned(),
+                            end: "''".to_owned(),
+                            last_line_break_significant: true,
+                            carriage_return_significant,
+                            tab_significant,
+                        },
+                        &input
+                            .strip_prefix("''")
+                            .unwrap()
+                            .strip_suffix("''")
+                            .unwrap()
+                            .replace('.', " "),
+                        4,
+                        "    ",
+                        &start_position(),
+                    ),
+                    output,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_3_lines0() {
+        for (input, output) in [
+            (
+                "\
+''
+
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+
+''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+....
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+....
+''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....a
+''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''....
+....a
+''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''........a
+....a
+''",
+                "''
+                        a
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+
+....''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+....
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+....
+....''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....a
+....''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''....
+....a
+....''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''........a
+....a
+....''",
+                "''
+                        a
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+
+....a''",
+                "''
+
+                    a
+                ''",
+            ),
+            (
+                "\
+''....
+
+....a''",
+                "''
+
+                    a
+                ''",
+            ),
+            (
+                "\
+''........a
+
+....a''",
+                "''
+                        a
+
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+....
+....a''",
+                "''
+
+                    a
+                ''",
+            ),
+            (
+                "\
+''....
+....
+....a''",
+                "''
+
+                    a
+                ''",
+            ),
+            (
+                "\
+''........a
+....
+....a''",
+                "''
+                        a
+
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+........a
+....a''",
+                "''
+                        a
+                    a
+                ''",
+            ),
+            (
+                "\
+''....
+........a
+....a''",
+                "''
+                        a
+                    a
+                ''",
+            ),
+            (
+                "\
+''............a
+........a
+....a''",
+                "''
+                            a
+                        a
+                    a
+                ''",
+            ),
+        ] {
+            for (carriage_return_significant, tab_significant) in
+                cartesian_product([false, true], [false, true])
+            {
+                assert_eq!(
+                    render_multi_line_string(
+                        &multi_line_indent::EnforceIndentation {
+                            start: "''".to_owned(),
+                            end: "''".to_owned(),
+                            last_line_break_significant: false,
+                            carriage_return_significant,
+                            tab_significant,
+                        },
+                        &input
+                            .strip_prefix("''")
+                            .unwrap()
+                            .strip_suffix("''")
+                            .unwrap()
+                            .replace('.', " "),
+                        4,
+                        "    ",
+                        &start_position(),
+                    ),
+                    output,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_render_multi_line_string_3_lines1() {
+        for (input, output) in [
+            (
+                "\
+''
+
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+
+''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+....
+''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+....
+''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....a
+''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''....
+....a
+''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''........a
+....a
+''",
+                "''
+                        a
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+
+....''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....
+....
+....''",
+                "''
+
+                ''",
+            ),
+            (
+                "\
+''....a
+....
+....''",
+                "''
+                    a
+
+                ''",
+            ),
+            (
+                "\
+''
+....a
+....''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''....
+....a
+....''",
+                "''
+                    a
+                ''",
+            ),
+            (
+                "\
+''........a
+....a
+....''",
+                "''
+                        a
+                    a
+                ''",
+            ),
+            (
+                "\
+''
+
+....a''",
+                "''
+
+                    a''",
+            ),
+            (
+                "\
+''....
+
+....a''",
+                "''
+
+                    a''",
+            ),
+            (
+                "\
+''........a
+
+....a''",
+                "''
+                        a
+
+                    a''",
+            ),
+            (
+                "\
+''
+....
+....a''",
+                "''
+
+                    a''",
+            ),
+            (
+                "\
+''....
+....
+....a''",
+                "''
+
+                    a''",
+            ),
+            (
+                "\
+''........a
+....
+....a''",
+                "''
+                        a
+
+                    a''",
+            ),
+            (
+                "\
+''
+........a
+....a''",
+                "''
+                        a
+                    a''",
+            ),
+            (
+                "\
+''....
+........a
+....a''",
+                "''
+                        a
+                    a''",
+            ),
+            (
+                "\
+''............a
+........a
+....a''",
+                "''
+                            a
+                        a
+                    a''",
+            ),
+        ] {
+            for (carriage_return_significant, tab_significant) in
+                cartesian_product([false, true], [false, true])
+            {
+                assert_eq!(
+                    render_multi_line_string(
+                        &multi_line_indent::EnforceIndentation {
+                            start: "''".to_owned(),
+                            end: "''".to_owned(),
+                            last_line_break_significant: true,
+                            carriage_return_significant,
+                            tab_significant,
+                        },
+                        &input
+                            .strip_prefix("''")
+                            .unwrap()
+                            .strip_suffix("''")
+                            .unwrap()
+                            .replace('.', " "),
+                        4,
+                        "    ",
+                        &start_position(),
+                    ),
+                    output,
+                );
+            }
+        }
+    }
+
+    fn cartesian_product<AS, BS>(
+        list_a: AS,
+        list_b: BS,
+    ) -> impl Iterator<
+        Item = (
+            <AS::IntoIter as Iterator>::Item,
+            <BS::IntoIter as Iterator>::Item,
+        ),
+    >
+    where
+        AS: IntoIterator,
+        BS: IntoIterator,
+        BS::IntoIter: Clone,
+        <AS::IntoIter as Iterator>::Item: Clone,
+    {
+        cartesian_product_internal(list_a.into_iter(), list_b.into_iter())
+    }
+
+    fn cartesian_product_internal<AS, BS>(
+        list_a: AS,
+        list_b: BS,
+    ) -> impl Iterator<Item = (AS::Item, BS::Item)>
+    where
+        AS: Iterator,
+        BS: Iterator + Clone,
+        AS::Item: Clone,
+    {
+        list_a.flat_map(move |a| list_b.clone().map(move |b| (a.clone(), b)))
+    }
 }

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -195,15 +195,17 @@ fn render_enforced_indentation(
         .strip_prefix(start)
         .ok_or_else(|| {
             FormatterError::Query(format!(
-                "the multi line leaf starting with {:?} should start with {start:?} as marked by the query",
-                &content_original[..content_original.len().min(16)]
+                "the multi line leaf starting with {:?} at {} should start with {start:?} as marked by the query.",
+                &content_original[..content_original.len().min(16)],
+                start_position,
             ))
         })?
         .strip_suffix(end)
         .ok_or_else(|| {
             FormatterError::Query(format!(
-                "the multi line leaf ending with {:?} should end with {end:?} as marked by the query",
-                &content_original[content_original.len().saturating_sub(16)..]
+                "the multi line leaf ending with {:?} at {} should end with {end:?} as marked by the query.",
+                &content_original[content_original.len().saturating_sub(16)..],
+                start_position,
             ))
         })?
         .split("\n")
@@ -278,9 +280,10 @@ fn render_enforced_indentation(
             None => (), // no lines other than whitespace lines
             // do not change the log level without changing it in the if condition 6 lines above.
             Some(Ordering::Less) => log::info!(
-                "the multi line string starting at {} mixes different whitespace characters like spaces and tabs in its lines' whitespace prefixes. \
+                "the multi line leaf starting with {:?} at {} mixes different whitespace characters like spaces and tabs in its lines' whitespace prefixes. \
                     is this supposed to be indentation? then you should not mix different whitespace characters.",
-                start_position
+                &content_original[..content_original.len().min(16)],
+                start_position,
             ),
             Some(Ordering::Equal) => (),
             Some(Ordering::Greater) => panic!(

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -7,7 +7,7 @@ use std::{cmp::Ordering, fmt::Write};
 use rootcause::prelude::ResultExt;
 
 use crate::{
-    Atom, Capitalisation, EnforceIndentation, FormatterError, FormatterResult, MultiLineIndent,
+    Atom, Capitalisation, FormatterError, FormatterResult, MultiLineIndent, multi_line_indent,
     tree_sitter::Position,
 };
 
@@ -179,13 +179,13 @@ fn try_removing_spaces_after_newlines(s: &str, n: i32) -> String {
 /// `indent` is the white space prefix of a line at indentation level 1.
 /// the returned `String` differs only in white space from `content_original`.
 fn render_enforced_indentation(
-    enforce_indentation: &EnforceIndentation,
+    enforce_indentation: &multi_line_indent::EnforceIndentation,
     content_original: &str,
     indent_level: usize,
     indent: &str,
     start_position: &Position,
 ) -> FormatterResult<String> {
-    let EnforceIndentation {
+    let multi_line_indent::EnforceIndentation {
         last_line_break_significant,
         start,
         end,
@@ -321,7 +321,7 @@ mod tests {
     fn test_render_enforced_indentation0() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -349,7 +349,7 @@ mod tests {
     fn test_render_enforced_indentation1() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -379,7 +379,7 @@ mod tests {
         for line in ["''''", "'' ''", "'' a''"] {
             assert_eq!(
                 render_enforced_indentation(
-                    &EnforceIndentation {
+                    &multi_line_indent::EnforceIndentation {
                         last_line_break_significant: false,
                         start: "''".to_owned(),
                         end: "''".to_owned(),
@@ -400,7 +400,7 @@ mod tests {
         for line in ["''''", "'' ''", "'' a''"] {
             assert_eq!(
                 render_enforced_indentation(
-                    &EnforceIndentation {
+                    &multi_line_indent::EnforceIndentation {
                         last_line_break_significant: true,
                         start: "''".to_owned(),
                         end: "''".to_owned(),
@@ -420,7 +420,7 @@ mod tests {
     fn test_render_enforced_indentation_2_lines0() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -438,7 +438,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -456,7 +456,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -476,7 +476,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -494,7 +494,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -512,7 +512,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -532,7 +532,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -552,7 +552,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -572,7 +572,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -597,7 +597,7 @@ mod tests {
     fn test_render_enforced_indentation_2_lines1() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -615,7 +615,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -633,7 +633,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -653,7 +653,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -671,7 +671,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -689,7 +689,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -709,7 +709,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -728,7 +728,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -747,7 +747,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -771,7 +771,7 @@ mod tests {
     fn test_render_enforced_indentation_3_lines0() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -792,7 +792,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -813,7 +813,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -835,7 +835,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -856,7 +856,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -877,7 +877,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -899,7 +899,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -920,7 +920,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -941,7 +941,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -963,7 +963,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -984,7 +984,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1005,7 +1005,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1027,7 +1027,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1048,7 +1048,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1069,7 +1069,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1091,7 +1091,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1112,7 +1112,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1133,7 +1133,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1155,7 +1155,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1177,7 +1177,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1199,7 +1199,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1222,7 +1222,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1244,7 +1244,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1266,7 +1266,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1289,7 +1289,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1311,7 +1311,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1333,7 +1333,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1360,7 +1360,7 @@ mod tests {
     fn test_render_enforced_indentation_3_lines1() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1381,7 +1381,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1402,7 +1402,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1424,7 +1424,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1445,7 +1445,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1466,7 +1466,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1488,7 +1488,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1509,7 +1509,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1530,7 +1530,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1552,7 +1552,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1573,7 +1573,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1594,7 +1594,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1616,7 +1616,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1637,7 +1637,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1658,7 +1658,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1680,7 +1680,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1701,7 +1701,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1722,7 +1722,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1744,7 +1744,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1765,7 +1765,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1786,7 +1786,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1808,7 +1808,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1829,7 +1829,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1850,7 +1850,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1872,7 +1872,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1893,7 +1893,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1914,7 +1914,7 @@ mod tests {
         );
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1940,7 +1940,7 @@ mod tests {
     fn test_render_enforced_indentation_significant_whitespace0() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1967,7 +1967,7 @@ mod tests {
     fn test_render_enforced_indentation_significant_whitespace1() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -1994,7 +1994,7 @@ mod tests {
     fn test_render_enforced_indentation_mixed_whitespace0() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: false,
                     start: "''".to_owned(),
                     end: "''".to_owned(),
@@ -2019,7 +2019,7 @@ mod tests {
     fn test_render_enforced_indentation_mixed_whitespace1() {
         assert_eq!(
             render_enforced_indentation(
-                &EnforceIndentation {
+                &multi_line_indent::EnforceIndentation {
                     last_line_break_significant: true,
                     start: "''".to_owned(),
                     end: "''".to_owned(),

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -56,7 +56,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                 content,
                 original_position,
                 single_line_no_indent,
-                multi_line_indent_all,
+                multi_line_indent,
                 keep_whitespace,
                 capitalisation,
                 ..
@@ -72,7 +72,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                     content.trim_end_matches('\n')
                 };
 
-                let mut content = match multi_line_indent_all {
+                let mut content = match multi_line_indent {
                     MultiLineIndent::None => content.into(),
                     MultiLineIndent::MaintainOffset => {
                         let cursor = current_column(&buffer) as i32;

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -2,7 +2,7 @@
 // streaming_iterator::StreamingIterator
 #![cfg_attr(target_arch = "wasm32", allow(unused_imports))]
 
-use std::{collections::HashSet, fmt::Display};
+use std::{collections::HashSet, fmt::Display, ops::Deref as _};
 
 use miette::{LabeledSpan, Severity, SourceSpan};
 use rootcause::{prelude::ResultExt, report};
@@ -189,7 +189,7 @@ pub fn collect_injections<'a>(
     while let Some(query_match) = matches.next() {
         let content_captures = query_match
             .captures()
-            .filter(|c| c.name(capture_names.as_slice()) == "injection.content")
+            .filter(|c| c.name(&capture_names) == "injection.content")
             .collect::<Vec<_>>();
 
         if content_captures.is_empty() {
@@ -215,7 +215,7 @@ pub fn collect_injections<'a>(
             .or_else(|| {
                 query_match
                     .captures()
-                    .find(|c| c.name(capture_names.as_slice()) == "injection.language")
+                    .find(|c| c.name(&capture_names) == "injection.language")
                     .and_then(|c| c.node().utf8_text(source).ok())
                     .map(|s| s.to_string())
             });
@@ -503,8 +503,17 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
 
     // Find the ids of all tree-sitter nodes that were identified as a leaf
     // We want to avoid recursing into them in the collect_leaves function.
-    let mut specified_leaf_nodes: HashSet<usize> =
-        collect_leaf_ids(&matches, capture_names.clone());
+    let mut specified_leaf_nodes: HashSet<usize> = collect_leaf_ids(&matches, &capture_names);
+    // add the ids of all tree-sitter nodes that were identified as a multi line string.
+    // we want to treat them as a leaf too.
+    specified_leaf_nodes.extend(
+        matches
+            .iter()
+            .flat_map(|m| &m.captures)
+            .filter(|c| c.name(&capture_names) == "multi_line_string")
+            .map(|c| c.node().id()),
+    );
+    // add the ids of all tree-sitter nodes that the call site wants us to treat as a leaf.
     specified_leaf_nodes.extend(forced_leaf_nodes);
 
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
@@ -518,7 +527,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
     // The web bindings for tree-sitter do not have support for pattern_count, so instead we will resize as needed
     // Only reallocate if we are actually going to use the vec
     #[cfg(not(target_arch = "wasm32"))]
-    if log::log_enabled!(log::Level::Info) {
+    if log::log_enabled!(log::Level::Debug) {
         pattern_positions.resize(query.query.pattern_count(), None);
     }
 
@@ -530,16 +539,42 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
     // )
     // means we want to append a hardline at
     // the end, but we don't know if we get a line_comment capture or not.
-    for m in matches {
+    for mut m in matches {
         let mut predicates = QueryPredicates::default();
 
         for p in query.query.general_predicates(m.pattern_index) {
             predicates = handle_predicate(&p, &predicates)?;
         }
+        let get_single_capture_content = |name| {
+            match m
+                .captures
+                .iter()
+                .filter(|c| c.name(&capture_names) == name)
+                .take(2)
+                .collect::<Vec<_>>()
+                .as_slice()
+            {
+                [] => Ok(None),
+                [capture] => Ok(Some(
+                    input_content
+                        .get(capture.node().byte_range())
+                        .expect("`tree-sitter::Node::{start_byte, end_byte}` should always return a valid string slice indexes range.")
+                        .to_owned(),
+                )),
+                _ => Err(FormatterError::Query(format!(
+                    "the query{} at location {} should match the @{name} capture once only \
+                    in order to associate @multi_line_string captures with well defined delimiter information.",
+                    if let Some(n) = &predicates.query_name {format!(" {n}")} else {"".to_owned()},
+                    query.pattern_position(m.pattern_index),
+                ))),
+            }
+        };
+        predicates.multi_line_string_start = get_single_capture_content("multi_line_string.start")?;
+        predicates.multi_line_string_end = get_single_capture_content("multi_line_string.end")?;
         check_predicates(&predicates)?;
 
         // NOTE: Only performed if logging is enabled to avoid unnecessary computation of Position
-        if log::log_enabled!(log::Level::Info) {
+        if log::log_enabled!(log::Level::Debug) {
             #[cfg(target_arch = "wasm32")]
             // Resize the pattern_positions vector if we need to store more positions
             if m.pattern_index >= pattern_positions.len() {
@@ -559,19 +594,27 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
                 "".into()
             };
 
+            // do not change the log level without changing it in the 2 if conditions above.
             log::debug!("Processing match{query_name_info}: {m} at location {pos}");
         }
+
+        m.captures.retain(|c| {
+            !matches!(
+                c.name(&capture_names).deref(),
+                "multi_line_string.start" | "multi_line_string.end"
+            )
+        });
 
         // If any capture is a do_nothing, then do nothing.
         if m.captures
             .iter()
-            .any(|c| c.name(capture_names.as_slice()) == "do_nothing")
+            .any(|c| c.name(&capture_names) == "do_nothing")
         {
             continue;
         }
 
         for c in m.captures {
-            let name = c.name(capture_names.as_slice());
+            let name = c.name(&capture_names);
             atoms.resolve_capture(&name, &c.node(), &predicates)?;
         }
     }
@@ -605,11 +648,10 @@ pub fn parse(
         .context_to()
         .attach("Could not apply Tree-sitter grammar")?;
 
-    let tree = parser.parse(content, None).context_to()?.ok_or_else(|| {
-        report!(FormatterError::Internal(
-            "Could not parse input".to_string()
-        ))
-    })?;
+    let tree = parser
+        .parse(content, None)
+        .context_to()?
+        .ok_or_else(|| FormatterError::Internal("Could not parse input".to_string()))?;
 
     // Fail parsing if we don't get a complete syntax tree.
     if !tolerate_parsing_errors {
@@ -638,12 +680,12 @@ fn check_for_error_nodes(node: &Node) -> FormatterResult<()> {
 ///
 /// This function takes a slice of `LocalQueryMatch` and a slice of capture names,
 /// and returns a `HashSet` of node IDs that are matched by the "leaf" capture name.
-fn collect_leaf_ids(matches: &[LocalQueryMatch], capture_names: Vec<&str>) -> HashSet<usize> {
+fn collect_leaf_ids(matches: &[LocalQueryMatch], capture_names: &[&str]) -> HashSet<usize> {
     let mut ids = HashSet::new();
 
     for m in matches {
         for c in &m.captures {
-            if c.name(capture_names.as_slice()) == "leaf" {
+            if c.name(capture_names) == "leaf" {
                 ids.insert(c.node().id());
             }
         }
@@ -701,6 +743,18 @@ fn handle_predicate(
         }),
         "multi_line_only!" => Ok(QueryPredicates {
             multi_line_only: true,
+            ..predicates.clone()
+        }),
+        "multi_line_string.last_insignificant!" => Ok(QueryPredicates {
+            multi_line_string_last_insignificant: true,
+            ..predicates.clone()
+        }),
+        "multi_line_string.carriage_return_significant!" => Ok(QueryPredicates {
+            multi_line_string_cr_significant: true,
+            ..predicates.clone()
+        }),
+        "multi_line_string.tab_significant!" => Ok(QueryPredicates {
+            multi_line_string_tab_significant: true,
             ..predicates.clone()
         }),
         _ => Err(FormatterError::Query(format!(

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -545,16 +545,16 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
                 .expect("`tree-sitter::Node::{start_byte, end_byte}` should always return a valid string slice indexes range.")
                 .to_owned()
         };
-        predicates.multi_line_string_delimiters = Option::zip(
-            m.captures
-                .iter()
-                .rfind(|c| c.name(&capture_names).deref() == "multi_line_string.start")
-                .map(capture_content),
-            m.captures
-                .iter()
-                .rfind(|c| c.name(&capture_names).deref() == "multi_line_string.end")
-                .map(capture_content),
-        );
+        predicates.multi_line_string_start = m
+            .captures
+            .iter()
+            .rfind(|c| c.name(&capture_names).deref() == "multi_line_string.start")
+            .map(capture_content);
+        predicates.multi_line_string_end = m
+            .captures
+            .iter()
+            .rfind(|c| c.name(&capture_names).deref() == "multi_line_string.end")
+            .map(capture_content);
         check_predicates(&predicates)?;
 
         // NOTE: Only performed if logging is enabled to avoid unnecessary computation of Position

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -2,7 +2,7 @@
 // streaming_iterator::StreamingIterator
 #![cfg_attr(target_arch = "wasm32", allow(unused_imports))]
 
-use std::{collections::HashSet, fmt::Display};
+use std::{collections::HashSet, fmt::Display, ops::Deref as _};
 
 use miette::{LabeledSpan, Severity, SourceSpan};
 use rootcause::{prelude::ResultExt, report};
@@ -185,7 +185,7 @@ pub fn collect_injections<'a>(
     while let Some(query_match) = matches.next() {
         let content_captures = query_match
             .captures()
-            .filter(|c| c.name(capture_names.as_slice()) == "injection.content")
+            .filter(|c| c.name(&capture_names) == "injection.content")
             .collect::<Vec<_>>();
 
         if content_captures.is_empty() {
@@ -211,7 +211,7 @@ pub fn collect_injections<'a>(
             .or_else(|| {
                 query_match
                     .captures()
-                    .find(|c| c.name(capture_names.as_slice()) == "injection.language")
+                    .find(|c| c.name(&capture_names) == "injection.language")
                     .and_then(|c| c.node().utf8_text(source).ok())
                     .map(|s| s.to_string())
             });
@@ -497,8 +497,17 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
 
     // Find the ids of all tree-sitter nodes that were identified as a leaf
     // We want to avoid recursing into them in the collect_leaves function.
-    let mut specified_leaf_nodes: HashSet<usize> =
-        collect_leaf_ids(&matches, capture_names.clone());
+    let mut specified_leaf_nodes: HashSet<usize> = collect_leaf_ids(&matches, &capture_names);
+    // add the ids of all tree-sitter nodes that were identified as a multi line string.
+    // we want to treat them as a leaf too.
+    specified_leaf_nodes.extend(
+        matches
+            .iter()
+            .flat_map(|m| &m.captures)
+            .filter(|c| c.name(&capture_names) == "multi_line_string")
+            .map(|c| c.node().id()),
+    );
+    // add the ids of all tree-sitter nodes that the call site wants us to treat as a leaf.
     specified_leaf_nodes.extend(forced_leaf_nodes);
 
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
@@ -524,12 +533,28 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
     // )
     // means we want to append a hardline at
     // the end, but we don't know if we get a line_comment capture or not.
-    for m in matches {
+    for mut m in matches {
         let mut predicates = QueryPredicates::default();
 
         for p in query.query.general_predicates(m.pattern_index) {
             predicates = handle_predicate(&p, &predicates)?;
         }
+        let capture_content = |capture: &QueryCapture<'_>| {
+            input_content
+                .get(capture.node().byte_range())
+                .expect("`tree-sitter::Node::{start_byte, end_byte}` should always return a valid string slice indexes range.")
+                .to_owned()
+        };
+        predicates.multi_line_string_delimiters = Option::zip(
+            m.captures
+                .iter()
+                .rfind(|c| c.name(&capture_names).deref() == "multi_line_string.start")
+                .map(capture_content),
+            m.captures
+                .iter()
+                .rfind(|c| c.name(&capture_names).deref() == "multi_line_string.end")
+                .map(capture_content),
+        );
         check_predicates(&predicates)?;
 
         // NOTE: Only performed if logging is enabled to avoid unnecessary computation of Position
@@ -556,16 +581,23 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
             log::debug!("Processing match{query_name_info}: {m} at location {pos}");
         }
 
+        m.captures.retain(|c| {
+            !matches!(
+                c.name(&capture_names).deref(),
+                "multi_line_string.start" | "multi_line_string.end"
+            )
+        });
+
         // If any capture is a do_nothing, then do nothing.
         if m.captures
             .iter()
-            .any(|c| c.name(capture_names.as_slice()) == "do_nothing")
+            .any(|c| c.name(&capture_names) == "do_nothing")
         {
             continue;
         }
 
         for c in m.captures {
-            let name = c.name(capture_names.as_slice());
+            let name = c.name(&capture_names);
             atoms.resolve_capture(&name, &c.node(), &predicates)?;
         }
     }
@@ -632,12 +664,12 @@ fn check_for_error_nodes(node: &Node) -> FormatterResult<()> {
 ///
 /// This function takes a slice of `LocalQueryMatch` and a slice of capture names,
 /// and returns a `HashSet` of node IDs that are matched by the "leaf" capture name.
-fn collect_leaf_ids(matches: &[LocalQueryMatch], capture_names: Vec<&str>) -> HashSet<usize> {
+fn collect_leaf_ids(matches: &[LocalQueryMatch], capture_names: &[&str]) -> HashSet<usize> {
     let mut ids = HashSet::new();
 
     for m in matches {
         for c in &m.captures {
-            if c.name(capture_names.as_slice()) == "leaf" {
+            if c.name(capture_names) == "leaf" {
                 ids.insert(c.node().id());
             }
         }
@@ -695,6 +727,10 @@ fn handle_predicate(
         }),
         "multi_line_only!" => Ok(QueryPredicates {
             multi_line_only: true,
+            ..predicates.clone()
+        }),
+        "multi_line_string.last_insignificant!" => Ok(QueryPredicates {
+            multi_line_string_last_insignificant: true,
             ..predicates.clone()
         }),
         _ => Err(FormatterError::Query(format!(

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -521,7 +521,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
     // The web bindings for tree-sitter do not have support for pattern_count, so instead we will resize as needed
     // Only reallocate if we are actually going to use the vec
     #[cfg(not(target_arch = "wasm32"))]
-    if log::log_enabled!(log::Level::Info) {
+    if log::log_enabled!(log::Level::Debug) {
         pattern_positions.resize(query.query.pattern_count(), None);
     }
 
@@ -558,7 +558,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
         check_predicates(&predicates)?;
 
         // NOTE: Only performed if logging is enabled to avoid unnecessary computation of Position
-        if log::log_enabled!(log::Level::Info) {
+        if log::log_enabled!(log::Level::Debug) {
             #[cfg(target_arch = "wasm32")]
             // Resize the pattern_positions vector if we need to store more positions
             if m.pattern_index >= pattern_positions.len() {
@@ -578,6 +578,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
                 "".into()
             };
 
+            // do not change the log level without changing it in the 2 if conditions above.
             log::debug!("Processing match{query_name_info}: {m} at location {pos}");
         }
 

--- a/topiary-queries/queries/nickel/formatting.scm
+++ b/topiary-queries/queries/nickel/formatting.scm
@@ -4,10 +4,20 @@
 [
   (static_string)
   (str_chunks_single)
-  (str_chunks_multi)
   (builtin)
   (quoted_enum_tag)
 ] @leaf
+
+(static_string
+  (multstr_start) @multi_line_string.start
+  (multstr_end) @multi_line_string.end
+  (#multi_line_string.last_insignificant!)
+) @multi_line_string
+(str_chunks_multi
+  start: (multstr_start) @multi_line_string.start
+  end: (multstr_end) @multi_line_string.end
+  (#multi_line_string.last_insignificant!)
+) @multi_line_string
 
 ; Allow a blank line before the following nodes
 [


### PR DESCRIPTION
<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #654
Resolves #1224
Resolves #1225
References #1236 (*2nd strategy*)

## Description

- new directive `@mutli_line_string`
- use the new directive in `nickel/formatting.scm`

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [x] Updated regression tests
