### PR TITLE
fix(ocaml): Keep local-open records dangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This name should be decided amongst the team before the release.
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.
 - [#1253](https://github.com/topiary/topiary/pull/1253) Handle linebreak preservation in OpenSCAD let chains
 - [#1255](https://github.com/topiary/topiary/pull/1255) Unpinned outdated wasm-bindgen dependency
+- [#1287](https://github.com/topiary/topiary/pull/1287) [#1296](https://github.com/topiary/topiary/pull/1296) Various OCaml issues and improvements
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -1534,3 +1534,10 @@ let e () = (
 let g = (e :> t)
 let h (x : int) (y : string) = x
 let i = [(a : t); (b : t)]
+
+(* #1074 Idempotency error on `pure A.{x}` within a function *)
+let () =
+  with_
+    (fun x ->
+      pure A.{x}
+    )

--- a/topiary-cli/tests/samples/input/ocaml.ml
+++ b/topiary-cli/tests/samples/input/ocaml.ml
@@ -1467,3 +1467,9 @@ let e () =
 let g = (e :> t)
 let h (x : int) (y : string) = x
 let i = [ (a : t); (b : t) ]
+
+(* #1074 Idempotency error on `pure A.{x}` within a function *)
+let () =
+  with_
+    (fun x ->
+       pure A.{x})

--- a/topiary-queries/queries/ocaml/formatting.scm
+++ b/topiary-queries/queries/ocaml/formatting.scm
@@ -922,6 +922,20 @@
   )
 )
 
+; Tie the scope to the "." in local opens, so that `A.{x}` is kept dangling
+; from it rather than from an enclosing scope. Otherwise the "." makes the
+; queries above skip it, and `pure A.{x}` gets broken onto several lines.
+(local_open_expression
+  "." @append_begin_scope
+  .
+  [
+    (record_expression)
+    (list_expression)
+    (array_expression)
+  ] @append_end_scope
+  (#scope_id! "dangling_list_like")
+)
+
 ; We want to add a line when the regular scope is multi-line,
 ; But only if the (measured) custom scope is single-line.
 ; In essence, we want to preserve all of the following three:


### PR DESCRIPTION
Closes #1074

## Description

A local open like `A.{x}` puts a "." between the module path and the record, which made the `dangling_list_like` scope queries skip it. The record then attached to an enclosing scope and `pure A.{x}` was broken onto several lines, failing the idempotence check.

Same as #1287: I have no idea what I'm doing, so I hope I'm not ruining the queries file. At least on the Topiary tests and on my personal projects this looks fine.

## Checklist

Checklist before merging, wherever relevant:

- [ ] `CHANGELOG.md` updated
- [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [ ] Updated regression tests