### PR TITLE
Enable `log` behind a feature flag in `topiary-core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ This name should be decided amongst the team before the release.
 - [#1315](https://github.com/topiary/topiary/pull/1315) Add rootcause-backtrace to cli
 - [#1314](https://github.com/topiary/topiary/pull/1314) Allow skipping of formatting stages
 - [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string. And use `@multi_line_string` to add multi line string formatting to the Nickel formatter.
+- [#1330](https://github.com/topiary/topiary/pull/1330) Add a new feature flag on the `topiary-core` crate to enable the `log` dependency; this feature flag is enabled by default.
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ This name should be decided amongst the team before the release.
 - [#1315](https://github.com/topiary/topiary/pull/1315) Add rootcause-backtrace to cli
 - [#1314](https://github.com/topiary/topiary/pull/1314) Allow skipping of formatting stages
 - [#1266](https://github.com/topiary/topiary/pull/1266) Add `@multi_line_string` capture to format multi line strings in languages like Nix and Nickel that ignore indentation common to all lines of a multi line string. And use `@multi_line_string` to add multi line string formatting to the Nickel formatter.
-- [#1330](https://github.com/topiary/topiary/pull/1330) Add a new feature flag on the `topiary-core` crate to enable the `log` dependency; this feature flag is enabled by default.
+- [#1330](https://github.com/topiary/topiary/pull/1330) Add a new feature flag on the `topiary-core` crate to enable the `log` dependency; this feature flag is enabled by default. Thanks to @GrandChaman.
 
 ### Removed
 - [#1217](https://github.com/topiary/topiary/pull/1217) The `check` alias for the `check-grammar` subcommand, to avoid confusion with `topiary fmt --check`.

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -32,7 +32,7 @@ nickel-lang-core.workspace = true
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "sync", "macros"] }
 toml = { workspace = true }
-topiary-core.workspace = true
+topiary-core = { workspace = true, features = [ "log" ] }
 topiary-config.workspace = true
 topiary-queries.workspace = true
 topiary-tree-sitter-facade.workspace = true

--- a/topiary-core/Cargo.toml
+++ b/topiary-core/Cargo.toml
@@ -12,8 +12,12 @@ documentation.workspace = true
 readme.workspace = true
 license.workspace = true
 
+[features]
+default = [ "log" ]
+log = [ "dep:log" ]
+
 [dependencies]
-log = { workspace = true }
+log = { workspace = true, optional = true }
 miette = { workspace = true }
 pretty_assertions = { workspace = true }
 prettydiff = { workspace = true }
@@ -31,6 +35,7 @@ rootcause = { workspace = true }
 topiary-web-tree-sitter-sys.workspace = true
 
 [dev-dependencies]
+log = { workspace = true }
 criterion = { workspace = true, features = ["async_futures"] }
 env_logger = { workspace = true }
 test-log = { workspace = true }

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -230,6 +230,7 @@ impl AtomCollection {
         node: &Node,
         predicates: &QueryPredicates,
     ) -> FormatterResult<()> {
+        #[cfg(feature = "log")]
         log::debug!("Resolving {name}");
 
         let requires_delimiter = || {
@@ -280,16 +281,19 @@ impl AtomCollection {
             }
         }
         if is_multi_line && predicates.single_line_only {
+            #[cfg(feature = "log")]
             log::debug!("Skipping because context is multi-line and #single_line_only! is set");
             return Ok(());
         }
         if !is_multi_line && predicates.multi_line_only {
+            #[cfg(feature = "log")]
             log::debug!("Skipping because context is single-line and #multi_line_only! is set");
             return Ok(());
         }
         if let Some(parent_id) = self.parent_leaf_nodes.get(&node.id())
             && *parent_id != node.id()
         {
+            #[cfg(feature = "log")]
             log::debug!(
                 "Skipping because the match occurred below a leaf node: {}",
                 node.display_one_based()
@@ -607,9 +611,11 @@ impl AtomCollection {
                 let swapped_atom = mem::take(atom);
 
                 if !prepends.is_empty() {
+                    #[cfg(feature = "log")]
                     log::debug!("Applying prepend of {prepends:?} to {:?}.", swapped_atom);
                 }
                 if !appends.is_empty() {
+                    #[cfg(feature = "log")]
                     log::debug!("Applying append of {appends:?} to {:?}.", swapped_atom);
                 }
 
@@ -618,6 +624,7 @@ impl AtomCollection {
 
                 expanded.append(appends);
             } else {
+                #[cfg(feature = "log")]
                 log::debug!("Not a leaf: {atom:?}");
                 expanded.push(mem::take(atom));
             }
@@ -657,6 +664,7 @@ impl AtomCollection {
     ) -> FormatterResult<()> {
         let id = node.id();
 
+        #[cfg(feature = "log")]
         log::debug!(
             "CST node: {}{} - Named: {}",
             "  ".repeat(level),
@@ -665,6 +673,7 @@ impl AtomCollection {
         );
 
         if node.end_byte() == node.start_byte() {
+            #[cfg(feature = "log")]
             log::debug!("Skipping zero-byte node: {}", node.display_one_based());
         } else if node.child_count() == 0
             || self.specified_leaf_nodes.contains(&node.id())
@@ -707,6 +716,7 @@ impl AtomCollection {
         // TODO: Pre-populate these
         let target_node = self.first_leaf(node);
 
+        #[cfg(feature = "log")]
         log::debug!(
             "Prepending {atom:?} to node {}",
             target_node.display_one_based()
@@ -727,6 +737,7 @@ impl AtomCollection {
         let atom = self.wrap(atom, predicates);
         let target_node = self.last_leaf(node);
 
+        #[cfg(feature = "log")]
         log::debug!(
             "Appending {atom:?} to node {}",
             target_node.display_one_based()
@@ -761,6 +772,7 @@ impl AtomCollection {
                 let parent_id = parent.id();
 
                 if self.multi_line_nodes.contains(&parent_id) {
+                    #[cfg(feature = "log")]
                     log::debug!(
                         "Expanding softline to hardline in node {} with parent {}: {}",
                         node.display_one_based(),
@@ -769,6 +781,7 @@ impl AtomCollection {
                     );
                     Atom::Hardline
                 } else if spaced {
+                    #[cfg(feature = "log")]
                     log::debug!(
                         "Expanding softline to space in node {} with parent {}: {}",
                         node.display_one_based(),
@@ -869,6 +882,7 @@ impl AtomCollection {
                         }
                     }
                 } else {
+                    #[cfg(feature = "log")]
                     log::warn!("Closing unopened scope {scope_id:?}");
                     force_apply_modifications = true;
                 }
@@ -879,6 +893,7 @@ impl AtomCollection {
             }) = atom
             {
                 if opened_scopes.entry(scope_id).or_default().is_empty() {
+                    #[cfg(feature = "log")]
                     log::warn!(
                         "Opening measuring scope with no associated regular scope {scope_id:?}"
                     );
@@ -909,16 +924,19 @@ impl AtomCollection {
                                 Some(multi_line),
                             ));
                         } else {
+                            #[cfg(feature = "log")]
                             log::warn!(
                                 "Found several measuring scopes in a single regular scope {scope_id:?}"
                             );
                             force_apply_modifications = true;
                         }
                     } else {
+                        #[cfg(feature = "log")]
                         log::warn!("Found measuring scope outside of regular scope {scope_id:?}");
                         force_apply_modifications = true;
                     }
                 } else {
+                    #[cfg(feature = "log")]
                     log::warn!("Closing unopened measuring scope {scope_id:?}");
                     force_apply_modifications = true;
                 }
@@ -929,6 +947,7 @@ impl AtomCollection {
                 {
                     vec.push(atom);
                 } else {
+                    #[cfg(feature = "log")]
                     log::warn!("Found scoped softline {atom:?} outside of its scope");
                     force_apply_modifications = true;
                 }
@@ -939,6 +958,7 @@ impl AtomCollection {
                 {
                     vec.push(atom);
                 } else {
+                    #[cfg(feature = "log")]
                     log::warn!("Found scoped conditional {atom:?} outside of its scope");
                     force_apply_modifications = true;
                 }
@@ -949,6 +969,7 @@ impl AtomCollection {
             .filter_map(|(scope_id, vec)| if vec.is_empty() { None } else { Some(scope_id) })
             .collect();
         if !still_opened.is_empty() {
+            #[cfg(feature = "log")]
             log::warn!("Some scopes have been left opened: {still_opened:?}");
             force_apply_modifications = true;
         }
@@ -957,6 +978,7 @@ impl AtomCollection {
             .filter_map(|(scope_id, vec)| if vec.is_empty() { None } else { Some(scope_id) })
             .collect();
         if !still_opened.is_empty() {
+            #[cfg(feature = "log")]
             log::warn!("Some measuring scopes have been left opened: {still_opened:?}");
             force_apply_modifications = true;
         }
@@ -980,6 +1002,7 @@ impl AtomCollection {
                     if let Some(replacement) = modifications.remove(id) {
                         *atom = replacement;
                     } else {
+                        #[cfg(feature = "log")]
                         log::warn!("Found scoped softline {atom:?}, but was unable to replace it.");
                         *atom = Atom::Empty;
                     }
@@ -987,6 +1010,7 @@ impl AtomCollection {
                     if let Some(replacement) = modifications.remove(id) {
                         *atom = replacement;
                     } else {
+                        #[cfg(feature = "log")]
                         log::warn!(
                             "Found scoped conditional {atom:?}, but was unable to replace it."
                         );
@@ -1018,6 +1042,7 @@ impl AtomCollection {
             }
         }
         if delete_level != 0 {
+            #[cfg(feature = "log")]
             log::warn!("The number of DeleteBegin is different from the number of DeleteEnd.");
         }
     }
@@ -1061,6 +1086,7 @@ impl AtomCollection {
         // antispaces may have produced more empty atoms.
         self.post_process_inner();
 
+        #[cfg(feature = "log")]
         log::debug!("List of atoms after post-processing: {:?}", self.atoms);
     }
 
@@ -1325,6 +1351,7 @@ fn detect_multi_line_nodes(dfs_nodes: &[Node]) -> HashSet<usize> {
             let end_line = node.end_position().row();
 
             if end_line > start_line {
+                #[cfg(feature = "log")]
                 log::debug!(
                     "Multi-line node {}: {}",
                     node.id(),
@@ -1366,6 +1393,7 @@ fn detect_line_breaks(dfs_nodes: &[Node], minimum_line_breaks: u32) -> NodesWith
             let next = right.start_position().row();
 
             if next >= last + minimum_line_breaks {
+                #[cfg(feature = "log")]
                 log::debug!(
                     "There are at least {} line breaks between {:?} and {:?}",
                     minimum_line_breaks,

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -230,8 +230,7 @@ impl AtomCollection {
         node: &Node,
         predicates: &QueryPredicates,
     ) -> FormatterResult<()> {
-        #[cfg(feature = "log")]
-        log::debug!("Resolving {name}");
+        crate::debug!("Resolving {name}");
 
         let requires_delimiter = || {
             predicates.delimiter.as_deref().ok_or_else(|| {
@@ -281,20 +280,17 @@ impl AtomCollection {
             }
         }
         if is_multi_line && predicates.single_line_only {
-            #[cfg(feature = "log")]
-            log::debug!("Skipping because context is multi-line and #single_line_only! is set");
+            crate::debug!("Skipping because context is multi-line and #single_line_only! is set");
             return Ok(());
         }
         if !is_multi_line && predicates.multi_line_only {
-            #[cfg(feature = "log")]
-            log::debug!("Skipping because context is single-line and #multi_line_only! is set");
+            crate::debug!("Skipping because context is single-line and #multi_line_only! is set");
             return Ok(());
         }
         if let Some(parent_id) = self.parent_leaf_nodes.get(&node.id())
             && *parent_id != node.id()
         {
-            #[cfg(feature = "log")]
-            log::debug!(
+            crate::debug!(
                 "Skipping because the match occurred below a leaf node: {}",
                 node.display_one_based()
             );
@@ -611,12 +607,10 @@ impl AtomCollection {
                 let swapped_atom = mem::take(atom);
 
                 if !prepends.is_empty() {
-                    #[cfg(feature = "log")]
-                    log::debug!("Applying prepend of {prepends:?} to {:?}.", swapped_atom);
+                    crate::debug!("Applying prepend of {prepends:?} to {:?}.", swapped_atom);
                 }
                 if !appends.is_empty() {
-                    #[cfg(feature = "log")]
-                    log::debug!("Applying append of {appends:?} to {:?}.", swapped_atom);
+                    crate::debug!("Applying append of {appends:?} to {:?}.", swapped_atom);
                 }
 
                 expanded.append(prepends);
@@ -624,8 +618,7 @@ impl AtomCollection {
 
                 expanded.append(appends);
             } else {
-                #[cfg(feature = "log")]
-                log::debug!("Not a leaf: {atom:?}");
+                crate::debug!("Not a leaf: {atom:?}");
                 expanded.push(mem::take(atom));
             }
         }
@@ -664,8 +657,7 @@ impl AtomCollection {
     ) -> FormatterResult<()> {
         let id = node.id();
 
-        #[cfg(feature = "log")]
-        log::debug!(
+        crate::debug!(
             "CST node: {}{} - Named: {}",
             "  ".repeat(level),
             node.display_one_based(),
@@ -673,8 +665,7 @@ impl AtomCollection {
         );
 
         if node.end_byte() == node.start_byte() {
-            #[cfg(feature = "log")]
-            log::debug!("Skipping zero-byte node: {}", node.display_one_based());
+            crate::debug!("Skipping zero-byte node: {}", node.display_one_based());
         } else if node.child_count() == 0
             || self.specified_leaf_nodes.contains(&node.id())
             // We treat error nodes as leaves when `tolerate_parsing_errors` is set to true.
@@ -716,8 +707,7 @@ impl AtomCollection {
         // TODO: Pre-populate these
         let target_node = self.first_leaf(node);
 
-        #[cfg(feature = "log")]
-        log::debug!(
+        crate::debug!(
             "Prepending {atom:?} to node {}",
             target_node.display_one_based()
         );
@@ -737,8 +727,7 @@ impl AtomCollection {
         let atom = self.wrap(atom, predicates);
         let target_node = self.last_leaf(node);
 
-        #[cfg(feature = "log")]
-        log::debug!(
+        crate::debug!(
             "Appending {atom:?} to node {}",
             target_node.display_one_based()
         );
@@ -772,8 +761,7 @@ impl AtomCollection {
                 let parent_id = parent.id();
 
                 if self.multi_line_nodes.contains(&parent_id) {
-                    #[cfg(feature = "log")]
-                    log::debug!(
+                    crate::debug!(
                         "Expanding softline to hardline in node {} with parent {}: {}",
                         node.display_one_based(),
                         parent_id,
@@ -781,8 +769,7 @@ impl AtomCollection {
                     );
                     Atom::Hardline
                 } else if spaced {
-                    #[cfg(feature = "log")]
-                    log::debug!(
+                    crate::debug!(
                         "Expanding softline to space in node {} with parent {}: {}",
                         node.display_one_based(),
                         parent_id,
@@ -882,8 +869,7 @@ impl AtomCollection {
                         }
                     }
                 } else {
-                    #[cfg(feature = "log")]
-                    log::warn!("Closing unopened scope {scope_id:?}");
+                    crate::warn!("Closing unopened scope {scope_id:?}");
                     force_apply_modifications = true;
                 }
             // Open measuring scope
@@ -893,8 +879,7 @@ impl AtomCollection {
             }) = atom
             {
                 if opened_scopes.entry(scope_id).or_default().is_empty() {
-                    #[cfg(feature = "log")]
-                    log::warn!(
+                    crate::warn!(
                         "Opening measuring scope with no associated regular scope {scope_id:?}"
                     );
                     force_apply_modifications = true;
@@ -924,20 +909,17 @@ impl AtomCollection {
                                 Some(multi_line),
                             ));
                         } else {
-                            #[cfg(feature = "log")]
-                            log::warn!(
+                            crate::warn!(
                                 "Found several measuring scopes in a single regular scope {scope_id:?}"
                             );
                             force_apply_modifications = true;
                         }
                     } else {
-                        #[cfg(feature = "log")]
-                        log::warn!("Found measuring scope outside of regular scope {scope_id:?}");
+                        crate::warn!("Found measuring scope outside of regular scope {scope_id:?}");
                         force_apply_modifications = true;
                     }
                 } else {
-                    #[cfg(feature = "log")]
-                    log::warn!("Closing unopened measuring scope {scope_id:?}");
+                    crate::warn!("Closing unopened measuring scope {scope_id:?}");
                     force_apply_modifications = true;
                 }
             // Register the ScopedSoftline in the correct scope
@@ -947,8 +929,7 @@ impl AtomCollection {
                 {
                     vec.push(atom);
                 } else {
-                    #[cfg(feature = "log")]
-                    log::warn!("Found scoped softline {atom:?} outside of its scope");
+                    crate::warn!("Found scoped softline {atom:?} outside of its scope");
                     force_apply_modifications = true;
                 }
             // Register the ScopedConditional in the correct scope
@@ -958,8 +939,7 @@ impl AtomCollection {
                 {
                     vec.push(atom);
                 } else {
-                    #[cfg(feature = "log")]
-                    log::warn!("Found scoped conditional {atom:?} outside of its scope");
+                    crate::warn!("Found scoped conditional {atom:?} outside of its scope");
                     force_apply_modifications = true;
                 }
             }
@@ -969,8 +949,7 @@ impl AtomCollection {
             .filter_map(|(scope_id, vec)| if vec.is_empty() { None } else { Some(scope_id) })
             .collect();
         if !still_opened.is_empty() {
-            #[cfg(feature = "log")]
-            log::warn!("Some scopes have been left opened: {still_opened:?}");
+            crate::warn!("Some scopes have been left opened: {still_opened:?}");
             force_apply_modifications = true;
         }
         still_opened = opened_measuring_scopes
@@ -978,8 +957,7 @@ impl AtomCollection {
             .filter_map(|(scope_id, vec)| if vec.is_empty() { None } else { Some(scope_id) })
             .collect();
         if !still_opened.is_empty() {
-            #[cfg(feature = "log")]
-            log::warn!("Some measuring scopes have been left opened: {still_opened:?}");
+            crate::warn!("Some measuring scopes have been left opened: {still_opened:?}");
             force_apply_modifications = true;
         }
 
@@ -1003,7 +981,9 @@ impl AtomCollection {
                         *atom = replacement;
                     } else {
                         #[cfg(feature = "log")]
-                        log::warn!("Found scoped softline {atom:?}, but was unable to replace it.");
+                        crate::warn!(
+                            "Found scoped softline {atom:?}, but was unable to replace it."
+                        );
                         *atom = Atom::Empty;
                     }
                 } else if let Atom::ScopedConditional { id, .. } = atom {
@@ -1011,7 +991,7 @@ impl AtomCollection {
                         *atom = replacement;
                     } else {
                         #[cfg(feature = "log")]
-                        log::warn!(
+                        crate::warn!(
                             "Found scoped conditional {atom:?}, but was unable to replace it."
                         );
                         *atom = Atom::Empty;
@@ -1043,7 +1023,7 @@ impl AtomCollection {
         }
         if delete_level != 0 {
             #[cfg(feature = "log")]
-            log::warn!("The number of DeleteBegin is different from the number of DeleteEnd.");
+            crate::warn!("The number of DeleteBegin is different from the number of DeleteEnd.");
         }
     }
 
@@ -1086,8 +1066,7 @@ impl AtomCollection {
         // antispaces may have produced more empty atoms.
         self.post_process_inner();
 
-        #[cfg(feature = "log")]
-        log::debug!("List of atoms after post-processing: {:?}", self.atoms);
+        crate::debug!("List of atoms after post-processing: {:?}", self.atoms);
     }
 
     /// This function post-processes the atoms in the collection.
@@ -1351,8 +1330,7 @@ fn detect_multi_line_nodes(dfs_nodes: &[Node]) -> HashSet<usize> {
             let end_line = node.end_position().row();
 
             if end_line > start_line {
-                #[cfg(feature = "log")]
-                log::debug!(
+                crate::debug!(
                     "Multi-line node {}: {}",
                     node.id(),
                     node.display_one_based()
@@ -1393,8 +1371,7 @@ fn detect_line_breaks(dfs_nodes: &[Node], minimum_line_breaks: u32) -> NodesWith
             let next = right.start_position().row();
 
             if next >= last + minimum_line_breaks {
-                #[cfg(feature = "log")]
-                log::debug!(
+                crate::debug!(
                     "There are at least {} line breaks between {:?} and {:?}",
                     minimum_line_breaks,
                     left.id(),

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -980,7 +980,6 @@ impl AtomCollection {
                     if let Some(replacement) = modifications.remove(id) {
                         *atom = replacement;
                     } else {
-                        #[cfg(feature = "log")]
                         crate::warn!(
                             "Found scoped softline {atom:?}, but was unable to replace it."
                         );
@@ -990,7 +989,6 @@ impl AtomCollection {
                     if let Some(replacement) = modifications.remove(id) {
                         *atom = replacement;
                     } else {
-                        #[cfg(feature = "log")]
                         crate::warn!(
                             "Found scoped conditional {atom:?}, but was unable to replace it."
                         );
@@ -1022,7 +1020,6 @@ impl AtomCollection {
             }
         }
         if delete_level != 0 {
-            #[cfg(feature = "log")]
             crate::warn!("The number of DeleteBegin is different from the number of DeleteEnd.");
         }
     }

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -33,6 +33,9 @@ mod pretty;
 mod tree_sitter;
 
 #[doc(hidden)]
+mod macros;
+
+#[doc(hidden)]
 pub mod test_utils;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -357,7 +360,7 @@ pub fn formatter_tree(
             let spans = match skip_stage {
                 Some(SkipStage::HostLanguage) => {
                     #[cfg(feature = "log")]
-                    log::debug!("Skipping host formatting; only processing injections");
+                    crate::debug!("Skipping host formatting; only processing injections");
                     let spans = language.collect_injections(&tree, input_content);
                     let rendered = splice_formatted_injections(
                         input_content,
@@ -372,7 +375,7 @@ pub fn formatter_tree(
                 Some(SkipStage::Injections) => Vec::new(),
                 None => {
                     #[cfg(feature = "log")]
-                    log::debug!("Discovering potentially injected languages");
+                    crate::debug!("Discovering potentially injected languages");
                     language.collect_injections(&tree, input_content)
                 }
             };
@@ -383,7 +386,7 @@ pub fn formatter_tree(
 
             // All the work related to tree-sitter and the query is done here
             #[cfg(feature = "log")]
-            log::debug!("Apply Tree-sitter query");
+            crate::debug!("Apply Tree-sitter query");
 
             let mut atoms = tree_sitter::apply_query_tree_with_forced_leaves(
                 tree,
@@ -399,7 +402,7 @@ pub fn formatter_tree(
 
             // Pretty-print atoms
             #[cfg(feature = "log")]
-            log::debug!("Pretty-print output");
+            crate::debug!("Pretty-print output");
             let rendered = pretty::render(
                 &atoms[..],
                 // Default to "  " if the language has no indentation specified
@@ -445,7 +448,7 @@ fn rewrite_injected_leaves(
         // by continuing the loop. This leaves the original, unformatted text intact.
         let Some(inner_language) = resolve_injected_language(resolve, &span.language)? else {
             #[cfg(feature = "log")]
-            log::warn!(
+            crate::warn!(
                 "Skipping injection for unsupported language: {}",
                 span.language
             );
@@ -497,8 +500,7 @@ fn splice_formatted_injections(
     spans.sort_by_key(|s| s.byte_range.start);
     for span in spans {
         if span.byte_range.start < cursor {
-            #[cfg(feature = "log")]
-            log::warn!(
+            crate::warn!(
                 "Overlapping spans detected for language {} at byte {}; skipping",
                 span.language,
                 span.byte_range.start
@@ -507,8 +509,7 @@ fn splice_formatted_injections(
         }
 
         let Some(inner_language) = resolve_injected_language(resolve, &span.language)? else {
-            #[cfg(feature = "log")]
-            log::warn!(
+            crate::warn!(
                 "Injection for unsupported language: {}; skipping",
                 span.language
             );
@@ -557,8 +558,7 @@ fn resolve_injected_language(
 
     match resolve(language) {
         Ok(Some(language_cfg)) => {
-            #[cfg(feature = "log")]
-            log::info!("resolved injected language: {language}");
+            crate::info!("resolved injected language: {language}");
             Ok(Some(language_cfg))
         }
         Ok(None) => Ok(None),
@@ -600,7 +600,7 @@ fn idempotence_check(
     resolve: Option<&LanguageResolver<'_>>,
 ) -> FormatterResult<()> {
     #[cfg(feature = "log")]
-    log::info!("Checking for idempotence ...");
+    crate::info!("Checking for idempotence ...");
 
     let mut input = content.as_bytes();
     let mut output = io::BufWriter::new(Vec::new());
@@ -628,8 +628,8 @@ fn idempotence_check(
             } else {
                 #[cfg(feature = "log")]
                 {
-                    log::error!("Failed idempotence check");
-                    log::error!("{}", StrComparison::new(content, &reformatted));
+                    crate::error!("Failed idempotence check");
+                    crate::error!("{}", StrComparison::new(content, &reformatted));
                 }
                 Err(report!(FormatterError::Idempotence))
             }
@@ -760,7 +760,7 @@ mod tests {
         .unwrap();
 
         let formatted = String::from_utf8(output).unwrap();
-        log::debug!("{formatted}");
+        crate::debug!("{formatted}");
 
         pretty_assert_eq(expected, &formatted);
     }

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -356,6 +356,7 @@ pub fn formatter_tree(
         } => {
             let spans = match skip_stage {
                 Some(SkipStage::HostLanguage) => {
+                    #[cfg(feature = "log")]
                     log::debug!("Skipping host formatting; only processing injections");
                     let spans = language.collect_injections(&tree, input_content);
                     let rendered = splice_formatted_injections(
@@ -370,6 +371,7 @@ pub fn formatter_tree(
                 }
                 Some(SkipStage::Injections) => Vec::new(),
                 None => {
+                    #[cfg(feature = "log")]
                     log::debug!("Discovering potentially injected languages");
                     language.collect_injections(&tree, input_content)
                 }
@@ -380,6 +382,7 @@ pub fn formatter_tree(
             let injection_leaf_nodes = spans.iter().map(|span| span.node_id);
 
             // All the work related to tree-sitter and the query is done here
+            #[cfg(feature = "log")]
             log::debug!("Apply Tree-sitter query");
 
             let mut atoms = tree_sitter::apply_query_tree_with_forced_leaves(
@@ -395,6 +398,7 @@ pub fn formatter_tree(
             atoms.post_process();
 
             // Pretty-print atoms
+            #[cfg(feature = "log")]
             log::debug!("Pretty-print output");
             let rendered = pretty::render(
                 &atoms[..],
@@ -440,6 +444,7 @@ fn rewrite_injected_leaves(
         // If the injected language is unsupported, skip formatting this injection
         // by continuing the loop. This leaves the original, unformatted text intact.
         let Some(inner_language) = resolve_injected_language(resolve, &span.language)? else {
+            #[cfg(feature = "log")]
             log::warn!(
                 "Skipping injection for unsupported language: {}",
                 span.language
@@ -492,6 +497,7 @@ fn splice_formatted_injections(
     spans.sort_by_key(|s| s.byte_range.start);
     for span in spans {
         if span.byte_range.start < cursor {
+            #[cfg(feature = "log")]
             log::warn!(
                 "Overlapping spans detected for language {} at byte {}; skipping",
                 span.language,
@@ -501,6 +507,7 @@ fn splice_formatted_injections(
         }
 
         let Some(inner_language) = resolve_injected_language(resolve, &span.language)? else {
+            #[cfg(feature = "log")]
             log::warn!(
                 "Injection for unsupported language: {}; skipping",
                 span.language
@@ -550,6 +557,7 @@ fn resolve_injected_language(
 
     match resolve(language) {
         Ok(Some(language_cfg)) => {
+            #[cfg(feature = "log")]
             log::info!("resolved injected language: {language}");
             Ok(Some(language_cfg))
         }
@@ -591,6 +599,7 @@ fn idempotence_check(
     skip: Option<SkipStage>,
     resolve: Option<&LanguageResolver<'_>>,
 ) -> FormatterResult<()> {
+    #[cfg(feature = "log")]
     log::info!("Checking for idempotence ...");
 
     let mut input = content.as_bytes();
@@ -617,8 +626,11 @@ fn idempotence_check(
             if content == reformatted {
                 Ok(())
             } else {
-                log::error!("Failed idempotence check");
-                log::error!("{}", StrComparison::new(content, &reformatted));
+                #[cfg(feature = "log")]
+                {
+                    log::error!("Failed idempotence check");
+                    log::error!("{}", StrComparison::new(content, &reformatted));
+                }
                 Err(report!(FormatterError::Idempotence))
             }
         }

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -359,7 +359,6 @@ pub fn formatter_tree(
         } => {
             let spans = match skip_stage {
                 Some(SkipStage::HostLanguage) => {
-                    #[cfg(feature = "log")]
                     crate::debug!("Skipping host formatting; only processing injections");
                     let spans = language.collect_injections(&tree, input_content);
                     let rendered = splice_formatted_injections(
@@ -374,7 +373,6 @@ pub fn formatter_tree(
                 }
                 Some(SkipStage::Injections) => Vec::new(),
                 None => {
-                    #[cfg(feature = "log")]
                     crate::debug!("Discovering potentially injected languages");
                     language.collect_injections(&tree, input_content)
                 }
@@ -385,7 +383,6 @@ pub fn formatter_tree(
             let injection_leaf_nodes = spans.iter().map(|span| span.node_id);
 
             // All the work related to tree-sitter and the query is done here
-            #[cfg(feature = "log")]
             crate::debug!("Apply Tree-sitter query");
 
             let mut atoms = tree_sitter::apply_query_tree_with_forced_leaves(
@@ -401,7 +398,6 @@ pub fn formatter_tree(
             atoms.post_process();
 
             // Pretty-print atoms
-            #[cfg(feature = "log")]
             crate::debug!("Pretty-print output");
             let rendered = pretty::render(
                 &atoms[..],
@@ -447,7 +443,6 @@ fn rewrite_injected_leaves(
         // If the injected language is unsupported, skip formatting this injection
         // by continuing the loop. This leaves the original, unformatted text intact.
         let Some(inner_language) = resolve_injected_language(resolve, &span.language)? else {
-            #[cfg(feature = "log")]
             crate::warn!(
                 "Skipping injection for unsupported language: {}",
                 span.language
@@ -599,7 +594,6 @@ fn idempotence_check(
     skip: Option<SkipStage>,
     resolve: Option<&LanguageResolver<'_>>,
 ) -> FormatterResult<()> {
-    #[cfg(feature = "log")]
     crate::info!("Checking for idempotence ...");
 
     let mut input = content.as_bytes();
@@ -626,7 +620,6 @@ fn idempotence_check(
             if content == reformatted {
                 Ok(())
             } else {
-                #[cfg(feature = "log")]
                 {
                     crate::error!("Failed idempotence check");
                     crate::error!("{}", StrComparison::new(content, &reformatted));

--- a/topiary-core/src/macros.rs
+++ b/topiary-core/src/macros.rs
@@ -1,0 +1,38 @@
+//! ## Logging macros
+//!
+//! Encapsulate the `log` macros if the `log` feature is active to reduce the number of `#[cfg(feature = "log")]` in code.
+//!
+//! If the feature is **not** active, calling these macro is a no-op.
+
+/// Macro encapsulating the `log::debug!` macro if the `log` feature is active.
+#[macro_export]
+macro_rules! debug {
+    ($($args:tt)+) => ({
+        #[cfg(feature = "log")]
+        log::debug!(
+            $($args)*
+        )
+    });
+}
+
+/// Macro encapsulating the `log::warn!` macro if the `log` feature is active.
+#[macro_export]
+macro_rules! warn {
+    ($($args:tt)+) => ({
+        #[cfg(feature = "log")]
+        log::warn!(
+            $($args)*
+        )
+    });
+}
+
+/// Macro encapsulating the `log::info!` macro if the `log` feature is active.
+#[macro_export]
+macro_rules! info {
+    ($($args:tt)+) => ({
+        #[cfg(feature = "log")]
+        log::info!(
+            $($args)*
+        )
+    });
+}

--- a/topiary-core/src/macros.rs
+++ b/topiary-core/src/macros.rs
@@ -36,3 +36,14 @@ macro_rules! info {
         )
     });
 }
+
+/// Macro encapsulating the `log::error!` macro if the `log` feature is active.
+#[macro_export]
+macro_rules! error {
+    ($($args:tt)+) => ({
+        #[cfg(feature = "log")]
+        log::error!(
+            $($args)*
+        )
+    });
+}

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -231,6 +231,7 @@ fn render_multi_line_string(
         // we do not want to introduce `\n` line breaks because we do not want to introduce inconsistent line endings.
         // so we have to short circuit the rest of the algorithm because it might add line breaks.
         // we might implement some reduced formatting that does not add line breaks in the future if that is considered worth it.
+        #[cfg(feature = "log")]
         log::warn!(
             "not formatting the multi line string starting with {:?} at {} \
                 because carriage returns become part of the string's value according to the query \
@@ -290,6 +291,7 @@ fn render_multi_line_string(
     }
 
     // very simple non exhaustive check for mixing of spaces and tabs
+    #[cfg(feature = "log")]
     if log::log_enabled!(log::Level::Info) {
         match content
             .clone()

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -231,8 +231,7 @@ fn render_multi_line_string(
         // we do not want to introduce `\n` line breaks because we do not want to introduce inconsistent line endings.
         // so we have to short circuit the rest of the algorithm because it might add line breaks.
         // we might implement some reduced formatting that does not add line breaks in the future if that is considered worth it.
-        #[cfg(feature = "log")]
-        log::warn!(
+        crate::warn!(
             "not formatting the multi line string starting with {:?} at {} \
                 because carriage returns become part of the string's value according to the query \
                 and the line of the string's start delimiter ends with a carriage return.",
@@ -291,7 +290,6 @@ fn render_multi_line_string(
     }
 
     // very simple non exhaustive check for mixing of spaces and tabs
-    #[cfg(feature = "log")]
     if log::log_enabled!(log::Level::Info) {
         match content
             .clone()
@@ -305,7 +303,7 @@ fn render_multi_line_string(
             }) {
             None => (), // no lines other than whitespace lines
             // do not change the log level without changing it in the if condition 6 lines above.
-            Some(Ordering::Less) => log::info!(
+            Some(Ordering::Less) => crate::info!(
                 "the multi line string starting with {:?} at {} mixes different whitespace characters like spaces and tabs in its lines' whitespace prefixes. \
                     is this supposed to be indentation? then you should not mix different whitespace characters.",
                 content_original.chars().take(16).collect::<String>(),

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -193,6 +193,7 @@ pub fn collect_injections<'a>(
             .collect::<Vec<_>>();
 
         if content_captures.is_empty() {
+            #[cfg(feature = "log")]
             log::warn!(
                 "Injection query pattern {} has no @injection.content capture; skipping",
                 query_match.pattern_index()
@@ -221,6 +222,7 @@ pub fn collect_injections<'a>(
             });
 
         let Some(language_name) = language_name else {
+            #[cfg(feature = "log")]
             log::warn!(
                 "Injection query pattern {} has neither a #set! injection.language property nor an @injection.language capture; skipping",
                 query_match.pattern_index()
@@ -519,6 +521,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
     let mut atoms = AtomCollection::collect_leaves(&root, source, specified_leaf_nodes)?;
 
+    #[cfg(feature = "log")]
     log::debug!("List of atoms before formatting: {atoms:?}");
 
     // Memoization of the pattern positions
@@ -526,7 +529,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
 
     // The web bindings for tree-sitter do not have support for pattern_count, so instead we will resize as needed
     // Only reallocate if we are actually going to use the vec
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "log"))]
     if log::log_enabled!(log::Level::Debug) {
         pattern_positions.resize(query.query.pattern_count(), None);
     }
@@ -574,6 +577,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
         check_predicates(&predicates)?;
 
         // NOTE: Only performed if logging is enabled to avoid unnecessary computation of Position
+        #[cfg(feature = "log")]
         if log::log_enabled!(log::Level::Debug) {
             #[cfg(target_arch = "wasm32")]
             // Resize the pattern_positions vector if we need to store more positions

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -193,8 +193,7 @@ pub fn collect_injections<'a>(
             .collect::<Vec<_>>();
 
         if content_captures.is_empty() {
-            #[cfg(feature = "log")]
-            log::warn!(
+            crate::warn!(
                 "Injection query pattern {} has no @injection.content capture; skipping",
                 query_match.pattern_index()
             );
@@ -222,8 +221,7 @@ pub fn collect_injections<'a>(
             });
 
         let Some(language_name) = language_name else {
-            #[cfg(feature = "log")]
-            log::warn!(
+            crate::warn!(
                 "Injection query pattern {} has neither a #set! injection.language property nor an @injection.language capture; skipping",
                 query_match.pattern_index()
             );
@@ -521,8 +519,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
     let mut atoms = AtomCollection::collect_leaves(&root, source, specified_leaf_nodes)?;
 
-    #[cfg(feature = "log")]
-    log::debug!("List of atoms before formatting: {atoms:?}");
+    crate::debug!("List of atoms before formatting: {atoms:?}");
 
     // Memoization of the pattern positions
     let mut pattern_positions: Vec<Option<Position>> = Vec::new();
@@ -599,7 +596,7 @@ pub(crate) fn apply_query_tree_with_forced_leaves(
             };
 
             // do not change the log level without changing it in the 2 if conditions above.
-            log::debug!("Processing match{query_name_info}: {m} at location {pos}");
+            crate::debug!("Processing match{query_name_info}: {m} at location {pos}");
         }
 
         m.captures.retain(|c| {


### PR DESCRIPTION
# Enable `log` behind a feature flag in `topiary-core`

Resolves #1329

## Description

Add a new feature flag to the `topiary-core` crate which enables the `log` dependency. This new feature flag is enabled by default, thus not breaking logging for users not aware of this new addition.

Explicitly enables this features flag in the `topiary-cli`.

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
- [ ] Updated regression tests
