### PR TITLE
doc(book): Cross-link configuration pages

### DIFF
--- a/docs/book/src/cli/configuration.md
+++ b/docs/book/src/cli/configuration.md
@@ -49,9 +49,9 @@ following order (highest to lowest):
 3. The user configuration file in the OS's configuration directory.
 4. The built-in configuration file.
 
-One can call `topiary config show-sources` to display configuration
-sources along with any detected `language.ncl` files or `queries`
-directories therein:
+One can call [`topiary config show-sources`](usage/config.md) to display
+configuration sources along with any detected `language.ncl` files or
+`queries` directories therein:
 
 ```
 $ topiary config show-sources

--- a/docs/book/src/cli/usage/config.md
+++ b/docs/book/src/cli/usage/config.md
@@ -19,5 +19,8 @@ Options:
 ```
 <!-- usage:end -->
 
+For more information about configuration sources, their precedence, and
+merging behaviour, see [Configuration](../configuration.md).
+
 > **Note**\
 > `cfg` is a recognised alias of the `config` subcommand.


### PR DESCRIPTION
# Cross-link configuration pages

Resolves #1143

## Description

Cross-link the configuration overview and the `topiary config` command
reference so readers can move between the conceptual explanation and the
available CLI options. The existing `topiary config show-sources` mention now
also links directly to the command reference.

## Validation

- `mdbook v0.4.47 build docs/book` completed successfully
- `git diff --check` passed

## Checklist

- [x] `CHANGELOG.md` update not required (documentation navigation only)
- [x] Documentation is up-to-date
- [x] Regression tests not required (documentation-only change)
