### PR TITLE
feat(cli): Move topiary-cli configuration logic into its own module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,9 @@ This name should be decided amongst the team before the release.
 - [#1270](https://github.com/topiary/topiary/pull/1270) Add initial `languages.ncl` Nickel contracts
 - [#1139](https://github.com/topiary/topiary/pull/1139) Added `rootcause::Report` handling in topiary-cli.
 - [#1283](https://github.com/topiary/topiary/pull/1283) Render Nickel parsing error diagnostics
-- [#1298] https://github.com/topiary/topiary/pull/1298) Update WIT formatter for tree-sitter-wit to v1.4
-- [#1303] https://github.com/topiary/topiary/pull/1303) Add `bin/verify-documented-usage.sh --no-nix-shell` flag
+- [#1298](https://github.com/topiary/topiary/pull/1298) Update WIT formatter for tree-sitter-wit to v1.4
+- [#1303](https://github.com/topiary/topiary/pull/1303) Add `bin/verify-documented-usage.sh --no-nix-shell` flag
+- [#1306](https://github.com/topiary/topiary/pull/1306) Move topiary-cli configuration logic into its own module
 
 ### Fixed
 - [#1176](https://github.com/topiary/topiary/pull/1176) Increase the stack size to 4MiB in Windows builds.

--- a/examples/client-app/src/main.rs
+++ b/examples/client-app/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
     let config = Configuration::default();
 
     // Get JSON language configuration
-    let json = config.get_language("json").unwrap();
+    let json = config.get_language_cfg("json").unwrap();
 
     // Get default query for JSON
     let query = topiary_queries::json();

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -60,9 +60,12 @@ default = [
   "ocamllex",
   "toml",
   "tree_sitter_query",
+  "fancy-config",
 ]
 
+
 # Included by default
+fancy-config = ["nickel"]
 contributed = [
   "css",
   "openscad",
@@ -90,3 +93,4 @@ toml = ["topiary-config/toml", "topiary-queries/toml"]
 tree_sitter_query = ["topiary-config/tree_sitter_query", "topiary-queries/tree_sitter_query"]
 markdown = ["topiary-config/markdown", "topiary-queries/markdown"]
 wit = ["topiary-config/wit", "topiary-queries/wit"]
+

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -1,0 +1,178 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::{ops::Deref, path::Path};
+
+use nickel_lang_core::eval::value::NickelValue;
+use topiary_config::source::Source;
+
+use crate::error::{CLIResult, ResultPreformat};
+
+/// Wrapper around Configuration and its raw Nickel representation.
+///
+/// [`NickelValue`] is used for operations that require the using the Nickel AST,
+/// such as formatting or querying the configuration with Nickel-aware tooling.
+#[derive(Debug, Clone)]
+pub struct Configuration {
+    inner: topiary_config::Configuration,
+    ncl: Arc<NickelValue>,
+    path: Option<PathBuf>,
+}
+
+impl Configuration {
+    /// Create a new Configuration by fetching from the given path
+    pub fn new(merge: bool, path: Option<&Path>) -> CLIResult<Self> {
+        let (inner, ncl) = topiary_config::Configuration::fetch(merge, path).preformat_context()?;
+        Ok(Self {
+            inner,
+            ncl: Arc::new(ncl),
+            path: path.map(|p| p.to_owned()),
+        })
+    }
+
+    /// Get the config sources
+    pub fn config_sources(&self) -> impl Iterator<Item = (&'static str, Source)> {
+        Source::config_sources(self.path.as_deref())
+    }
+
+    /// Extract a field from the configuration
+    pub fn extract_field(&self, merge: bool, field_path: &str) -> CLIResult<NickelValue> {
+        let ncl = topiary_config::Configuration::extract_field(merge, &self.path, field_path)
+            .preformat_context()?;
+
+        Ok(ncl)
+    }
+
+    /// Prefetch a language's grammar and queries
+    pub fn prefetch_language<T>(&self, language: T, force: bool) -> CLIResult<()>
+    where
+        T: AsRef<str> + std::fmt::Display,
+    {
+        self.inner
+            .prefetch_language(language, force)
+            .preformat_context()?;
+
+        Ok(())
+    }
+
+    /// Prefetch all languages' grammars and queries
+    pub fn prefetch_languages(&self, force: bool) -> CLIResult<()> {
+        self.inner.prefetch_languages(force).preformat_context()?;
+
+        Ok(())
+    }
+
+    /// Get a language by name synchronously
+    pub fn get_language<T>(&self, name: T) -> CLIResult<topiary_core::Language>
+    where
+        T: AsRef<str> + std::fmt::Display,
+    {
+        crate::io::to_language_from_config_sync(&self.inner, name)
+    }
+}
+
+impl Deref for Configuration {
+    type Target = topiary_config::Configuration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl AsRef<topiary_config::Configuration> for Configuration {
+    fn as_ref(&self) -> &topiary_config::Configuration {
+        &self.inner
+    }
+}
+
+#[cfg(feature = "nickel")]
+impl std::fmt::Display for Configuration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use topiary_core::{Operation, formatter};
+
+        // TODO handle verbose flag
+        let stripped = strip_metadata(self.ncl.as_ref().clone());
+        let nickel_config = format!("{stripped}");
+
+        // if errors are encountered in formatting, return
+        let language = match self.get_language("nickel") {
+            Ok(lang) => lang,
+            Err(_) => return write!(f, "{}", self.ncl),
+        };
+
+        let mut output = Vec::new();
+        if let Err(_) = formatter(
+            &mut nickel_config.as_bytes(),
+            &mut output,
+            &language,
+            Operation::Format {
+                skip_idempotence: true,
+                tolerate_parsing_errors: false,
+            },
+            None,
+        ) {
+            return write!(f, "{}", self.ncl);
+        }
+
+        write!(f, "{}", String::from_utf8_lossy(&output))
+    }
+}
+
+#[cfg(not(feature = "nickel"))]
+impl std::fmt::Display for Configuration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.ncl)
+    }
+}
+
+// Strip field metadata (doc strings, type/contract annotations, `| default`,
+// `| optional`, priority) and unwrap `Term::Annotated` nodes from a NickelValue
+// so that the pretty printer emits a plain data record.
+#[cfg(feature = "nickel")]
+fn strip_metadata(value: NickelValue) -> NickelValue {
+    use nickel_lang_core::eval::value::{RecordData, ValueContent};
+    use nickel_lang_core::term::Term;
+    use nickel_lang_core::traverse::{Traverse, TraverseOrder};
+
+    value
+        .traverse(
+            &mut |v: NickelValue| -> std::result::Result<NickelValue, std::convert::Infallible> {
+                let pos_idx = v.pos_idx();
+                match v.content() {
+                    ValueContent::Record(lens) => {
+                        let Some(record) = lens.take().into_opt() else {
+                            return Ok(NickelValue::record_posless(RecordData::empty())
+                                .with_pos_idx(pos_idx));
+                        };
+                        let fields = record
+                            .fields
+                            .into_iter()
+                            .map(|(id, field)| {
+                                let nickel_lang_core::term::record::Field { value, .. } = field;
+                                (
+                                    id,
+                                    nickel_lang_core::term::record::Field::from(
+                                        value.unwrap_or_else(NickelValue::null),
+                                    ),
+                                )
+                            })
+                            .collect();
+                        Ok(NickelValue::record(
+                            RecordData::new_shared_tail(fields, record.attrs, record.sealed_tail),
+                            pos_idx,
+                        ))
+                    }
+                    ValueContent::Term(lens) => {
+                        let term = lens.take();
+                        if let Term::Annotated(data) = term {
+                            Ok(data.inner.clone())
+                        } else {
+                            Ok(NickelValue::term(term, pos_idx))
+                        }
+                    }
+                    other => Ok(other.restore()),
+                }
+            },
+            TraverseOrder::BottomUp,
+        )
+        .unwrap_or_else(|never: std::convert::Infallible| match never {})
+}

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -5,12 +5,13 @@ use std::{ops::Deref, path::Path};
 
 use nickel_lang_core::eval::value::NickelValue;
 use rootcause::prelude::ResultExt;
-use topiary_config::language::LocalRepos;
 use topiary_config::source::Source;
-use topiary_core::{FormatterError, InjectionQuery, SpanAttachment, TopiaryQuery};
+use topiary_core::{
+    FormatterError, FormatterResult, InjectionQuery, Language, SpanAttachment, TopiaryQuery,
+};
+use topiary_queries;
 
-use crate::error::{CLIResult, ResultPreformat};
-use crate::io::to_query_from_language;
+use crate::error::{CLIResult, ResultPreformat, TopiaryError};
 use crate::language::LanguageDefinitionCache;
 
 thread_local! {
@@ -65,6 +66,8 @@ impl Configuration {
     /// `Configuration::new()` call, ensuring the index is always within bounds of the thread-local storage.
     pub fn ncl(&self) -> Arc<NickelValue> {
         NICKEL_VALUES.with(|values| {
+            // `Cell` does not give out mutable references (unsafe in thread-local context);
+            // instead one has to take a value, modify/use it, and put it back.
             let vec = values.take();
             // SAFETY: We have a guarantee that the index is valid because:
             // 1. Each `Configuration` stores an `ncl_id` from `NEXT_ID`
@@ -78,7 +81,7 @@ impl Configuration {
     }
 
     /// Get the config sources
-    pub fn config_sources(&self) -> impl Iterator<Item = (&'static str, Source)> {
+    pub fn iter_sources(&self) -> impl Iterator<Item = (&'static str, Source)> {
         Source::config_sources(self.path.as_deref())
     }
 
@@ -114,33 +117,25 @@ impl Configuration {
     where
         T: AsRef<str> + std::fmt::Display,
     {
-        let config_language = self.get_language_cfg(name.as_ref()).preformat_context()?;
+        let name_ref = name.as_ref();
+        let config_language = self.get_language_cfg(name_ref).preformat_context()?;
         let grammar = config_language.grammar()?;
-        let repos = LocalRepos::new();
-        let query_source = to_query_from_language(
-            config_language,
-            topiary_queries::FORMATTING_QUERY,
-            Some(&repos),
-        )?;
+        let query_source = self.get_query_source(name_ref, topiary_queries::FORMATTING_QUERY)?;
         let query_content = query_source.get_content_sync()?;
         let formatting_query = TopiaryQuery::new(&grammar, &query_content)
             .attach_filepath(query_source.filepath())
             .context(FormatterError::Parsing)?;
-        let injection_query = match to_query_from_language(
-            config_language,
-            topiary_queries::INJECTIONS_QUERY,
-            Some(&repos),
-        )
-        .ok()
+        let injection_query = match self
+            .get_query_source(name_ref, topiary_queries::INJECTIONS_QUERY)
         {
-            Some(source) => {
+            Ok(source) => {
                 let contents = source.get_content_sync()?;
                 Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
             }
-            None => None,
+            Err(_) => None,
         };
         Ok(topiary_core::Language {
-            name: name.as_ref().to_string(),
+            name: name_ref.to_string(),
             formatting_query,
             injection_query,
             grammar,
@@ -148,8 +143,128 @@ impl Configuration {
         })
     }
 
+    /// Get a query source for the given language and query name, using the cached repos
+    pub fn get_query_source(
+        &self,
+        language_name: &str,
+        query_name: &str,
+    ) -> CLIResult<crate::io::QuerySource> {
+        let config_language = self.get_language_cfg(language_name).preformat_context()?;
+        let cache = self.cache();
+        let repos = cache.repos();
+        let find = config_language.find_query_file_with(query_name, repos);
+        let query: crate::io::QuerySource = match find {
+            Ok(p) => p.into(),
+            // For some reason, Topiary could not find any
+            // matching file in a default location. As a final attempt, try the
+            // builtin ones. Store the error, return that if we
+            // fail to find anything, because the builtin error might be unexpected.
+            Err(e) => {
+                log::warn!(
+                    "No {query_name} query files found in any of the expected locations. Falling back to compile-time included files."
+                );
+                query_from_builtin(&config_language.name, query_name)
+                    .local_context(e)
+                    .preformat_context()?
+            }
+        };
+        Ok(query)
+    }
+
     pub(crate) fn cache(&self) -> Arc<LanguageDefinitionCache> {
         self.cache.clone()
+    }
+
+    /// Resolve an injected language by name, returning None if the language is unknown.
+    ///
+    /// This is used to fetch language definitions for code injections during formatting.
+    /// Returns `Ok(None)` if the language is not configured, `Ok(Some(language))` if found,
+    /// or `Err` if there was an error resolving the language.
+    pub fn resolve_injected_language(&self, name: &str) -> FormatterResult<Option<Arc<Language>>> {
+        if matches!(
+            self.get_language_cfg(name),
+            Err(topiary_config::error::TopiaryConfigError::UnknownLanguage(
+                _
+            ))
+        ) {
+            return Ok(None);
+        }
+
+        match self.cache().fetch_from_config(self, name) {
+            Ok(language) => Ok(Some(language)),
+            Err(report) => Err(report.context(FormatterError::InjectionLanguageResolution {
+                language: name.to_owned(),
+            })),
+        }
+    }
+}
+
+/// Get a builtin query for the given language and query name
+fn query_from_builtin<T, Q>(language: T, query: Q) -> CLIResult<crate::io::QuerySource>
+where
+    T: AsRef<str> + std::fmt::Display,
+    Q: AsRef<str>,
+{
+    let name_str = language.as_ref();
+    match query.as_ref() {
+        topiary_queries::FORMATTING_QUERY => match name_str {
+            #[cfg(feature = "bash")]
+            "bash" => Ok(topiary_queries::bash().into()),
+
+            #[cfg(feature = "css")]
+            "css" => Ok(topiary_queries::css().into()),
+
+            #[cfg(feature = "json")]
+            "json" => Ok(topiary_queries::json().into()),
+
+            #[cfg(feature = "markdown")]
+            "markdown" => Ok(topiary_queries::markdown().into()),
+
+            #[cfg(feature = "nickel")]
+            "nickel" => Ok(topiary_queries::nickel().into()),
+
+            #[cfg(feature = "ocaml")]
+            "ocaml" => Ok(topiary_queries::ocaml().into()),
+
+            #[cfg(feature = "ocaml_interface")]
+            "ocaml_interface" => Ok(topiary_queries::ocaml_interface().into()),
+
+            #[cfg(feature = "ocamllex")]
+            "ocamllex" => Ok(topiary_queries::ocamllex().into()),
+
+            #[cfg(feature = "openscad")]
+            "openscad" => Ok(topiary_queries::openscad().into()),
+
+            #[cfg(feature = "rust")]
+            "rust" => Ok(topiary_queries::rust().into()),
+
+            #[cfg(feature = "sdml")]
+            "sdml" => Ok(topiary_queries::sdml().into()),
+
+            #[cfg(feature = "toml")]
+            "toml" => Ok(topiary_queries::toml().into()),
+
+            #[cfg(feature = "tree_sitter_query")]
+            "tree_sitter_query" => Ok(topiary_queries::tree_sitter_query().into()),
+
+            #[cfg(feature = "wit")]
+            "wit" => Ok(topiary_queries::wit().into()),
+
+            _ => Err(TopiaryError::UnsupportedLanguage(name_str.to_string()).into()),
+        },
+        topiary_queries::INJECTIONS_QUERY => match name_str {
+            #[cfg(feature = "markdown")]
+            "markdown" => Ok(topiary_queries::markdown_injections().into()),
+
+            #[cfg(feature = "ocamllex")]
+            "ocamllex" => Ok(topiary_queries::ocamllex_injections().into()),
+
+            #[cfg(feature = "rust")]
+            "rust" => Ok(topiary_queries::rust_injections().into()),
+
+            _ => Err(TopiaryError::UnsupportedLanguage(name_str.to_string()).into()),
+        },
+        _ => Err(TopiaryError::UnsupportedLanguage(name_str.to_string()).into()),
     }
 }
 
@@ -167,7 +282,7 @@ impl AsRef<topiary_config::Configuration> for Configuration {
     }
 }
 
-#[cfg(feature = "nickel")]
+#[cfg(feature = "fancy-config")]
 impl std::fmt::Display for Configuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use topiary_core::{Operation, formatter};
@@ -183,7 +298,7 @@ impl std::fmt::Display for Configuration {
         };
 
         let mut output = Vec::new();
-        if let Err(_) = formatter(
+        if let Err(err) = formatter(
             &mut nickel_config.as_bytes(),
             &mut output,
             &language,
@@ -193,6 +308,10 @@ impl std::fmt::Display for Configuration {
             },
             None,
         ) {
+            log::error!(
+                "error calling {}::fmt : {err}",
+                std::any::type_name::<Self>()
+            );
             return write!(f, "{}", self.ncl());
         }
 
@@ -210,7 +329,7 @@ impl std::fmt::Display for Configuration {
 // Strip field metadata (doc strings, type/contract annotations, `| default`,
 // `| optional`, priority) and unwrap `Term::Annotated` nodes from a NickelValue
 // so that the pretty printer emits a plain data record.
-#[cfg(feature = "nickel")]
+#[cfg(feature = "fancy-config")]
 fn strip_metadata(value: NickelValue) -> NickelValue {
     use nickel_lang_core::eval::value::{RecordData, ValueContent};
     use nickel_lang_core::term::Term;

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -319,7 +319,7 @@ impl std::fmt::Display for Configuration {
     }
 }
 
-#[cfg(not(feature = "nickel"))]
+#[cfg(not(feature = "fancy-config"))]
 impl std::fmt::Display for Configuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.ncl())

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -3,9 +3,14 @@ use std::sync::Arc;
 use std::{ops::Deref, path::Path};
 
 use nickel_lang_core::eval::value::NickelValue;
+use rootcause::prelude::ResultExt;
+use topiary_config::language::LocalRepos;
 use topiary_config::source::Source;
+use topiary_core::{FormatterError, InjectionQuery, SpanAttachment, TopiaryQuery};
 
 use crate::error::{CLIResult, ResultPreformat};
+use crate::io::to_query_from_language;
+use crate::language::LanguageDefinitionCache;
 
 /// Wrapper around Configuration and its raw Nickel representation.
 ///
@@ -16,6 +21,7 @@ pub struct Configuration {
     inner: topiary_config::Configuration,
     ncl: Arc<NickelValue>,
     path: Option<PathBuf>,
+    cache: Arc<LanguageDefinitionCache>,
 }
 
 impl Configuration {
@@ -26,6 +32,7 @@ impl Configuration {
             inner,
             ncl: Arc::new(ncl),
             path: path.map(|p| p.to_owned()),
+            cache: Arc::new(LanguageDefinitionCache::new()),
         })
     }
 
@@ -61,12 +68,47 @@ impl Configuration {
         Ok(())
     }
 
-    /// Get a language by name synchronously
+    /// Build a [`topiary_core::Language`]
     pub fn get_language<T>(&self, name: T) -> CLIResult<topiary_core::Language>
     where
         T: AsRef<str> + std::fmt::Display,
     {
-        crate::io::to_language_from_config_sync(&self.inner, name)
+        let config_language = self.get_language_cfg(name.as_ref()).preformat_context()?;
+        let grammar = config_language.grammar()?;
+        let repos = LocalRepos::new();
+        let query_source = to_query_from_language(
+            config_language,
+            topiary_queries::FORMATTING_QUERY,
+            Some(&repos),
+        )?;
+        let query_content = query_source.get_content_sync()?;
+        let formatting_query = TopiaryQuery::new(&grammar, &query_content)
+            .attach_filepath(query_source.filepath())
+            .context(FormatterError::Parsing)?;
+        let injection_query = match to_query_from_language(
+            config_language,
+            topiary_queries::INJECTIONS_QUERY,
+            Some(&repos),
+        )
+        .ok()
+        {
+            Some(source) => {
+                let contents = source.get_content_sync()?;
+                Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
+            }
+            None => None,
+        };
+        Ok(topiary_core::Language {
+            name: name.as_ref().to_string(),
+            formatting_query,
+            injection_query,
+            grammar,
+            indent: config_language.indent(),
+        })
+    }
+
+    pub(crate) fn cache(&self) -> Arc<LanguageDefinitionCache> {
+        self.cache.clone()
     }
 }
 

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{ops::Deref, path::Path};
@@ -12,14 +13,21 @@ use crate::error::{CLIResult, ResultPreformat};
 use crate::io::to_query_from_language;
 use crate::language::LanguageDefinitionCache;
 
+thread_local! {
+    static NICKEL_VALUES: Cell<Vec<Arc<NickelValue>>> = Cell::new(Vec::new());
+    static NEXT_ID: Cell<u32> = Cell::new(0);
+}
+
 /// Wrapper around Configuration and its raw Nickel representation.
 ///
 /// [`NickelValue`] is used for operations that require the using the Nickel AST,
 /// such as formatting or querying the configuration with Nickel-aware tooling.
+///
+/// The NickelValue is stored in thread-local storage to avoid Send+Sync issues.
 #[derive(Debug, Clone)]
 pub struct Configuration {
     inner: topiary_config::Configuration,
-    ncl: Arc<NickelValue>,
+    ncl_id: u32,
     path: Option<PathBuf>,
     cache: Arc<LanguageDefinitionCache>,
 }
@@ -28,11 +36,44 @@ impl Configuration {
     /// Create a new Configuration by fetching from the given path
     pub fn new(merge: bool, path: Option<&Path>) -> CLIResult<Self> {
         let (inner, ncl) = topiary_config::Configuration::fetch(merge, path).preformat_context()?;
+
+        // Store the NickelValue in thread-local storage
+        let ncl_id = NEXT_ID.with(|id| {
+            let current = id.get();
+            id.set(current + 1);
+            current
+        });
+
+        NICKEL_VALUES.with(|values| {
+            let mut vec = values.take();
+            vec.push(Arc::new(ncl));
+            values.set(vec);
+        });
+
         Ok(Self {
             inner,
-            ncl: Arc::new(ncl),
+            ncl_id,
             path: path.map(|p| p.to_owned()),
             cache: Arc::new(LanguageDefinitionCache::new()),
+        })
+    }
+
+    /// Get the Nickel value for this configuration
+    ///
+    /// Returns an [`Arc<NickelValue>`] which allows cheap cloning via reference counting.
+    /// The reference is guaranteed to be valid because we increment the counter on every
+    /// `Configuration::new()` call, ensuring the index is always within bounds of the thread-local storage.
+    pub fn ncl(&self) -> Arc<NickelValue> {
+        NICKEL_VALUES.with(|values| {
+            let vec = values.take();
+            // SAFETY: We have a guarantee that the index is valid because:
+            // 1. Each `Configuration` stores an `ncl_id` from `NEXT_ID`
+            // 2. Each `Configuration::new()` increments `NEXT_ID` after pushing to `NICKEL_VALUES`
+            // 3. We never remove items from `NICKEL_VALUES,` only add
+            // Therefore, the index is always valid.
+            let result = vec.get(self.ncl_id as usize).unwrap().clone();
+            values.set(vec);
+            result
         })
     }
 
@@ -132,13 +173,13 @@ impl std::fmt::Display for Configuration {
         use topiary_core::{Operation, formatter};
 
         // TODO handle verbose flag
-        let stripped = strip_metadata(self.ncl.as_ref().clone());
+        let stripped = strip_metadata((*self.ncl()).clone());
         let nickel_config = format!("{stripped}");
 
         // if errors are encountered in formatting, return
         let language = match self.get_language("nickel") {
             Ok(lang) => lang,
-            Err(_) => return write!(f, "{}", self.ncl),
+            Err(_) => return write!(f, "{}", self.ncl()),
         };
 
         let mut output = Vec::new();
@@ -152,7 +193,7 @@ impl std::fmt::Display for Configuration {
             },
             None,
         ) {
-            return write!(f, "{}", self.ncl);
+            return write!(f, "{}", self.ncl());
         }
 
         write!(f, "{}", String::from_utf8_lossy(&output))
@@ -162,7 +203,7 @@ impl std::fmt::Display for Configuration {
 #[cfg(not(feature = "nickel"))]
 impl std::fmt::Display for Configuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.ncl)
+        write!(f, "{}", self.ncl())
     }
 }
 

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::{ops::Deref, path::Path};
 
@@ -9,14 +10,13 @@ use topiary_config::source::Source;
 use topiary_core::{
     FormatterError, FormatterResult, InjectionQuery, Language, SpanAttachment, TopiaryQuery,
 };
-use topiary_queries;
 
 use crate::error::{CLIResult, ResultPreformat, TopiaryError};
 use crate::language::LanguageDefinitionCache;
 
 thread_local! {
-    static NICKEL_VALUES: Cell<Vec<Arc<NickelValue>>> = Cell::new(Vec::new());
-    static NEXT_ID: Cell<u32> = Cell::new(0);
+    static NICKEL_VALUES: Cell<Vec<Rc<NickelValue>>> = const { Cell::new(Vec::new()) };
+    static NEXT_ID: Cell<u32> = const { Cell::new(0) };
 }
 
 /// Wrapper around Configuration and its raw Nickel representation.
@@ -47,7 +47,7 @@ impl Configuration {
 
         NICKEL_VALUES.with(|values| {
             let mut vec = values.take();
-            vec.push(Arc::new(ncl));
+            vec.push(Rc::new(ncl));
             values.set(vec);
         });
 
@@ -61,10 +61,10 @@ impl Configuration {
 
     /// Get the Nickel value for this configuration
     ///
-    /// Returns an [`Arc<NickelValue>`] which allows cheap cloning via reference counting.
+    /// Returns an [`Rc<NickelValue>`] which allows cheap cloning via reference counting.
     /// The reference is guaranteed to be valid because we increment the counter on every
     /// `Configuration::new()` call, ensuring the index is always within bounds of the thread-local storage.
-    pub fn ncl(&self) -> Arc<NickelValue> {
+    pub fn ncl(&self) -> Rc<NickelValue> {
         NICKEL_VALUES.with(|values| {
             // `Cell` does not give out mutable references (unsafe in thread-local context);
             // instead one has to take a value, modify/use it, and put it back.

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -21,7 +21,6 @@ use topiary_core::{
 };
 
 use crate::cli::{AtLeastOneInput, ExactlyOneInput, FromStdin};
-#[cfg(feature = "nickel")]
 use crate::config::Configuration;
 use crate::error::{CLIResult, ResultPreformat, TopiaryError};
 

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -7,12 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use nickel_lang_core::eval::value::NickelValue;
-#[cfg(feature = "nickel")]
-use nickel_lang_core::{
-    term::{Term, record::Field},
-    traverse::{Traverse, TraverseOrder},
-};
+use nickel_lang_core::error::NullReporter;
 use rootcause::{
     Report,
     markers::{ObjectMarkerFor, SendSync},
@@ -22,11 +17,13 @@ use rootcause::{
 };
 use rootcause_preformat::PreformatReportExt;
 use tempfile::tempfile;
-use topiary_config::{Configuration, language::LocalRepos};
+use topiary_config::language::LocalRepos;
 use topiary_core::{
     ErrorSpan, FormatterError, InjectionQuery, Language, SpanAttachment, TopiaryQuery,
 };
 
+#[cfg(feature = "nickel")]
+use crate::config::Configuration;
 use crate::{
     cli::{AtLeastOneInput, ExactlyOneInput, FromStdin},
     error::{CLIResult, ResultPreformat, TopiaryError},
@@ -250,7 +247,7 @@ pub(crate) async fn to_language_from_config<T: AsRef<str>>(
     config: &Configuration,
     name: T,
 ) -> CLIResult<Language> {
-    let config_language = config.get_language(name.as_ref()).preformat_context()?;
+    let config_language = config.get_language(name.as_ref())?;
     let grammar = config_language.grammar()?;
     let repos = LocalRepos::new();
     let query_source = to_query_from_language(
@@ -601,91 +598,6 @@ where
         },
         _ => Err(TopiaryError::UnsupportedLanguage(name_str.to_string()).into()),
     }
-}
-
-// Strip field metadata (doc strings, type/contract annotations, `| default`,
-// `| optional`, priority) and unwrap `Term::Annotated` nodes from a NickelValue
-// so that the pretty printer emits a plain data record.
-#[cfg(feature = "nickel")]
-fn strip_metadata(value: NickelValue) -> NickelValue {
-    use nickel_lang_core::eval::value::{RecordData, ValueContent};
-    value
-        .traverse(
-            &mut |v: NickelValue| -> std::result::Result<NickelValue, std::convert::Infallible> {
-                let pos_idx = v.pos_idx();
-                match v.content() {
-                    ValueContent::Record(lens) => {
-                        let Some(record) = lens.take().into_opt() else {
-                            return Ok(NickelValue::record_posless(RecordData::empty())
-                                .with_pos_idx(pos_idx));
-                        };
-                        let fields = record
-                            .fields
-                            .into_iter()
-                            .map(|(id, field)| {
-                                let Field { value, .. } = field;
-                                (id, Field::from(value.unwrap_or_else(NickelValue::null)))
-                            })
-                            .collect();
-                        Ok(NickelValue::record(
-                            RecordData::new_shared_tail(fields, record.attrs, record.sealed_tail),
-                            pos_idx,
-                        ))
-                    }
-                    ValueContent::Term(lens) => {
-                        let term = lens.take();
-                        if let Term::Annotated(data) = term {
-                            Ok(data.inner.clone())
-                        } else {
-                            Ok(NickelValue::term(term, pos_idx))
-                        }
-                    }
-                    other => Ok(other.restore()),
-                }
-            },
-            TraverseOrder::BottomUp,
-        )
-        .unwrap_or_else(|never: std::convert::Infallible| match never {})
-}
-
-// uses nickel queries and topiary proper to format the nickel record
-#[cfg(feature = "nickel")]
-pub(crate) async fn format_config(
-    config: &Configuration,
-    config_ncl: &NickelValue,
-    output: &mut impl io::Write,
-) -> CLIResult<()> {
-    use topiary_core::{Operation, formatter};
-
-    // TODO handle verbose flag
-    let stripped = strip_metadata(config_ncl.clone());
-    let nickel_config = format!("{stripped}");
-    // if errors are encountered in formatting, return
-    let language = to_language_from_config(config, "nickel").await?;
-
-    formatter(
-        &mut nickel_config.as_bytes(),
-        output,
-        &language,
-        Operation::Format {
-            skip_idempotence: true,
-            tolerate_parsing_errors: false,
-        },
-        None,
-    )?;
-
-    Ok(())
-}
-
-#[cfg(not(feature = "nickel"))]
-pub(crate) async fn format_config(
-    _config: &Configuration,
-    config_ncl: &NickelValue,
-    output: &mut impl io::Write,
-) -> CLIResult<()> {
-    write!(output, "{config_ncl}")?;
-
-    Ok(())
 }
 
 // meant to be used in scenarios where multiple inputs are possible

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -64,7 +64,7 @@ impl Display for QuerySource {
 }
 
 impl QuerySource {
-    fn filepath(&self) -> Option<&Path> {
+    pub(crate) fn filepath(&self) -> Option<&Path> {
         match self {
             QuerySource::Path(p) => Some(p.as_path()),
             QuerySource::BuiltIn(_) => None,
@@ -80,7 +80,7 @@ impl QuerySource {
         Ok(contents)
     }
 
-    fn get_content_sync(&self) -> CLIResult<String> {
+    pub(crate) fn get_content_sync(&self) -> CLIResult<String> {
         let contents = match self {
             Self::Path(query) => std::fs::read_to_string(query)?,
             Self::BuiltIn(contents) => contents.to_owned(),
@@ -242,84 +242,6 @@ impl InputFile<'_> {
     }
 }
 
-#[cfg(feature = "nickel")]
-pub(crate) async fn to_language_from_config<T: AsRef<str>>(
-    config: &Configuration,
-    name: T,
-) -> CLIResult<Language> {
-    let config_language = config.get_language(name.as_ref())?;
-    let grammar = config_language.grammar()?;
-    let repos = LocalRepos::new();
-    let query_source = to_query_from_language(
-        config_language,
-        topiary_queries::FORMATTING_QUERY,
-        Some(&repos),
-    )?;
-    let query_content = query_source.get_content().await?;
-    let formatting_query = TopiaryQuery::new(&grammar, &query_content)
-        .attach_filepath(query_source.filepath())
-        .context(FormatterError::Parsing)?;
-    let injection_query = match to_query_from_language(
-        config_language,
-        topiary_queries::INJECTIONS_QUERY,
-        Some(&repos),
-    )
-    .ok()
-    {
-        Some(source) => {
-            let contents = source.get_content().await?;
-            Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
-        }
-        None => None,
-    };
-
-    Ok(Language {
-        name: name.as_ref().to_string(),
-        formatting_query,
-        injection_query,
-        grammar,
-        indent: config_language.indent(),
-    })
-}
-
-pub(crate) fn to_language_from_config_sync<T: AsRef<str> + fmt::Display>(
-    config: &Configuration,
-    name: T,
-) -> CLIResult<Language> {
-    let config_language = config.get_language(name.as_ref()).preformat_context()?;
-    let grammar = config_language.grammar()?;
-    let repos = LocalRepos::new();
-    let query_source = to_query_from_language(
-        config_language,
-        topiary_queries::FORMATTING_QUERY,
-        Some(&repos),
-    )?;
-    let query_content = query_source.get_content_sync()?;
-    let formatting_query = TopiaryQuery::new(&grammar, &query_content)
-        .attach_filepath(query_source.filepath())
-        .context(FormatterError::Parsing)?;
-    let injection_query = match to_query_from_language(
-        config_language,
-        topiary_queries::INJECTIONS_QUERY,
-        Some(&repos),
-    )
-    .ok()
-    {
-        Some(source) => {
-            let contents = source.get_content_sync()?;
-            Some(InjectionQuery::new(&grammar, &contents).attach_filepath(source.filepath())?)
-        }
-        None => None,
-    };
-
-    Ok(Language {
-        name: name.as_ref().to_string(),
-        formatting_query,
-        injection_query,
-        grammar,
-        indent: config_language.indent(),
-    })
-}
 /// Simple helper function to read the full content of an io Read stream
 pub(crate) fn read_input(input: &mut dyn io::Read) -> CLIResult<String> {
     let mut content = String::new();
@@ -357,7 +279,7 @@ impl<'cfg, 'i> Inputs<'cfg> {
             InputFrom::Stdin(language_name, query) => {
                 vec![(|| {
                     let language = config
-                        .get_language(&language_name)
+                        .get_language_cfg(&language_name)
                         .map_err(|e| report!(e).preformat())
                         .context(TopiaryError::Config)?;
                     let query_source: QuerySource = match query {

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -7,7 +7,6 @@ use std::{
     sync::Arc,
 };
 
-use nickel_lang_core::error::NullReporter;
 use rootcause::{
     Report,
     markers::{ObjectMarkerFor, SendSync},
@@ -17,7 +16,6 @@ use rootcause::{
 };
 use rootcause_preformat::PreformatReportExt;
 use tempfile::tempfile;
-use topiary_config::language::LocalRepos;
 use topiary_core::{
     ErrorSpan, FormatterError, InjectionQuery, Language, SpanAttachment, TopiaryQuery,
 };
@@ -66,15 +64,6 @@ impl QuerySource {
             QuerySource::Path(p) => Some(p.as_path()),
             QuerySource::BuiltIn(_) => None,
         }
-    }
-
-    #[cfg(feature = "nickel")]
-    async fn get_content(&self) -> CLIResult<String> {
-        let contents = match self {
-            Self::Path(query) => tokio::fs::read_to_string(query).await?,
-            Self::BuiltIn(contents) => contents.to_owned(),
-        };
-        Ok(contents)
     }
 
     pub(crate) fn get_content_sync(&self) -> CLIResult<String> {
@@ -271,7 +260,6 @@ impl<'cfg, 'i> Inputs<'cfg> {
     where
         &'i T: Into<InputFrom>,
     {
-        let repos = LocalRepos::new();
         let inputs = match inputs.into() {
             InputFrom::Stdin(language_name, query) => {
                 vec![(|| {
@@ -283,18 +271,12 @@ impl<'cfg, 'i> Inputs<'cfg> {
                         // The user specified a query file
                         Some(p) => p,
                         // The user did not specify a file, try the default locations
-                        None => to_query_from_language(
-                            language,
-                            topiary_queries::FORMATTING_QUERY,
-                            Some(&repos),
-                        )?,
+                        None => config
+                            .get_query_source(&language_name, topiary_queries::FORMATTING_QUERY)?,
                     };
-                    let injection_query = to_query_from_language(
-                        language,
-                        topiary_queries::INJECTIONS_QUERY,
-                        Some(&repos),
-                    )
-                    .ok();
+                    let injection_query = config
+                        .get_query_source(&language_name, topiary_queries::INJECTIONS_QUERY)
+                        .ok();
                     Ok(InputFile {
                         source: InputSource::Stdin,
                         language,
@@ -307,17 +289,12 @@ impl<'cfg, 'i> Inputs<'cfg> {
                 .into_iter()
                 .map(|path| {
                     let language = config.detect(&path).preformat_context()?;
-                    let query: QuerySource = to_query_from_language(
-                        language,
-                        topiary_queries::FORMATTING_QUERY,
-                        Some(&repos),
-                    )?;
-                    let injection_query = to_query_from_language(
-                        language,
-                        topiary_queries::INJECTIONS_QUERY,
-                        Some(&repos),
-                    )
-                    .ok();
+                    let language_name = language.name.clone();
+                    let query: QuerySource = config
+                        .get_query_source(&language_name, topiary_queries::FORMATTING_QUERY)?;
+                    let injection_query = config
+                        .get_query_source(&language_name, topiary_queries::INJECTIONS_QUERY)
+                        .ok();
 
                     Ok(InputFile {
                         source: InputSource::Disk(path.into(), None),
@@ -333,32 +310,6 @@ impl<'cfg, 'i> Inputs<'cfg> {
     }
 }
 
-pub(crate) fn to_query_from_language(
-    language: &topiary_config::language::Language,
-    query_name: &str,
-    repos: Option<&LocalRepos>,
-) -> CLIResult<QuerySource> {
-    let find = match repos {
-        Some(repos) => language.find_query_file_with(query_name, repos),
-        None => language.find_query_file(query_name),
-    };
-    let query: QuerySource = match find {
-        Ok(p) => p.into(),
-        // For some reason, Topiary could not find any
-        // matching file in a default location. As a final attempt, try the
-        // builtin ones. Store the error, return that if we
-        // fail to find anything, because the builtin error might be unexpected.
-        Err(e) => {
-            log::warn!(
-                "No {query_name} query files found in any of the expected locations. Falling back to compile-time included files."
-            );
-            to_query_from_builtin(&language.name, query_name)
-                .local_context(e)
-                .preformat_context()?
-        }
-    };
-    Ok(query)
-}
 impl<'cfg> Iterator for Inputs<'cfg> {
     type Item = CLIResult<InputFile<'cfg>>;
 
@@ -448,74 +399,6 @@ impl TryFrom<&InputFile<'_>> for OutputFile {
             InputSource::Stdin => Ok(Self::Stdout),
             InputSource::Disk(path, _) => Self::new(path.to_string_lossy().as_ref()),
         }
-    }
-}
-
-fn to_query_from_builtin<T, Q>(language: T, query: Q) -> CLIResult<QuerySource>
-where
-    T: AsRef<str> + fmt::Display,
-    Q: AsRef<str>,
-{
-    let name_str = language.as_ref();
-    match query.as_ref() {
-        topiary_queries::FORMATTING_QUERY => match name_str {
-            #[cfg(feature = "bash")]
-            "bash" => Ok(topiary_queries::bash().into()),
-
-            #[cfg(feature = "css")]
-            "css" => Ok(topiary_queries::css().into()),
-
-            #[cfg(feature = "json")]
-            "json" => Ok(topiary_queries::json().into()),
-
-            #[cfg(feature = "markdown")]
-            "markdown" => Ok(topiary_queries::markdown().into()),
-
-            #[cfg(feature = "nickel")]
-            "nickel" => Ok(topiary_queries::nickel().into()),
-
-            #[cfg(feature = "ocaml")]
-            "ocaml" => Ok(topiary_queries::ocaml().into()),
-
-            #[cfg(feature = "ocaml_interface")]
-            "ocaml_interface" => Ok(topiary_queries::ocaml_interface().into()),
-
-            #[cfg(feature = "ocamllex")]
-            "ocamllex" => Ok(topiary_queries::ocamllex().into()),
-
-            #[cfg(feature = "openscad")]
-            "openscad" => Ok(topiary_queries::openscad().into()),
-
-            #[cfg(feature = "rust")]
-            "rust" => Ok(topiary_queries::rust().into()),
-
-            #[cfg(feature = "sdml")]
-            "sdml" => Ok(topiary_queries::sdml().into()),
-
-            #[cfg(feature = "toml")]
-            "toml" => Ok(topiary_queries::toml().into()),
-
-            #[cfg(feature = "tree_sitter_query")]
-            "tree_sitter_query" => Ok(topiary_queries::tree_sitter_query().into()),
-
-            #[cfg(feature = "wit")]
-            "wit" => Ok(topiary_queries::wit().into()),
-
-            _ => Err(TopiaryError::UnsupportedLanguage(name_str.to_string()).into()),
-        },
-        topiary_queries::INJECTIONS_QUERY => match name_str {
-            #[cfg(feature = "markdown")]
-            "markdown" => Ok(topiary_queries::markdown_injections().into()),
-
-            #[cfg(feature = "ocamllex")]
-            "ocamllex" => Ok(topiary_queries::ocamllex_injections().into()),
-
-            #[cfg(feature = "rust")]
-            "rust" => Ok(topiary_queries::rust_injections().into()),
-
-            _ => Err(TopiaryError::UnsupportedLanguage(name_str.to_string()).into()),
-        },
-        _ => Err(TopiaryError::UnsupportedLanguage(name_str.to_string()).into()),
     }
 }
 

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -22,13 +22,10 @@ use topiary_core::{
     ErrorSpan, FormatterError, InjectionQuery, Language, SpanAttachment, TopiaryQuery,
 };
 
+use crate::cli::{AtLeastOneInput, ExactlyOneInput, FromStdin};
 #[cfg(feature = "nickel")]
 use crate::config::Configuration;
-use crate::{
-    cli::{AtLeastOneInput, ExactlyOneInput, FromStdin},
-    error::{CLIResult, ResultPreformat, TopiaryError},
-    language::LanguageDefinitionCache,
-};
+use crate::error::{CLIResult, ResultPreformat, TopiaryError};
 
 #[derive(Debug, Clone, Hash)]
 pub enum QuerySource {
@@ -526,10 +523,10 @@ where
 pub(crate) async fn process_inputs<F>(
     inputs: Inputs<'_>,
     process_fn: F,
-    cache: Arc<LanguageDefinitionCache>,
+    config: Arc<crate::config::Configuration>,
 ) -> CLIResult<()>
 where
-    F: Fn(InputFile, Arc<Language>, Arc<LanguageDefinitionCache>) -> Result<(), Report>
+    F: Fn(InputFile, Arc<Language>, Arc<Configuration>) -> Result<(), Report>
         + Send
         + Sync
         + 'static,
@@ -537,16 +534,21 @@ where
 {
     let (_, mut results) = async_scoped::TokioScope::scope_and_block(|scope| {
         for input in inputs {
-            let cache = cache.clone();
             let process_fn = &process_fn;
+            let config = config.clone();
             scope.spawn(async move {
                 // This happens when the input resolver cannot establish an input
                 // source, language or query file.
                 let input = input?;
                 let location = input.source().location();
                 tokio::task::block_in_place(|| {
-                    let language = cache.fetch_input(&input)?;
-                    process_fn(input, language, cache)
+                    let language_name = input.language().name.clone();
+                    let language = Arc::new(
+                        config
+                            .get_language(&language_name)
+                            .attach_filepath(location.to_path())?,
+                    );
+                    process_fn(input, language, config)
                         .map_err(|e| e.attach_filepath(location.to_path()))
                 })
             });

--- a/topiary-cli/src/language.rs
+++ b/topiary-cli/src/language.rs
@@ -10,7 +10,6 @@ use std::{
 use crate::Configuration;
 use topiary_config::language::LocalRepos;
 use topiary_core::Language;
-use topiary_queries;
 
 use crate::error::CLIResult;
 use crate::io::InputFile;

--- a/topiary-cli/src/language.rs
+++ b/topiary-cli/src/language.rs
@@ -10,11 +10,10 @@ use std::{
 use crate::Configuration;
 use topiary_config::language::LocalRepos;
 use topiary_core::Language;
+use topiary_queries;
 
-use crate::{
-    error::{CLIResult, ResultPreformat},
-    io::{InputFile, to_query_from_language},
-};
+use crate::error::CLIResult;
+use crate::io::InputFile;
 
 /// Thread-safe language definition cache
 #[derive(Debug)]
@@ -29,6 +28,10 @@ impl LanguageDefinitionCache {
             languages: Mutex::new(HashMap::new()),
             repos: LocalRepos::new(),
         }
+    }
+
+    pub fn repos(&self) -> &LocalRepos {
+        &self.repos
     }
 
     fn key_for_parts(
@@ -97,18 +100,10 @@ impl LanguageDefinitionCache {
         config: &Configuration,
         name: &str,
     ) -> CLIResult<Arc<Language>> {
-        let config_language = config.get_language_cfg(name).preformat_context()?;
-        let formatting_query = to_query_from_language(
-            config_language,
-            topiary_queries::FORMATTING_QUERY,
-            Some(&self.repos),
-        )?;
-        let injection_query = to_query_from_language(
-            config_language,
-            topiary_queries::INJECTIONS_QUERY,
-            Some(&self.repos),
-        )
-        .ok();
+        let formatting_query = config.get_query_source(name, topiary_queries::FORMATTING_QUERY)?;
+        let injection_query = config
+            .get_query_source(name, topiary_queries::INJECTIONS_QUERY)
+            .ok();
         let key = Self::key_for_parts(name, &formatting_query, injection_query.as_ref());
 
         let mut cache = self

--- a/topiary-cli/src/language.rs
+++ b/topiary-cli/src/language.rs
@@ -7,15 +7,17 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use topiary_config::{Configuration, language::LocalRepos};
+use crate::Configuration;
+use topiary_config::language::LocalRepos;
 use topiary_core::Language;
 
 use crate::{
     error::{CLIResult, ResultPreformat},
-    io::{InputFile, to_language_from_config_sync, to_query_from_language},
+    io::{InputFile, to_query_from_language},
 };
 
 /// Thread-safe language definition cache
+#[derive(Debug)]
 pub struct LanguageDefinitionCache {
     languages: Mutex<HashMap<u64, Arc<Language>>>,
     repos: LocalRepos,
@@ -95,7 +97,7 @@ impl LanguageDefinitionCache {
         config: &Configuration,
         name: &str,
     ) -> CLIResult<Arc<Language>> {
-        let config_language = config.get_language(name).preformat_context()?;
+        let config_language = config.get_language_cfg(name).preformat_context()?;
         let formatting_query = to_query_from_language(
             config_language,
             topiary_queries::FORMATTING_QUERY,
@@ -122,7 +124,7 @@ impl LanguageDefinitionCache {
 
             Entry::Vacant(slot) => {
                 log::debug!("Cache {:p}: Insert at {:#016x} ({name})", self, key);
-                let lang_def = Arc::new(to_language_from_config_sync(config, name)?);
+                let lang_def = Arc::new(config.get_language(name)?);
                 slot.insert(lang_def).to_owned()
             }
         })

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -25,27 +25,28 @@ use topiary_core::{
 
 use crate::{
     cli::Commands,
-    config::Configuration,
     error::{CLIResult, exit_code},
     io::{Inputs, OutputFile, process_inputs, read_input},
     language::LanguageDefinitionCache,
 };
+pub(crate) use config::Configuration;
 
 use miette::NamedSource;
 
 fn resolve_injected_language(
-    _cache: &LanguageDefinitionCache,
-    config: &topiary_config::Configuration,
+    config: &Configuration,
     name: &str,
 ) -> FormatterResult<Option<Arc<Language>>> {
     if matches!(
-        config.get_language(name),
-        Err(topiary_config::error::TopiaryConfigError::UnknownLanguage(_))
+        config.get_language_cfg(name),
+        Err(topiary_config::error::TopiaryConfigError::UnknownLanguage(
+            _
+        ))
     ) {
         return Ok(None);
     }
 
-    match crate::io::to_language_from_config_sync(config, name) {
+    match config.get_language(name) {
         Ok(language) => Ok(Some(Arc::new(language))),
         Err(report) => Err(report.context(FormatterError::InjectionLanguageResolution {
             language: name.to_owned(),
@@ -105,7 +106,7 @@ async fn run() -> CLIResult<()> {
                         &language,
                         skip_idempotence,
                         tolerate_parsing_errors,
-                        Some(&|name| resolve_injected_language(&cache, inner_config, name)),
+                        Some(&|name| resolve_injected_language(inner_config, name)),
                     )
                     .attach_filepath(filepath.as_deref())
                 },
@@ -153,7 +154,7 @@ async fn run() -> CLIResult<()> {
                                 skip_idempotence,
                                 tolerate_parsing_errors,
                             },
-                            Some(&|name| resolve_injected_language(&cache, inner_config, name)),
+                            Some(&|name| resolve_injected_language(inner_config, name)),
                         )?;
                     }
 
@@ -227,7 +228,8 @@ async fn run() -> CLIResult<()> {
                     false => "\u{274C}", // Cross Mark
                 }
             };
-            let sources = config.config_sources()
+            let sources = config
+                .config_sources()
                 .map(|(hint, source)| {
                     let languages_exists = bool_emoji(source.languages_exists());
                     let queries_exists =

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -8,7 +8,6 @@ mod language;
 mod visualisation;
 
 use std::{
-    cell::OnceCell,
     io::{BufReader, BufWriter, Write},
     process::ExitCode,
     sync::Arc,
@@ -17,7 +16,6 @@ use std::{
 use error::Benign;
 use rootcause::prelude::ResultExt;
 use tabled::{Table, settings::Style};
-use topiary_config::error::TopiaryConfigError;
 use topiary_core::{
     FormatterError, FormatterResult, Language, Operation, SpanAttachment, check_query_coverage,
     formatter,
@@ -27,7 +25,6 @@ use crate::{
     cli::Commands,
     error::{CLIResult, exit_code},
     io::{Inputs, OutputFile, process_inputs, read_input},
-    language::LanguageDefinitionCache,
 };
 pub(crate) use config::Configuration;
 
@@ -69,16 +66,10 @@ async fn main() -> ExitCode {
 async fn run() -> CLIResult<()> {
     let args = cli::get_args()?;
 
-    let config = Configuration::new(
+    let config = Arc::new(Configuration::new(
         args.global.merge_configuration,
         args.global.configuration.as_deref(),
-    )?;
-    let cache_cell = OnceCell::new();
-    let get_cache = || {
-        cache_cell
-            .get_or_init(|| Arc::new(LanguageDefinitionCache::new()))
-            .clone()
-    };
+    )?);
 
     // Delegate by subcommand
     match args.command {
@@ -89,10 +80,9 @@ async fn run() -> CLIResult<()> {
             inputs,
         } => {
             let inputs = Inputs::new(&config, &inputs);
-            let inner_config = config.as_ref();
             process_inputs(
                 inputs,
-                move |input, language, cache| {
+                move |input, language, config| {
                     log::info!(
                         "Checking {}, as {} using {}",
                         input.source(),
@@ -106,11 +96,11 @@ async fn run() -> CLIResult<()> {
                         &language,
                         skip_idempotence,
                         tolerate_parsing_errors,
-                        Some(&|name| resolve_injected_language(inner_config, name)),
+                        Some(&|name| resolve_injected_language(&config, name)),
                     )
                     .attach_filepath(filepath.as_deref())
                 },
-                get_cache(),
+                config.clone(),
             )
             .await?;
         }
@@ -121,11 +111,10 @@ async fn run() -> CLIResult<()> {
             ..
         } => {
             let inputs = Inputs::new(&config, &inputs);
-            let inner_config = config.as_ref();
 
             process_inputs(
                 inputs,
-                move |input, language, cache| {
+                move |input, language, config| {
                     let output = OutputFile::try_from(&input)?;
 
                     log::info!(
@@ -154,7 +143,7 @@ async fn run() -> CLIResult<()> {
                                 skip_idempotence,
                                 tolerate_parsing_errors,
                             },
-                            Some(&|name| resolve_injected_language(inner_config, name)),
+                            Some(&|name| resolve_injected_language(&config, name)),
                         )?;
                     }
 
@@ -162,7 +151,7 @@ async fn run() -> CLIResult<()> {
 
                     CLIResult::Ok(())
                 },
-                get_cache(),
+                config.clone(),
             )
             .await?;
         }
@@ -172,7 +161,7 @@ async fn run() -> CLIResult<()> {
 
             process_inputs(
                 inputs,
-                |mut input, language, _cache| {
+                |mut input, language, config| {
                     let input_content = read_input(&mut input)?;
                     log::debug!(
                         "Checking {}, as {} for grammar correctness",
@@ -184,7 +173,7 @@ async fn run() -> CLIResult<()> {
 
                     Ok(())
                 },
-                get_cache(),
+                config.clone(),
             )
             .await?;
         }
@@ -194,7 +183,7 @@ async fn run() -> CLIResult<()> {
             let input = Inputs::new(&config, &input).next().unwrap()?;
             let output = OutputFile::Stdout;
 
-            let language = tokio::task::block_in_place(|| get_cache().fetch_input(&input))?;
+            let language = tokio::task::block_in_place(|| config.cache().fetch_input(&input))?;
 
             log::info!(
                 "Visualising {}, as {}, to {}",
@@ -275,7 +264,7 @@ async fn run() -> CLIResult<()> {
             let input = Inputs::new(&config, &input).next().unwrap()?;
             let output = OutputFile::Stdout;
 
-            let language = tokio::task::block_in_place(|| get_cache().fetch_input(&input))?;
+            let language = tokio::task::block_in_place(|| config.cache().fetch_input(&input))?;
 
             log::info!(
                 "Checking query coverage of {}, as {}",

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 use error::Benign;
 use tabled::{Table, settings::Style};
 use topiary_core::{
-    FormatterError, FormatterResult, Language, Operation, SpanAttachment, check_query_coverage,
+    Operation, SpanAttachment, check_query_coverage,
     formatter,
 };
 

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -15,10 +15,7 @@ use std::{
 
 use error::Benign;
 use tabled::{Table, settings::Style};
-use topiary_core::{
-    Operation, SpanAttachment, check_query_coverage,
-    formatter,
-};
+use topiary_core::{Operation, SpanAttachment, check_query_coverage, formatter};
 
 use crate::{
     cli::Commands,

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -14,7 +14,6 @@ use std::{
 };
 
 use error::Benign;
-use rootcause::prelude::ResultExt;
 use tabled::{Table, settings::Style};
 use topiary_core::{
     FormatterError, FormatterResult, Language, Operation, SpanAttachment, check_query_coverage,
@@ -29,27 +28,6 @@ use crate::{
 pub(crate) use config::Configuration;
 
 use miette::NamedSource;
-
-fn resolve_injected_language(
-    config: &Configuration,
-    name: &str,
-) -> FormatterResult<Option<Arc<Language>>> {
-    if matches!(
-        config.get_language_cfg(name),
-        Err(topiary_config::error::TopiaryConfigError::UnknownLanguage(
-            _
-        ))
-    ) {
-        return Ok(None);
-    }
-
-    match config.get_language(name) {
-        Ok(language) => Ok(Some(Arc::new(language))),
-        Err(report) => Err(report.context(FormatterError::InjectionLanguageResolution {
-            language: name.to_owned(),
-        })),
-    }
-}
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -96,7 +74,7 @@ async fn run() -> CLIResult<()> {
                         &language,
                         skip_idempotence,
                         tolerate_parsing_errors,
-                        Some(&|name| resolve_injected_language(&config, name)),
+                        Some(&|name| config.resolve_injected_language(name)),
                     )
                     .attach_filepath(filepath.as_deref())
                 },
@@ -143,7 +121,7 @@ async fn run() -> CLIResult<()> {
                                 skip_idempotence,
                                 tolerate_parsing_errors,
                             },
-                            Some(&|name| resolve_injected_language(&config, name)),
+                            Some(&|name| config.resolve_injected_language(name)),
                         )?;
                     }
 
@@ -161,7 +139,7 @@ async fn run() -> CLIResult<()> {
 
             process_inputs(
                 inputs,
-                |mut input, language, config| {
+                |mut input, language, _config| {
                     let input_content = read_input(&mut input)?;
                     log::debug!(
                         "Checking {}, as {} for grammar correctness",
@@ -218,7 +196,7 @@ async fn run() -> CLIResult<()> {
                 }
             };
             let sources = config
-                .config_sources()
+                .iter_sources()
                 .map(|(hint, source)| {
                     let languages_exists = bool_emoji(source.languages_exists());
                     let queries_exists =

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod check;
 mod cli;
+mod config;
 mod error;
 mod fs;
 mod io;
@@ -16,7 +17,7 @@ use std::{
 use error::Benign;
 use rootcause::prelude::ResultExt;
 use tabled::{Table, settings::Style};
-use topiary_config::{Configuration, error::TopiaryConfigError, source::Source};
+use topiary_config::error::TopiaryConfigError;
 use topiary_core::{
     FormatterError, FormatterResult, Language, Operation, SpanAttachment, check_query_coverage,
     formatter,
@@ -24,7 +25,8 @@ use topiary_core::{
 
 use crate::{
     cli::Commands,
-    error::{CLIResult, ResultPreformat, exit_code},
+    config::Configuration,
+    error::{CLIResult, exit_code},
     io::{Inputs, OutputFile, process_inputs, read_input},
     language::LanguageDefinitionCache,
 };
@@ -32,19 +34,19 @@ use crate::{
 use miette::NamedSource;
 
 fn resolve_injected_language(
-    cache: &LanguageDefinitionCache,
-    config: &Configuration,
+    _cache: &LanguageDefinitionCache,
+    config: &topiary_config::Configuration,
     name: &str,
 ) -> FormatterResult<Option<Arc<Language>>> {
     if matches!(
         config.get_language(name),
-        Err(TopiaryConfigError::UnknownLanguage(_))
+        Err(topiary_config::error::TopiaryConfigError::UnknownLanguage(_))
     ) {
         return Ok(None);
     }
 
-    match cache.fetch_from_config(config, name) {
-        Ok(language) => Ok(Some(language)),
+    match crate::io::to_language_from_config_sync(config, name) {
+        Ok(language) => Ok(Some(Arc::new(language))),
         Err(report) => Err(report.context(FormatterError::InjectionLanguageResolution {
             language: name.to_owned(),
         })),
@@ -66,10 +68,10 @@ async fn main() -> ExitCode {
 async fn run() -> CLIResult<()> {
     let args = cli::get_args()?;
 
-    let config_path = &args.global.configuration;
-    let (config, nickel_config) =
-        topiary_config::Configuration::fetch(args.global.merge_configuration, config_path)
-            .preformat_context()?;
+    let config = Configuration::new(
+        args.global.merge_configuration,
+        args.global.configuration.as_deref(),
+    )?;
     let cache_cell = OnceCell::new();
     let get_cache = || {
         cache_cell
@@ -86,7 +88,7 @@ async fn run() -> CLIResult<()> {
             inputs,
         } => {
             let inputs = Inputs::new(&config, &inputs);
-            let config = config.clone();
+            let inner_config = config.as_ref();
             process_inputs(
                 inputs,
                 move |input, language, cache| {
@@ -103,7 +105,7 @@ async fn run() -> CLIResult<()> {
                         &language,
                         skip_idempotence,
                         tolerate_parsing_errors,
-                        Some(&|name| resolve_injected_language(&cache, &config, name)),
+                        Some(&|name| resolve_injected_language(&cache, inner_config, name)),
                     )
                     .attach_filepath(filepath.as_deref())
                 },
@@ -118,7 +120,7 @@ async fn run() -> CLIResult<()> {
             ..
         } => {
             let inputs = Inputs::new(&config, &inputs);
-            let config = config.clone();
+            let inner_config = config.as_ref();
 
             process_inputs(
                 inputs,
@@ -151,7 +153,7 @@ async fn run() -> CLIResult<()> {
                                 skip_idempotence,
                                 tolerate_parsing_errors,
                             },
-                            Some(&|name| resolve_injected_language(&cache, &config, name)),
+                            Some(&|name| resolve_injected_language(&cache, inner_config, name)),
                         )?;
                     }
 
@@ -225,7 +227,7 @@ async fn run() -> CLIResult<()> {
                     false => "\u{274C}", // Cross Mark
                 }
             };
-            let sources = Source::config_sources(config_path)
+            let sources = config.config_sources()
                 .map(|(hint, source)| {
                     let languages_exists = bool_emoji(source.languages_exists());
                     let queries_exists =
@@ -243,30 +245,27 @@ async fn run() -> CLIResult<()> {
 
         Commands::Config {
             command: None,
-            field,
+            field: Some(field),
         } => {
-            let nickel_config = match field {
-                Some(field_path) => Configuration::extract_field(
-                    args.global.merge_configuration,
-                    config_path,
-                    &field_path,
-                )
-                .preformat_context()?,
-                None => nickel_config,
-            };
+            let nickel_config = config.extract_field(args.global.merge_configuration, &field)?;
 
             // Output the collated nickel configuration.
-            // Don't fail on error but merely log the event since the original `nickel_config` is
-            // already valid.
             let mut output = std::io::BufWriter::new(OutputFile::Stdout);
-            io::format_config(&config, &nickel_config, &mut output)
-                .await
-                .attach("Config formatting error")?;
+            write!(output, "{nickel_config}")?;
+        }
+
+        Commands::Config {
+            command: None,
+            field: None,
+        } => {
+            // Output the collated nickel configuration.
+            let mut output = std::io::BufWriter::new(OutputFile::Stdout);
+            write!(output, "{config}")?;
         }
 
         Commands::Prefetch { force, language } => match language {
-            Some(l) => config.prefetch_language(l, force).preformat_context()?,
-            _ => config.prefetch_languages(force).preformat_context()?,
+            Some(l) => config.prefetch_language(l, force)?,
+            _ => config.prefetch_languages(force)?,
         },
 
         Commands::Coverage { input } => {

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -159,7 +159,7 @@ impl Language {
     /// Locate a query file for this language by well-known name (e.g. `"formatting"`,
     /// `"injections"`, matching the constants exported by `topiary-queries`).
     ///
-    /// Prefer `languages.<language>.<query_name>` config entires over implicit query paths.
+    /// Prefer `languages.<language>.<query_name>` config entries over implicit query paths.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn find_query_file(&self, query_name: &str) -> TopiaryConfigResult<PathBuf> {
         self.find_query_file_with(query_name, &LocalRepos::new())

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -193,7 +193,7 @@ impl Language {
         let potentials: [Option<PathBuf>; 5] = [
             std::env::var("TOPIARY_LANGUAGE_DIR").map(PathBuf::from).ok(),
             option_env!("TOPIARY_LANGUAGE_DIR").map(PathBuf::from),
-            Source::fetch_one(&None).queries_dir(),
+            Source::fetch_one(None).queries_dir(),
             Some(PathBuf::from("./topiary-queries/queries")),
             Some(PathBuf::from("../topiary-queries/queries")),
         ];

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -601,7 +601,7 @@ mod tests {
 
         let (config, _) = crate::Configuration::fetch(false, &Some(config_file)).unwrap();
         let formatting = config
-            .get_language("markdown")
+            .get_language_cfg("markdown")
             .unwrap()
             .config_query("formatting")
             .unwrap();

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -55,7 +55,7 @@ impl Configuration {
     /// with the path that was not found.
     /// If the configuration file exists, but cannot be parsed, this function will return a
     /// `TopiaryConfigError` with the error that occurred.
-    pub fn fetch(merge: bool, file: &Option<PathBuf>) -> TopiaryConfigResult<(Self, NickelValue)> {
+    pub fn fetch(merge: bool, file: Option<&Path>) -> TopiaryConfigResult<(Self, NickelValue)> {
         // If we have an explicit file, fail if it doesn't exist
         if let Some(path) = file
             && !path.exists()
@@ -247,9 +247,9 @@ impl Configuration {
         }
 
         let sources: Vec<Source> = if merge {
-            Source::fetch_all(file)
+            Source::fetch_all(file.as_deref())
         } else {
-            match Source::fetch_one(file) {
+            match Source::fetch_one(file.as_deref()) {
                 Source::Builtin => vec![Source::Builtin],
                 source => vec![source, Source::Builtin],
             }

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -84,7 +84,7 @@ impl Configuration {
     ///
     /// If the provided language name cannot be found in the `Configuration`, this
     /// function returns a `TopiaryConfigError`
-    pub fn get_language<T>(&self, name: T) -> TopiaryConfigResult<&Language>
+    pub fn get_language_cfg<T>(&self, name: T) -> TopiaryConfigResult<&Language>
     where
         T: AsRef<str> + fmt::Display,
     {
@@ -177,7 +177,7 @@ impl Configuration {
         T: AsRef<str> + fmt::Display,
     {
         let repos = LocalRepos::new();
-        let l = self.get_language(language)?;
+        let l = self.get_language_cfg(language)?;
         Configuration::fetch_language(l, force, &repos)?;
         Ok(())
     }

--- a/topiary-config/src/source.rs
+++ b/topiary-config/src/source.rs
@@ -42,14 +42,14 @@ impl Source {
     /// 3. `~/.config/topiary/languages.ncl`
     /// 4. OS configuration directory (if different from #3)
     /// 5. Built-in configuration: [`Self::builtin_nickel`]
-    pub fn config_sources(path: &Option<PathBuf>) -> impl Iterator<Item = (&'static str, Self)> {
+    pub fn config_sources(path: Option<&Path>) -> impl Iterator<Item = (&'static str, Self)> {
         let mut sources = Vec::new();
 
         if let Some(path) = path {
             let source = if path.is_dir() {
-                Self::Directory(path.clone())
+                Self::Directory(path.to_owned())
             } else {
-                Self::File(path.clone())
+                Self::File(path.to_owned())
             };
 
             sources.push(("CLI", source));
@@ -86,7 +86,7 @@ impl Source {
     }
 
     // return an iterator containing all config sources that have been shown to exist
-    fn valid_config_sources(file: &Option<PathBuf>) -> impl Iterator<Item = (&'static str, Self)> {
+    fn valid_config_sources(file: Option<&Path>) -> impl Iterator<Item = (&'static str, Self)> {
         Self::config_sources(file).filter_map(|(hint, candidate)| {
             if matches!(candidate, Self::Builtin) {
                 return Some((hint, candidate));
@@ -102,7 +102,7 @@ impl Source {
     }
     /// Return all valid configuration sources.
     /// See [`Self::config_sources`].
-    pub fn fetch_all(file: &Option<PathBuf>) -> Vec<Self> {
+    pub fn fetch_all(file: Option<&Path>) -> Vec<Self> {
         // We always include the built-in configuration, as a fallback
         log::info!("Adding built-in configuration to merge");
         Self::valid_config_sources(file)
@@ -128,7 +128,7 @@ impl Source {
 
     /// Return a valid source of configuration with the highest priority.
     /// See [`Self::config_sources`].
-    pub fn fetch_one(file: &Option<PathBuf>) -> Self {
+    pub fn fetch_one(file: Option<&Path>) -> Self {
         let (hint, source) = Self::valid_config_sources(file)
             .next()
             .expect("built-in should always be present");

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -9,7 +9,11 @@ fn setup() -> (String, Language) {
     // The grammar is loaded dynamically via `topiary-config` rather than
     // depending on the `tree-sitter-nickel` crate directly.
     let config = topiary_config::Configuration::default();
-    let grammar = config.get_language("nickel").unwrap().grammar().unwrap();
+    let grammar = config
+        .get_language_cfg("nickel")
+        .unwrap()
+        .grammar()
+        .unwrap();
 
     let language: Language = Language {
         name: "nickel".to_owned(),

--- a/topiary-core/benches/injections.rs
+++ b/topiary-core/benches/injections.rs
@@ -18,7 +18,7 @@ fn language_from_config(
     formatting_query_content: &str,
     injection_query_content: Option<&str>,
 ) -> Language {
-    let config_language = config.get_language(name).unwrap();
+    let config_language = config.get_language_cfg(name).unwrap();
     let grammar = config_language.grammar().unwrap();
 
     Language {

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -231,7 +231,7 @@ pub enum Operation {
 /// // The grammar is loaded dynamically via `topiary-config` rather than
 /// // depending on the `tree-sitter-json` crate directly.
 /// let config = topiary_config::Configuration::default();
-/// let grammar = config.get_language("json").unwrap().grammar().unwrap();
+/// let grammar = config.get_language_cfg("json").unwrap().grammar().unwrap();
 ///
 /// let language: Language = Language {
 ///     name: "json".to_owned(),

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -526,7 +526,7 @@ mod tests {
 
     fn language(name: &str, formatting_query: &str, injection_query: Option<&str>) -> Language {
         let config = topiary_config::Configuration::default();
-        let config_language = config.get_language(name).unwrap();
+        let config_language = config.get_language_cfg(name).unwrap();
         let grammar = config_language.grammar().unwrap();
 
         Language {


### PR DESCRIPTION
# Move topiary-cli configuration logic into its own module

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves https://github.com/topiary/topiary/pull/1299#issuecomment-5124597328

## Description

* Handle configuration management and retrieval in a separate module called `config` for `topiary-cli`
* Add feature flag called `fancy-config` based on nickel feature flag discussions with @Xophmeister 

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated