### PR TITLE
chore: add verify-documented-usage to nix flake check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Build client-app example
         run: nix build .#client-app -L
 
-      - name: Verify that usage in README.md matches CLI output
-        run: nix run .#verify-documented-usage -L
-
       - name: Test against config regressions
         run: |
             nix run . -- config --merge --cfg ./topiary-config/tests/issue-1124.ncl

--- a/bin/verify-documented-usage.sh
+++ b/bin/verify-documented-usage.sh
@@ -9,10 +9,11 @@ readonly FENCE='```'
 get-cli-usage() {
   # Get the help text from the CLI
   local subcommand="$1"
+  local topiary="${TOPIARY_WRAPPED:-nix run .#topiary-wrapped --}"
 
   case "${subcommand}" in
-    "index") nix run .#topiary-wrapped -- --help;;
-    *)       nix run .#topiary-wrapped -- "${subcommand}" --help;;
+    "index") ${topiary} --help;;
+    *)       ${topiary} "${subcommand}" --help;;
   esac
 }
 

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -1,6 +1,9 @@
 {
+  runCommand,
+  lib,
   emptyFile,
   topiaryPkgs,
+  binPkgs,
   gitHook,
 }:
 
@@ -22,4 +25,17 @@ in
   # e2` evaluates `e1` strictly in depth before returning `e2`. We use this
   # trick because checks need to be derivations, which `lib.gitHook` is not.
   gitHook = deepSeq gitHook emptyFile;
+
+  verify-documented-usage =
+    runCommand "verify-documented-usage"
+      {
+        nativeBuildInputs = [ binPkgs.verify-documented-usage ];
+        TOPIARY_WRAPPED = lib.getExe topiaryPkgs.topiary-wrapped;
+      }
+      ''
+        mkdir -p docs/book/src/cli
+        cp -r ${../../docs/book/src/cli/usage} docs/book/src/cli/usage
+        verify-documented-usage
+        touch $out
+      '';
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -56,8 +56,8 @@ let
   };
 
   checks = callPackageNoOverrides ./checks {
-    inherit (pkgs') emptyFile;
-    inherit topiaryPkgs;
+    inherit (pkgs') emptyFile runCommand lib;
+    inherit topiaryPkgs binPkgs;
     inherit (topiaryLib) gitHook;
   };
 

--- a/nix/packages/topiary.nix
+++ b/nix/packages/topiary.nix
@@ -295,10 +295,22 @@ let
     ];
 
     text = ''
-      export COLUMNS=90
       export NO_COLOR=1
 
-      unbuffer topiary "$@"
+      TMPFILE=$(mktemp)
+      cat > "$TMPFILE" <<'EOF'
+      set stty_init "cols 90"
+      eval spawn -noecho topiary $argv
+      set timeout -1
+      expect
+      EOF
+
+      expect "$TMPFILE" "$@"
+
+      # Clean up and preserve exit code
+      EXIT_CODE=$?
+      rm "$TMPFILE"
+      exit $EXIT_CODE
     '';
   };
 


### PR DESCRIPTION
# add verify-documented-usage to nix flake check

## Description
Ideally, running `nix flake check` should run all tests and checks.

## Checklist

- [ ] `CHANGELOG.md` updated
- [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [ ] Updated regression tests
