### PR TITLE
fix(cli): Improve error message when Topiary cannot find a query file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This name should be decided amongst the team before the release.
 - [#1255](https://github.com/topiary/topiary/pull/1255) Unpinned outdated wasm-bindgen dependency
 - [#1287](https://github.com/topiary/topiary/pull/1287) [#1296](https://github.com/topiary/topiary/pull/1296) Various OCaml issues and improvements
 - [#1291](https://github.com/topiary/topiary/pull/1291) Improve warning for injection queries without content captures
+- [#1322](https://github.com/topiary/topiary/pull/1322) Improve error message when topiary cannot find a query file
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ This name should be decided amongst the team before the release.
 - [#1255](https://github.com/topiary/topiary/pull/1255) Unpinned outdated wasm-bindgen dependency
 - [#1287](https://github.com/topiary/topiary/pull/1287) [#1296](https://github.com/topiary/topiary/pull/1296) Various OCaml issues and improvements
 - [#1291](https://github.com/topiary/topiary/pull/1291) Improve warning for injection queries without content captures
-- [#1322](https://github.com/topiary/topiary/pull/1322) Improve error message when topiary cannot find a query file
+- [#1322](https://github.com/topiary/topiary/pull/1322) Improve error message when Topiary cannot find a query file
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/topiary-cli/src/cli.rs
+++ b/topiary-cli/src/cli.rs
@@ -308,7 +308,7 @@ pub fn get_args() -> CLIResult<Cli> {
 
             // if there are only errors and no files, we should propagate the given errors
             if files.is_empty() && !errs.is_empty() {
-                return Err(report!(errs).into_dynamic());
+                return Err(errs.context("One or more error(s)").into());
             }
 
             files.sort_unstable();

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -12,6 +12,7 @@ use topiary_core::{
 };
 
 use crate::error::{CLIResult, ResultPreformat, TopiaryError};
+use crate::io::QuerySource;
 use crate::language::LanguageDefinitionCache;
 
 thread_local! {
@@ -148,12 +149,14 @@ impl Configuration {
         &self,
         language_name: &str,
         query_name: &str,
-    ) -> CLIResult<crate::io::QuerySource> {
+    ) -> CLIResult<QuerySource> {
         let config_language = self.get_language_cfg(language_name).preformat_context()?;
         let cache = self.cache();
         let repos = cache.repos();
-        let find = config_language.find_query_file_with(query_name, repos);
-        let query: crate::io::QuerySource = match find {
+        let find = config_language
+            .find_query_file_with(query_name, repos)
+            .preformat_context();
+        let query: QuerySource = match find {
             Ok(p) => p.into(),
             // For some reason, Topiary could not find any
             // matching file in a default location. As a final attempt, try the
@@ -164,8 +167,7 @@ impl Configuration {
                     "No {query_name} query files found in any of the expected locations. Falling back to compile-time included files."
                 );
                 query_from_builtin(&config_language.name, query_name)
-                    .local_context(e)
-                    .preformat_context()?
+                    .map_err(|err| e.attach(err))?
             }
         };
         Ok(query)
@@ -200,7 +202,7 @@ impl Configuration {
 }
 
 /// Get a builtin query for the given language and query name
-fn query_from_builtin<T, Q>(language: T, query: Q) -> CLIResult<crate::io::QuerySource>
+fn query_from_builtin<T, Q>(language: T, query: Q) -> CLIResult<QuerySource>
 where
     T: AsRef<str> + std::fmt::Display,
     Q: AsRef<str>,

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -6,8 +6,6 @@ use std::{ops::Deref, path::Path};
 
 use nickel_lang_core::eval::value::NickelValue;
 use rootcause::prelude::ResultExt;
-use rootcause::report;
-use rootcause::report_collection::ReportCollection;
 use topiary_config::source::Source;
 use topiary_core::{
     FormatterError, FormatterResult, InjectionQuery, Language, SpanAttachment, TopiaryQuery,

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -167,6 +167,7 @@ impl Configuration {
                     "No {query_name} query files found in any of the expected locations. Falling back to compile-time included files."
                 );
                 query_from_builtin(&config_language.name, query_name).map_err(|builtin_err| {
+                    // join two `Report`s, similar to `Vec::append`
                     e.children_mut().push(builtin_err.into_cloneable());
                     e
                 })?

--- a/topiary-cli/src/config.rs
+++ b/topiary-cli/src/config.rs
@@ -6,6 +6,8 @@ use std::{ops::Deref, path::Path};
 
 use nickel_lang_core::eval::value::NickelValue;
 use rootcause::prelude::ResultExt;
+use rootcause::report;
+use rootcause::report_collection::ReportCollection;
 use topiary_config::source::Source;
 use topiary_core::{
     FormatterError, FormatterResult, InjectionQuery, Language, SpanAttachment, TopiaryQuery,
@@ -162,12 +164,14 @@ impl Configuration {
             // matching file in a default location. As a final attempt, try the
             // builtin ones. Store the error, return that if we
             // fail to find anything, because the builtin error might be unexpected.
-            Err(e) => {
+            Err(mut e) => {
                 log::warn!(
                     "No {query_name} query files found in any of the expected locations. Falling back to compile-time included files."
                 );
-                query_from_builtin(&config_language.name, query_name)
-                    .map_err(|err| e.attach(err))?
+                query_from_builtin(&config_language.name, query_name).map_err(|builtin_err| {
+                    e.children_mut().push(builtin_err.into_cloneable());
+                    e
+                })?
             }
         };
         Ok(query)

--- a/topiary-cli/src/error.rs
+++ b/topiary-cli/src/error.rs
@@ -4,7 +4,7 @@ use rootcause::{
     report,
     report_collection::ReportCollection,
 };
-use rootcause_preformat::PreformatReportExt;
+use rootcause_preformat::{PreformatReportExt, PreformattedContext};
 use std::{any::Any, error, fmt, io, process::ExitCode, result};
 use topiary_config::error::{TopiaryConfigError, TopiaryConfigFetchingError as FetchError};
 
@@ -17,7 +17,7 @@ use similar::TextDiff;
 use topiary_core::FormatterError;
 
 /// A convenience wrapper around `std::result::Result<T, TopiaryError>`.
-pub type CLIResult<C, T = SendSync> = result::Result<C, Report<Dynamic, Mutable, T>>;
+pub type CLIResult<T, E = SendSync> = result::Result<T, Report<Dynamic, Mutable, E>>;
 
 /// The errors that can be raised by either the Topiary CLI, or passed through by the formatter
 /// library code. This acts as a supertype of `FormatterError`, with additional members to denote
@@ -192,19 +192,19 @@ impl<T, O> From<&Report<TopiaryConfigError, O, T>> for TopiaryError {
 }
 
 pub(crate) trait ResultPreformat<T, C> {
-    fn preformat_context(self) -> Result<T, Report<TopiaryError>>;
+    #[track_caller]
+    fn preformat_context(self) -> Result<T, Report<PreformattedContext>>;
 }
 
 impl<T, C: 'static> ResultPreformat<T, C> for Result<T, C>
 where
-    C: 'static + fmt::Debug,
-    for<'a> TopiaryError: From<&'a C>,
+    C: 'static + std::error::Error,
 {
-    fn preformat_context(self) -> Result<T, Report<TopiaryError>> {
+    #[track_caller]
+    fn preformat_context(self) -> Result<T, Report<PreformattedContext>> {
         match self {
             Ok(t) => Ok(t),
             Err(e) => {
-                let cli_err = TopiaryError::from(&e);
                 let nickel_diagnostic = (&e as &dyn Any)
                     .downcast_ref::<TopiaryConfigError>()
                     .and_then(|cfg_err| match cfg_err {
@@ -227,11 +227,11 @@ where
                         }
                         _ => None,
                     });
-                let mut report = report!(e).preformat();
+                let mut report = report!(e);
                 if let Some(diagnostic) = nickel_diagnostic {
                     report = report.attach(diagnostic);
                 }
-                Err(report.context(cli_err))
+                Err(report.preformat())
             }
         }
     }

--- a/topiary-cli/src/error.rs
+++ b/topiary-cli/src/error.rs
@@ -193,18 +193,20 @@ impl<T, O> From<&Report<TopiaryConfigError, O, T>> for TopiaryError {
 
 pub(crate) trait ResultPreformat<T, C> {
     #[track_caller]
-    fn preformat_context(self) -> Result<T, Report<PreformattedContext>>;
+    fn preformat_context(self) -> Result<T, Report<TopiaryError>>;
 }
 
 impl<T, C: 'static> ResultPreformat<T, C> for Result<T, C>
 where
     C: 'static + std::error::Error,
+    for<'a> TopiaryError: From<&'a C>,
 {
     #[track_caller]
-    fn preformat_context(self) -> Result<T, Report<PreformattedContext>> {
+    fn preformat_context(self) -> Result<T, Report<TopiaryError>> {
         match self {
             Ok(t) => Ok(t),
             Err(e) => {
+                let cli_err = TopiaryError::from(&e);
                 let nickel_diagnostic = (&e as &dyn Any)
                     .downcast_ref::<TopiaryConfigError>()
                     .and_then(|cfg_err| match cfg_err {
@@ -225,13 +227,13 @@ where
                                 ColorOpt::Never,
                             ))
                         }
-                        _ => None,
+                        e => Some(format!("{}::{e:?}", std::any::type_name_of_val(e))),
                     });
                 let mut report = report!(e);
                 if let Some(diagnostic) = nickel_diagnostic {
                     report = report.attach(diagnostic);
                 }
-                Err(report.preformat())
+                Err(report.preformat().context(cli_err))
             }
         }
     }

--- a/topiary-cli/src/error.rs
+++ b/topiary-cli/src/error.rs
@@ -4,7 +4,7 @@ use rootcause::{
     report,
     report_collection::ReportCollection,
 };
-use rootcause_preformat::{PreformatReportExt, PreformattedContext};
+use rootcause_preformat::PreformatReportExt;
 use std::{any::Any, error, fmt, io, process::ExitCode, result};
 use topiary_config::error::{TopiaryConfigError, TopiaryConfigFetchingError as FetchError};
 
@@ -207,28 +207,29 @@ where
             Ok(t) => Ok(t),
             Err(e) => {
                 let cli_err = TopiaryError::from(&e);
-                let nickel_diagnostic = (&e as &dyn Any)
-                    .downcast_ref::<TopiaryConfigError>()
-                    .and_then(|cfg_err| match cfg_err {
-                        // TODO(mkatychev): use `report_with` to add the report to our `ErrorSpan`s
-                        TopiaryConfigError::Nickel { error, files } => Some(report_as_str(
-                            &mut (**files).clone(),
-                            (**error).clone(),
-                            ColorOpt::Never,
-                        )),
-                        // NOTE: NickelDeserialization does not currently support IntoDiagnostics
-                        // so the rendering is not as fancy
-                        TopiaryConfigError::NickelDeserialization { error, files } => {
-                            Some(report_as_str(
+                let nickel_diagnostic =
+                    (&e as &dyn Any)
+                        .downcast_ref::<TopiaryConfigError>()
+                        .map(|cfg_err| match cfg_err {
+                            // TODO(mkatychev): use `report_with` to add the report to our `ErrorSpan`s
+                            TopiaryConfigError::Nickel { error, files } => report_as_str(
                                 &mut (**files).clone(),
-                                Diagnostic::error()
-                                    .with_message(error)
-                                    .with_note("Failed to deserialize Topiary configuration."),
+                                (**error).clone(),
                                 ColorOpt::Never,
-                            ))
-                        }
-                        e => Some(format!("{}::{e:?}", std::any::type_name_of_val(e))),
-                    });
+                            ),
+                            // NOTE: NickelDeserialization does not currently support IntoDiagnostics
+                            // so the rendering is not as fancy
+                            TopiaryConfigError::NickelDeserialization { error, files } => {
+                                report_as_str(
+                                    &mut (**files).clone(),
+                                    Diagnostic::error()
+                                        .with_message(error)
+                                        .with_note("Failed to deserialize Topiary configuration."),
+                                    ColorOpt::Never,
+                                )
+                            }
+                            e => format!("{}::{e:?}", std::any::type_name_of_val(e)),
+                        });
                 let mut report = report!(e);
                 if let Some(diagnostic) = nickel_diagnostic {
                     report = report.attach(diagnostic);

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -14,7 +14,6 @@ use rootcause::{
     report,
     report_collection::ReportCollection,
 };
-use rootcause_preformat::PreformatReportExt;
 use tempfile::tempfile;
 use topiary_core::{
     ErrorSpan, FormatterError, InjectionQuery, Language, SpanAttachment, TopiaryQuery,
@@ -264,7 +263,7 @@ impl<'cfg, 'i> Inputs<'cfg> {
                 vec![(|| {
                     let language = config
                         .get_language_cfg(&language_name)
-                        .map_err(|e| report!(e).preformat())
+                        .preformat_context()
                         .context(TopiaryError::Config)?;
                     let query_source: QuerySource = match query {
                         // The user specified a query file


### PR DESCRIPTION
# Improve error message when topiary cannot find a query file

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves https://github.com/topiary/topiary/issues/1321

## Description

Fix handling of preformatted errors in topiary-cli, this mainly involved exposing `std::error::Error` of the underlying generic:

```sh-session
$ cargo run -- format test.nix -C languages.ncl

 ● Configuration error
 ├ topiary-cli/src/io.rs:289
 │
 ● You tried to format a file with extension: "nix", but we do not know that extension. Make sure the extension is in your configuration file!
 ├ topiary-cli/src/io.rs:289
 ╰ topiary_config::error::TopiaryConfigError::UnknownExtension("nix")
```

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
