### PR TITLE
chore(queries,wit): Update WIT formatter for tree-sitter-wit to v1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ This name should be decided amongst the team before the release.
 - [#1270](https://github.com/topiary/topiary/pull/1270) Add initial `languages.ncl` Nickel contracts
 - [#1139](https://github.com/topiary/topiary/pull/1139) Added `rootcause::Report` handling in topiary-cli.
 - [#1283](https://github.com/topiary/topiary/pull/1283) Render Nickel parsing error diagnostics
+- [#1298] https://github.com/topiary/topiary/pull/1298) Update WIT formatter for tree-sitter-wit to v1.4
 
 ### Fixed
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.
@@ -97,6 +98,7 @@ This name should be decided amongst the team before the release.
 [Full list of changes](https://github.com/topiary/topiary/compare/v0.7.2...v0.7.3)
 
 ### Changed
+- [#1149](https://github.com/topiary/topiary/pull/1149) Updated to Tree-sitter v0.26
 - [#1149](https://github.com/topiary/topiary/pull/1149) Updated to Tree-sitter v0.26
 
 ## v0.7.2 - Heavenly Hemlock - 2025-11-27

--- a/topiary-cli/tests/samples/expected/wit.wit
+++ b/topiary-cli/tests/samples/expected/wit.wit
@@ -194,3 +194,59 @@ world imports {
     @deprecated(version = 0.1.0)
     export streams;
 }
+
+// ==================
+// Nested Package Definitions
+// ==================
+
+package root:a;
+
+package local:a {
+    interface foo {}
+}
+
+package local:b@1.0.0 {
+    interface bar {}
+    world w {}
+}
+
+// ==================
+// Map Types and Fallible Constructors
+// ==================
+
+interface maps {
+    type headers = map<string, string>;
+    type counts = map<u32, u64>;
+    fn1: func(m: map<char, list<u8>>) -> map<bool, string>;
+
+    resource res-no-err {
+        constructor(init: list<u8>) -> result<blob>;
+    }
+    resource res-err {
+        constructor(x: u32) -> result<err, string>;
+    }
+}
+
+// ==================
+// External IDs and Named Interface Imports
+// ==================
+
+world my-component {
+    @external-id("https://esm.unpkg.com/slugify@1.6.6")
+    import slugify: func(text: string) -> string;
+    @since(version = 0.1.0)
+    @external-id("user-db-prod:region-a")
+    import users: wasi:keyvalue/store;
+    import primary: wasi:keyvalue/store;
+    export my-handler: wasi:http/handler;
+}
+
+interface my-interface {
+    @external-id("foo/0")
+    foo: func() -> string;
+    @external-id("DB.Bar")
+    resource bar {
+        @external-id("baz/1")
+        baz: func(s: string) -> string;
+    }
+}

--- a/topiary-cli/tests/samples/input/wit.wit
+++ b/topiary-cli/tests/samples/input/wit.wit
@@ -181,3 +181,46 @@ interface stream-async {
 world
 imports {@since(version=0.1.0)@unstable(feature=fancier-foo)import streams;
 @deprecated(version=0.1.0) export streams;}
+
+// ==================
+// Nested Package Definitions
+// ==================
+
+package root:a;
+
+package local:a {
+   interface foo {}
+}
+
+package local:b @1.0.0 {interface bar {}world w {}}
+
+// ==================
+// Map Types and Fallible Constructors
+// ==================
+
+interface maps {
+   type headers=map<string,string>;
+   type counts =map< u32,u64 >;
+   fn1:func(m:map <char,list<u8>> )->map<bool,string>;
+
+   resource res-no-err  { constructor(init:list<u8>)->result<blob>; }
+   resource res-err {
+       constructor(x:u32)->result<err,string>;
+   }
+}
+
+// ==================
+// External IDs and Named Interface Imports
+// ==================
+
+world my-component {@external-id("https://esm.unpkg.com/slugify@1.6.6")import slugify:func(text:string)->string;
+@since(version=0.1.0)@external-id ("user-db-prod:region-a")import users:wasi:keyvalue/store;
+   import primary:wasi:keyvalue/store;
+   export my-handler:wasi:http/handler;
+}
+
+interface my-interface {
+@external-id("foo/0")foo : func() -> string;@external-id("DB.Bar") resource bar { @external-id("baz/1")
+        baz: func(s: string) -> string;
+    }
+}

--- a/topiary-config/languages.ncl
+++ b/topiary-config/languages.ncl
@@ -245,7 +245,7 @@ in
       grammar.source | default = {
         git = {
           git = "https://github.com/bytecodealliance/tree-sitter-wit",
-          rev = "v1.2.0",
+          rev = "v1.4.0",
           nixHash = "sha256-scye60ETUak1mXJXC+UY5sqbuqAcjxCsm4+AVJHhGws=",
         },
       },

--- a/topiary-queries/queries/wit/formatting.scm
+++ b/topiary-queries/queries/wit/formatting.scm
@@ -25,10 +25,12 @@
 ; Allow blank line before
 [
   (enum_items)
+  (external_id)
   (flags_items)
   (interface_item)
   (line_comment)
   (block_comment)
+  (nested_package_definition)
   (package_decl)
   (record_item)
   (resource_item)
@@ -67,10 +69,12 @@
   [
     (deprecated_gate)
     (export_item)
+    (external_id)
     (func_item)
     (import_item)
     (include_item)
     (interface_item)
+    (nested_package_definition)
     (package_decl)
     (resource_item)
     (resource_method)
@@ -96,11 +100,26 @@
   (since_gate)
   (deprecated_gate)
   (unstable_gate)
+  (external_id)
 ] @append_spaced_softline
+
+; Always leave a space before an opening `{`, even when the body is empty
+; (the `{ _ }` pattern below only fires for non-empty bodies).
+(body "{" @prepend_space)
+(nested_package_definition "{" @prepend_space)
 
 (body
   .
-  "{" @append_hardline @append_indent_start @prepend_space
+  "{" @append_hardline @append_indent_start
+  _
+  "}" @prepend_hardline @prepend_indent_end
+  .
+)
+
+(nested_package_definition
+  .
+  (decl_head)
+  "{" @append_hardline @append_indent_start
   _
   "}" @prepend_hardline @prepend_indent_end
   .
@@ -171,7 +190,7 @@
 
 ; Colon should have whitespace trimmed for URI separator
 ; pkg & use nodes
-(package_decl
+(decl_head
   ["@" ":" "/"] @prepend_antispace @append_antispace
 )
 (use_path
@@ -181,6 +200,13 @@
   ":" @prepend_antispace @append_space
 )
 (named_type
+  ":" @prepend_antispace @append_space
+)
+; Space after the `:` separating an import/export name from its extern_type
+(import_item
+  ":" @prepend_antispace @append_space
+)
+(export_item
   ":" @prepend_antispace @append_space
 )
 ; Function signatures need proper spacing


### PR DESCRIPTION
# Update WIT formatter for tree-sitter-wit to v1.4
<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
References https://github.com/bytecodealliance/tree-sitter-wit/pull/30

## Description

Update the WIT formatter queries and test cases to handle grammar introduced in tree-sitter-wit 1.4.0, this includes new additions such as:
* map types
https://github.com/topiary/topiary/blob/5b9f3038db13d7cbe610b87eb098503781991e34/topiary-cli/tests/samples/expected/wit.wit#L218
* nested packages
  https://github.com/topiary/topiary/blob/5b9f3038db13d7cbe610b87eb098503781991e34/topiary-cli/tests/samples/expected/wit.wit#L208
* external-ids
  https://github.com/topiary/topiary/blob/5b9f3038db13d7cbe610b87eb098503781991e34/topiary-cli/tests/samples/expected/wit.wit#L235
* fallible constructors
  https://github.com/topiary/topiary/blob/5b9f3038db13d7cbe610b87eb098503781991e34/topiary-cli/tests/samples/expected/wit.wit#L223

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [x] Updated regression tests
