### PR TITLE
fix(ocaml): Dangle typed expressions with a type constraint

### DIFF
--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -1514,3 +1514,23 @@ let foo = [
   [bar];
   [baz];
 ]
+
+(* #1053 Idempotency error for module with type constraint *)
+let foo () = (
+  (module struct type s end)
+  : t
+)
+
+(* Typed expressions, related to #1053 *)
+let a = (x : int)
+let b = f (x : int) (y : bool)
+let c = (x : int) + (y : int)
+let d =
+  (long_function_application arg1 arg2: some_long_type_annotation_here_xxxx)
+let e () = (
+  (module M : S)
+  : t
+)
+let g = (e :> t)
+let h (x : int) (y : string) = x
+let i = [(a : t); (b : t)]

--- a/topiary-cli/tests/samples/input/ocaml.ml
+++ b/topiary-cli/tests/samples/input/ocaml.ml
@@ -1449,3 +1449,21 @@ let _ =
 let foo = [
   [bar]; [baz];
 ]
+
+(* #1053 Idempotency error for module with type constraint *)
+let foo () =
+  ((module struct type s end)
+   : t)
+
+(* Typed expressions, related to #1053 *)
+let a = (x : int)
+let b = f (x : int) (y : bool)
+let c = (x : int) + (y : int)
+let d =
+  (long_function_application arg1 arg2 : some_long_type_annotation_here_xxxx)
+let e () =
+  ((module M : S)
+   : t)
+let g = (e :> t)
+let h (x : int) (y : string) = x
+let i = [ (a : t); (b : t) ]

--- a/topiary-queries/queries/ocaml/formatting.scm
+++ b/topiary-queries/queries/ocaml/formatting.scm
@@ -1092,7 +1092,6 @@
     (product_expression)
     (sequence_expression)
     (set_expression)
-    (typed_expression)
     (unit)
     (value_path)
     (variant_declaration)
@@ -1356,6 +1355,26 @@
   .
   ; just doing _ above doesn't work, because it matches the final named node as
   ; well as the final non-named node, causing double indentation.
+)
+
+; The parentheses around a typed expression dangle like a parenthesized
+; expression, with the type ascription onto its own line, such as
+; let _ = (
+;   (module struct type s end)
+;   : t
+; )
+(typed_expression
+  .
+  "(" @append_empty_softline @append_indent_start
+  ")" @prepend_indent_end
+  .
+)
+(typed_expression
+  ")" @prepend_empty_softline
+  .
+)
+(typed_expression
+  ":" @prepend_empty_softline
 )
 
 (value_specification


### PR DESCRIPTION
# fix(ocaml): Dangle typed expressions with a type constraint

Closes #1053

## Description

The body of a `let` bound to a parenthesised typed expression such as `((module struct type s end) : t)` was not idempotent: the type ascription collapsed onto one line, which flipped the body's indentation between runs. Make the parentheses dangle like a parenthesized expression and keep the ascription on its own line.

This is my first time making changes to the queries language, so I'm really not sure what I've done there. Who's the right person to ping for this; @nbacquey I suppose?

## Checklist

Checklist before merging, wherever relevant:

- [ ] `CHANGELOG.md` updated
- [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [X] Updated regression tests
