### PR TITLE
feat(cli): Add rootcause-backtrace to cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -64,9 +64,9 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -131,7 +131,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -158,7 +158,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -175,19 +175,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -205,7 +205,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -225,19 +225,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -250,14 +250,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts
@@ -290,7 +290,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
+ "cpp_demangle",
  "libc",
  "miniz_oxide",
  "object",
@@ -551,6 +552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,7 +758,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -828,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2918,7 +2928,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3324,7 +3334,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3505,6 +3515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rootcause-backtrace"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82d7dc393bb10ce642672cd7db2a8cb045cadf9a23d15582e08d913e6efe720"
+dependencies = [
+ "backtrace",
+ "rootcause",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rootcause-internals"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,7 +3587,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3623,7 +3644,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4085,7 +4106,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4094,7 +4115,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4113,7 +4134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4399,6 +4420,7 @@ dependencies = [
  "pastey",
  "predicates",
  "rootcause",
+ "rootcause-backtrace",
  "rootcause-preformat",
  "similar",
  "tabled",
@@ -4979,7 +5001,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,20 @@ members = [
 default-members = ["topiary-core", "topiary-cli"]
 resolver = "2"
 
+[profile.dev]
+debug = true
+
 [profile.release]
 lto = true
 opt-level = 's'
+# https://docs.rs/rootcause-backtrace/latest/rootcause_backtrace/#debugging-symbols-in-release-builds
+strip = false
+debug = 1
 
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+lto = true
 
 [workspace.dependencies]
 anyhow = "1.0"
@@ -81,6 +87,7 @@ topiary-queries = { version = "0.7.3", path = "./topiary-queries" }
 topiary-tree-sitter-facade = { version = "0.7.3", path = "./topiary-tree-sitter-facade" }
 topiary-web-tree-sitter-sys = { version = "0.7.3", path = "./topiary-web-tree-sitter-sys" }
 similar = "3.1"
+rootcause-backtrace = "0.13.0"
 
 [profile.dev.package.lalrpop]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ members = [
 default-members = ["topiary-core", "topiary-cli"]
 resolver = "2"
 
-[profile.dev]
-debug = true
-
 [profile.release]
 lto = true
 opt-level = 's'
@@ -34,7 +31,7 @@ debug = 1
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
-lto = true
+lto = "thin"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.3"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -28,8 +28,6 @@ path = "src/main.rs"
 async-scoped = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 clap_complete = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
 nickel-lang-core.workspace = true
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "sync", "macros"] }
@@ -43,6 +41,9 @@ tabled = { workspace = true }
 rootcause.workspace = true
 similar = { workspace = true }
 rootcause-preformat.workspace = true
+rootcause-backtrace = { workspace = true }
+log.workspace = true
+env_logger.workspace = true
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/topiary-cli/src/cli.rs
+++ b/topiary-cli/src/cli.rs
@@ -2,10 +2,10 @@
 
 use clap::{ArgAction, ArgGroup, Args, CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, shells::Shell};
-use rootcause::{report, report_collection::ReportCollection};
-use std::{io::stdout, path::PathBuf};
-
 use log::LevelFilter;
+use rootcause::{report, report_collection::ReportCollection};
+use rootcause_backtrace::{BacktraceCollector, BacktraceFilter};
+use std::{io::stdout, path::PathBuf};
 
 use crate::{error::CLIResult, fs, visualisation};
 
@@ -219,17 +219,35 @@ pub fn get_args() -> CLIResult<Cli> {
         args.global.verbose = 2;
     }
 
+    let level = match args.global.verbose {
+        0 => LevelFilter::Error,
+        1 => LevelFilter::Warn,
+        2 => LevelFilter::Info,
+        3 => LevelFilter::Debug,
+        _ => LevelFilter::Trace,
+    };
+
     // This is the earliest point that we can initialise the logger, from the --verbose flags,
     // before any fallible operations have started
-    env_logger::Builder::new()
-        .filter_level(match args.global.verbose {
-            0 => LevelFilter::Error,
-            1 => LevelFilter::Warn,
-            2 => LevelFilter::Info,
-            3 => LevelFilter::Debug,
-            _ => LevelFilter::Trace,
-        })
-        .init();
+    env_logger::Builder::new().filter_level(level).init();
+
+    if level > LevelFilter::Warn {
+        let collector = BacktraceCollector {
+            filter: BacktraceFilter {
+                skipped_initial_crates: &["rootcause", "rootcause-backtrace", "backtrace", "core"],
+                skipped_middle_crates: &["tokio"],
+                skipped_final_crates: &["std", "core"],
+                max_entry_count: 10,
+                show_full_path: false,
+            },
+            capture_backtrace_for_reports_with_children: false, // Only leaf errors
+        };
+
+        rootcause::hooks::Hooks::new()
+            .report_creation_hook(collector)
+            .install()
+            .expect("failed to install hooks");
+    }
 
     // NOTE We do not check that input files are actual files (with Path::is_file), because that
     // would break in the case of, for example, named pipes; thus also adding a platform dimension


### PR DESCRIPTION
# Add rootcause-backtrace to cli

## Description

Passing `-vv` to `topiary` will now return a backtrace for a given error:

```sh-session
$ ./topiary-release-debug-1 fmt foo.sh -vv
[2026-08-05T02:01:35Z ERROR topiary::fs] Skipping foo.sh: Cannot access

 ●
 │  ● No such file or directory (os error 2)
 │  ├ topiary-cli/src/fs.rs:47
 │  ├ Backtrace
 │  │ │ new         - /user/rust/topiary/topiary-cli/src/fs.rs
 │  │ │ traverse    - /user/rust/topiary/topiary-cli/src/fs.rs:115
 │  │ │ get_args    - /user/rust/topiary/topiary-cli/src/cli.rs:283
 │  │ │ {closure#0} - /user/rust/topiary/topiary-cli/src/main.rs:42
 │  │ │ {closure#0} - /user/rust/topiary/topiary-cli/src/main.rs:31
 │  │ │ ... omitted 10 frame(s) from crate 'tokio' ...
 │  │ │ main        - /user/rust/topiary/topiary-cli/src/main.rs:38
 │  │ │ note: 26 frame(s) omitted. For a complete backtrace, set RUST_BACKTRACE=full.
 │  │ ╰─
 │  ╰ foo.sh
 ├ topiary-cli/src/cli.rs:287
 ╰ Backtrace
   │ get_args    - /user/rust/topiary/topiary-cli/src/cli.rs:287
   │ {closure#0} - /user/rust/topiary/topiary-cli/src/main.rs:42
   │ {closure#0} - /user/rust/topiary/topiary-cli/src/main.rs:31
   │ ... omitted 10 frame(s) from crate 'tokio' ...
   │ main        - /user/rust/topiary/topiary-cli/src/main.rs:38
   │ note: 23 frame(s) omitted. For a complete backtrace, set RUST_BACKTRACE=full.
   ╰─
```

Section that initializes the cli hook:
https://github.com/topiary/topiary/blob/4a0b9239c651540b3672712fa72da9fb59479b42/topiary-cli/src/cli.rs#L234-L250

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] `CHANGELOG.md` updated
