### PR TITLE
Improve warning for injection queries without content capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This name should be decided amongst the team before the release.
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.
 - [#1253](https://github.com/topiary/topiary/pull/1253) Handle linebreak preservation in OpenSCAD let chains
 - [#1255](https://github.com/topiary/topiary/pull/1255) Unpinned outdated wasm-bindgen dependency
+- [#1291](https://github.com/topiary/topiary/pull/1291) Improve warning for injection queries without content captures
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -637,6 +637,27 @@ mod tests {
     }
 
     #[test(tokio::test)]
+    async fn collect_injections_skips_pattern_without_content_capture() {
+        let input = r#"rule token = parse
+  | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }
+"#;
+        let mut language = ocamllex_language();
+        language.injection_query = Some(
+            InjectionQuery::new(
+                &language.grammar,
+                r#"
+(ocaml) @injection.language
+"#,
+            )
+            .unwrap(),
+        );
+        let tree = parse(input, &language.grammar, false).unwrap();
+        let spans = collect_injections(&tree, input, language.injection_query.as_ref().unwrap());
+
+        assert!(spans.is_empty());
+    }
+
+    #[test(tokio::test)]
     async fn unresolved_injection_skips_formatting() {
         let input = r#"rule token = parse
   | "x" { let values=[1;2;3] in List.map (fun x->x+1) values }

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -164,8 +164,8 @@ pub struct InjectionSpan<'a> {
 /// `@injection.content` capture paired with the language declared by its
 /// pattern's `#injection_language!` predicate.
 ///
-/// Patterns missing an `#injection_language!` predicate are skipped (with a
-/// warning logged).
+/// Patterns missing an `@injection.content` capture or an injection language
+/// are skipped (with a warning logged).
 ///
 /// Missing predicates or unmatched captures are logged, not raised.
 pub fn collect_injections<'a>(
@@ -183,6 +183,19 @@ pub fn collect_injections<'a>(
     let mut matches = query.query.matches(&root, source, &mut cursor);
     #[allow(clippy::while_let_on_iterator)] // Not a normal iterator
     while let Some(query_match) = matches.next() {
+        let content_captures = query_match
+            .captures()
+            .filter(|c| c.name(capture_names.as_slice()) == "injection.content")
+            .collect::<Vec<_>>();
+
+        if content_captures.is_empty() {
+            log::warn!(
+                "Injection query pattern {} has no @injection.content capture; skipping",
+                query_match.pattern_index()
+            );
+            continue;
+        }
+
         // Resolve the language of the injection either via a hardcoded `#injection_language!` predicate
         // or by dynamically reading the text of the `@injection.language` capture (e.g. for Markdown code blocks).
         let language_name = query
@@ -211,10 +224,7 @@ pub fn collect_injections<'a>(
             continue;
         };
 
-        for capture in query_match
-            .captures()
-            .filter(|c| c.name(capture_names.as_slice()) == "injection.content")
-        {
+        for capture in content_captures {
             let node = capture.node();
             spans.push(InjectionSpan {
                 content: input_content


### PR DESCRIPTION
Fixes #1289.

## Summary
- Skip injection query matches without `@injection.content` before resolving an injection language.
- Log a specific warning for patterns missing `@injection.content`.
- Add a regression test for content-less injection query patterns.

## Validation
- `docker run --rm -v "$PWD":/src -w /src rust:latest sh -lc 'export PATH=/usr/local/cargo/bin:$PATH; rustup component add rustfmt >/tmp/rustfmt.log && cargo fmt --check && cargo test -p topiary-core collect_injections'`