### PR TITLE
docs(book): add spacing capture examples

### DIFF
--- a/docs/book/src/reference/capture-names/horizontal-spacing.md
+++ b/docs/book/src/reference/capture-names/horizontal-spacing.md
@@ -14,12 +14,30 @@ deletion](insertion-and-deletion.md#append_delimiter--prepend_delimiter)).
 
 ### Example
 
+The Nickel formatting queries surround keywords and operators with
+spaces:
+
 ```scheme
-[
-  (infix_operator)
-  "if"
-  ":"
-] @append_space
+(
+  [
+    "if"
+    "then"
+    "else"
+    "+"
+  ] @prepend_space @append_space
+)
+```
+
+Before:
+
+```nickel
+if true then 1+2 else 0
+```
+
+After:
+
+```nickel
+if true then 1 + 2 else 0
 ```
 
 ## `@append_antispace` / `@prepend_antispace`
@@ -33,11 +51,26 @@ node, including those added by other formatting rules.
 
 ### Example
 
+The Nickel formatting queries use antispaces to keep parentheses next
+to their contents:
+
 ```scheme
-[
-  ","
-  ";"
-  ":"
-  "."
-] @prepend_antispace
+(atom
+  .
+  "(" @append_antispace
+  ")" @prepend_antispace
+  .
+)
+```
+
+Before:
+
+```nickel
+( 1 + 2 )
+```
+
+After:
+
+```nickel
+(1 + 2)
 ```


### PR DESCRIPTION
# Add before/after examples for spacing captures

Resolves #1252

## Description

I added Nickel before/after examples to the horizontal spacing reference. The examples now show how the paired space captures surround keywords and operators, and how the paired antispace captures remove whitespace inside parentheses.

## Validation

I ran:

- `cargo fmt --all -- --check`
- `cargo test -q -p topiary-cli --all-features --test sample-tester nickel` (3 tests passed)
- Both documented Nickel inputs through `cargo run -q --all-features -- format --language nickel`; their output matches the new examples
- `git diff --check origin/main...HEAD`

I did not run the full mdBook build locally; I am leaving that full documentation build to CI.

## Checklist

- [ ] `CHANGELOG.md` updated (not applicable for this documentation example)
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [ ] Updated regression tests (not applicable; I validated the examples against the existing Nickel sample tests and formatter)
