### PR TITLE
Fixed regression in `--query` parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ This name should be decided amongst the team before the release.
 - [#1287](https://github.com/topiary/topiary/pull/1287) [#1296](https://github.com/topiary/topiary/pull/1296) Various OCaml issues and improvements
 - [#1291](https://github.com/topiary/topiary/pull/1291) Improve warning for injection queries without content captures
 - [#1322](https://github.com/topiary/topiary/pull/1322) Improve error message when Topiary cannot find a query file
+- [#1325](https://github.com/topiary/topiary/pull/1325) Fix regression with `--query` value parsing in `topiary format`
 
 ### Added
 - [#1200](https://github.com/topiary/topiary/pull/1200) Build and deploy Topiary Docker images to ghcr.io.

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -423,12 +423,15 @@ where
                 let input = input?;
                 let location = input.source().location();
                 tokio::task::block_in_place(|| {
-                    let language_name = input.language().name.clone();
-                    let language = Arc::new(
-                        config
-                            .get_language(&language_name)
-                            .attach_filepath(location.to_path())?,
-                    );
+                    // NOTE Resolve the language definition from the input itself, rather
+                    // than by name from the configuration. The input carries the query
+                    // sources that were resolved for it, which may include a user-supplied
+                    // override (i.e. `--query`); going via the configuration would silently
+                    // discard that override.
+                    let language = config
+                        .cache()
+                        .fetch_input(&input)
+                        .attach_filepath(location.to_path())?;
                     process_fn(input, language, config)
                         .map_err(|e| e.attach_filepath(location.to_path()))
                 })

--- a/topiary-cli/tests/cli-tester.rs
+++ b/topiary-cli/tests/cli-tester.rs
@@ -119,6 +119,66 @@ fn test_fmt_stdin_query() {
         .stdout(JSON_EXPECTED);
 }
 
+// NOTE `test_fmt_stdin_query`, above, passes the built-in query as the override, so it
+// cannot distinguish an honoured override from an ignored one. These two tests use an
+// override that is observably *not* the built-in query, which is what a regression in the
+// override plumbing actually looks like. See issue #1306.
+
+#[test]
+#[cfg(feature = "json")]
+fn test_fmt_stdin_query_override_is_used() {
+    use predicates::{prelude::PredicateBooleanExt, str::contains};
+
+    // A deliberately idiosyncratic query: unlike the built-in JSON query, it puts a space
+    // *before* the colon and adds no soft lines or indentation. Its output is therefore
+    // unmistakably distinct from `JSON_EXPECTED`.
+    let tmp_dir = TempDir::new().unwrap();
+    let query = tmp_dir.path().join("formatting.scm");
+    fs::write(&query, "(string) @leaf\n\":\" @prepend_space\n").unwrap();
+
+    initialize();
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
+        .arg("fmt")
+        .arg("--language")
+        .arg("json")
+        .arg("--query")
+        .arg(&query)
+        .write_stdin(JSON_INPUT)
+        .assert()
+        .success()
+        .stdout(contains(r#"{"test" :123}"#).and(contains(JSON_EXPECTED.trim()).not()));
+}
+
+#[test]
+#[cfg(feature = "json")]
+fn test_fmt_stdin_invalid_query_override_fails() {
+    use predicates::str::contains;
+
+    // If the override is honoured, this must be compiled -- and fail. If it is silently
+    // dropped in favour of the built-in query, formatting would succeed instead.
+    let tmp_dir = TempDir::new().unwrap();
+    let query = tmp_dir.path().join("formatting.scm");
+    fs::write(&query, "this is not a tree-sitter query").unwrap();
+
+    initialize();
+    let mut topiary = cargo_bin_cmd!("topiary");
+
+    topiary
+        .env("TOPIARY_LANGUAGE_DIR", "../topiary-queries/queries")
+        .arg("fmt")
+        .arg("--language")
+        .arg("json")
+        .arg("--query")
+        .arg(&query)
+        .write_stdin(JSON_INPUT)
+        .assert()
+        .failure()
+        .stderr(contains("this is not a tree-sitter query"));
+}
+
 #[test]
 #[cfg(feature = "json")]
 fn test_fmt_stdin_query_fallback() {


### PR DESCRIPTION
# Fixed regression in `--query` parsing

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #1324
References #1306

## Description

### What broke

`topiary-cli/src/io.rs:425` in `process_inputs`. Commit `60ce420c` ("refactor(cli): fixed compilation") changed how the language definition is resolved for each input:

```rust
// before
let language = cache.fetch_input(&input)?;

// after (broken)
let language_name = input.language().name.clone();
let language = Arc::new(config.get_language(&language_name)?);
```

The two are not equivalent:

- `cache.fetch_input(&input)` to `input.to_language_sync()`, which compiles the queries held on the `InputFile`; i.e., `input.formatting_query`, which `Inputs::new` populates from the `--query` argument when one is given (`io.rs:268-274`).
- `config.get_language(name)` re-resolves the query from scratch by language name (`config.rs:124`), so it always picks the config/built-in query and silently discards the override.

So `--query` was still parsed, still validated, still logged ("Formatting ... using <your query>"), but the formatter received the default query.

This looks to be accidental as:
- `Commands::Visualise` in `main.rs:165` was left calling `config.cache().fetch_input(&input)`, so `--query` still worked there.
- The replacement also bypassed `LanguageDefinitionCache` entirely for the `format`/`check`/`check-grammar` paths, recompiling grammars and queries per input. That's the regression #605 originally guarded against.

This was collateral from making `Configuration` thread-safe (the same commit that introduced the thread-local `NickelValue` storage), not a deliberate change to query resolution.

### The fix

Restored the cache-based resolution, keeping the `attach_filepath` error context the refactor added:

```rust
let language = config
    .cache()
    .fetch_input(&input)
    .attach_filepath(location.to_path())?;
```

This also restores the language-definition caching for multi-input runs.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [x] Updated regression tests
